### PR TITLE
 Fix segmentation fault in numbers_stream

### DIFF
--- a/docs/overview/building-and-running.md
+++ b/docs/overview/building-and-running.md
@@ -59,7 +59,7 @@ mysql -h127.0.0.1 -P3307
 ### Avg Demo
 
 ```text
-mysql> SELECT avg(number) FROM system.numbers(10000);
+mysql> SELECT avg(number) FROM system.numbers_mt(10000);
 +-------------+
 | Avg(number) |
 +-------------+
@@ -73,7 +73,7 @@ mysql> SELECT avg(number) FROM system.numbers(10000);
 ### 10 Billion Performance
 
 ```text
-mysql> SELECT avg(number) FROM system.numbers(10000000000);
+mysql> SELECT avg(number) FROM system.numbers_mt(10000000000);
 +-------------------+
 | Avg(number)       |
 +-------------------+

--- a/fusequery/query/src/datasources/system/numbers_stream.rs
+++ b/fusequery/query/src/datasources/system/numbers_stream.rs
@@ -100,6 +100,7 @@ impl Stream for NumbersStream {
 
         Poll::Ready(match current {
             None => None,
+            Some(current) if current.begin == current.end => None,
             Some(current) => {
                 let v = (current.begin..current.end).collect::<Vec<u64>>();
                 let mut me = ManuallyDrop::new(v);


### PR DESCRIPTION

## Changelog

- Bug Fix
   Fix segmentation fault in numbers_stream
   SQL `select * from system.numbers_mt(0)` will trigger a segmentation fault. 

- Doc-Typo Fix 
   Table name for test-drive specified in `overview/building-and-running.md` should be `numbers_mt`


## Related Issues


## Test Plan


