### PR TITLE
[CI] support custom docker hub and tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+HUB ?= datafuselabs
+TAG ?= latest
 # Setup dev toolchain
 setup:
 	bash ./scripts/dev_setup.sh
@@ -25,7 +27,7 @@ lint:
 	cargo clippy -- -D warnings
 
 docker:
-	docker build --network host -f docker/Dockerfile -t datafusedev/fuse-query .
+	docker build --network host -f docker/Dockerfile -t ${HUB}/fuse-query:${TAG} .
 
 coverage:
 	bash ./scripts/dev_codecov.sh


### PR DESCRIPTION
<!--
Thank you for sending a PR. Thank you for spending time to help improve the FuseQuery project.
-->

## Summary

<!--
Write your motivation for proposed changes here.
-->
support to use custom docker hub and tag during build process
for example
```bash
make docker HUB=host TAG=beta1
```
it will build image host/fuse-query:beta1 in local environment(without push)
## Changelog

- Build/Testing/Packaging Improvement


## Related Issues

<!--
The issue fixed or related of this patch if have.
-->
resolve https://github.com/datafuselabs/datafuse/issues/177

## Test Plan

<!--
Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.
-->
N/A