### PR TITLE
Returns `SendableDataBlockStream` by stream mapping

### DIFF
--- a/fusequery/query/src/datasources/datasource.rs
+++ b/fusequery/query/src/datasources/datasource.rs
@@ -82,10 +82,7 @@ impl IDataSource for DataSource {
 
     fn check_database(&mut self, db_name: &str) -> Result<()> {
         self.databases.get(db_name).ok_or_else(|| {
-            return anyhow::Error::msg(format!(
-                "DataSource Error: Unknown database: '{}'",
-                db_name
-            ));
+            anyhow::Error::msg(format!("DataSource Error: Unknown database: '{}'", db_name))
         })?;
         Ok(())
     }
@@ -94,10 +91,7 @@ impl IDataSource for DataSource {
         self.databases
             .get_mut(db_name)
             .ok_or_else(|| {
-                return anyhow::Error::msg(format!(
-                    "DataSource Error: Unknown database: '{}'",
-                    db_name
-                ));
+                anyhow::Error::msg(format!("DataSource Error: Unknown database: '{}'", db_name))
             })?
             .insert(table.name().to_string(), table);
         Ok(())
@@ -105,16 +99,13 @@ impl IDataSource for DataSource {
 
     fn get_table(&self, db_name: &str, table_name: &str) -> Result<Arc<dyn ITable>> {
         let database = self.databases.get(db_name).ok_or_else(|| {
-            return anyhow::Error::msg(format!(
-                "DataSource Error: Unknown database: '{}'",
-                db_name
-            ));
+            anyhow::Error::msg(format!("DataSource Error: Unknown database: '{}'", db_name))
         })?;
         let table = database.get(table_name).ok_or_else(|| {
-            return anyhow::Error::msg(format!(
+            anyhow::Error::msg(format!(
                 "DataSource Error: Unknown table: '{}.{}'",
                 db_name, table_name
-            ));
+            ))
         })?;
         Ok(table.clone())
     }


### PR DESCRIPTION

## Summary

IMHO, It's more natural and efficient (at least in case of lengthy stream) to map a stream into another one.


## Changelog

- Improvement

## Related Issues
N/A

## Test Plan

Related test cases passed, no extra tests. 
