### PR TITLE
Add #[cfg(test)] to _test mod

### DIFF
--- a/common/datablocks/src/lib.rs
+++ b/common/datablocks/src/lib.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-mod data_block;
+#[cfg(test)]
 mod data_block_test;
+
+mod data_block;
 
 pub use crate::data_block::DataBlock;

--- a/common/datavalues/src/lib.rs
+++ b/common/datavalues/src/lib.rs
@@ -2,11 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod data_array_aggregate_test;
+#[cfg(test)]
 mod data_array_arithmetic_test;
+#[cfg(test)]
 mod data_array_comparison_test;
+#[cfg(test)]
 mod data_array_logic_test;
+#[cfg(test)]
 mod data_value_aggregate_test;
+#[cfg(test)]
 mod data_value_arithmetic_test;
 
 #[macro_use]

--- a/common/functions/src/aggregators/mod.rs
+++ b/common/functions/src/aggregators/mod.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod aggregator_test;
 
 mod aggregator;

--- a/common/functions/src/arithmetics/mod.rs
+++ b/common/functions/src/arithmetics/mod.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod arithmetic_test;
 
 mod arithmetic;

--- a/common/functions/src/comparisons/mod.rs
+++ b/common/functions/src/comparisons/mod.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod comparison_test;
 
 mod comparison;

--- a/common/functions/src/logics/mod.rs
+++ b/common/functions/src/logics/mod.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod logic_test;
 
 mod logic;

--- a/common/functions/src/udfs/mod.rs
+++ b/common/functions/src/udfs/mod.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod to_type_name_test;
+#[cfg(test)]
 mod udf_example_test;
 
 mod to_type_name;

--- a/common/infallible/src/lib.rs
+++ b/common/infallible/src/lib.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod mutex_test;
+#[cfg(test)]
 mod rwlock_test;
 
 mod mutex;

--- a/common/streams/src/lib.rs
+++ b/common/streams/src/lib.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod tests;
 
 mod stream;

--- a/fusequery/query/src/api/http/v1/mod.rs
+++ b/fusequery/query/src/api/http/v1/mod.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod cluster_test;
 
 pub mod cluster;

--- a/fusequery/query/src/api/rpc/mod.rs
+++ b/fusequery/query/src/api/rpc/mod.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod flight_service_test;
+#[cfg(test)]
 mod grpc_service_test;
 
 #[macro_use]

--- a/fusequery/query/src/clusters/mod.rs
+++ b/fusequery/query/src/clusters/mod.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod cluster_test;
 
 mod cluster;

--- a/fusequery/query/src/datasources/local/mod.rs
+++ b/fusequery/query/src/datasources/local/mod.rs
@@ -1,15 +1,19 @@
 // Copyright 2020-2021 The Datafuse Authors.
 //
 // SPDX-License-Identifier: Apache-2.0.
+
+#[cfg(test)]
+mod csv_table_test;
+#[cfg(test)]
+mod null_table_test;
+#[cfg(test)]
+mod parquet_table_test;
+
 mod csv_table;
+mod local_database;
 mod local_factory;
 mod null_table;
-
-mod csv_table_test;
-mod local_database;
-mod null_table_test;
 mod parquet_table;
-mod parquet_table_test;
 
 pub use csv_table::CsvTable;
 pub use local_database::LocalDatabase;

--- a/fusequery/query/src/datasources/system/mod.rs
+++ b/fusequery/query/src/datasources/system/mod.rs
@@ -2,9 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod clusters_table_test;
+#[cfg(test)]
 mod functions_table_test;
+#[cfg(test)]
 mod settings_table_test;
+#[cfg(test)]
 mod tables_table_test;
 
 mod clusters_table;

--- a/fusequery/query/src/interpreters/mod.rs
+++ b/fusequery/query/src/interpreters/mod.rs
@@ -2,9 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod interpreter_create_test;
+#[cfg(test)]
 mod interpreter_explain_test;
+#[cfg(test)]
 mod interpreter_select_test;
+#[cfg(test)]
 mod interpreter_setting_test;
 
 mod interpreter;

--- a/fusequery/query/src/lib.rs
+++ b/fusequery/query/src/lib.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 pub mod tests;
 
 pub mod api;

--- a/fusequery/query/src/pipelines/processors/mod.rs
+++ b/fusequery/query/src/pipelines/processors/mod.rs
@@ -2,11 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod pipe_test;
+#[cfg(test)]
 mod pipeline_builder_test;
+#[cfg(test)]
 mod pipeline_display_test;
+#[cfg(test)]
 mod pipeline_walker_test;
+#[cfg(test)]
 mod processor_empty_test;
+#[cfg(test)]
 mod processor_merge_test;
 
 mod pipe;

--- a/fusequery/query/src/pipelines/transforms/mod.rs
+++ b/fusequery/query/src/pipelines/transforms/mod.rs
@@ -2,11 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod transform_aggregator_test;
+#[cfg(test)]
 mod transform_filter_test;
+#[cfg(test)]
 mod transform_limit_test;
+#[cfg(test)]
 mod transform_projection_test;
+#[cfg(test)]
 mod transform_remote_test;
+#[cfg(test)]
 mod transform_source_test;
 
 mod transform_aggregator_final;

--- a/fusequery/query/src/sql/mod.rs
+++ b/fusequery/query/src/sql/mod.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
 mod sql_parser_test;
 
 mod plan_parser;


### PR DESCRIPTION
## Summary

The #[cfg(test)] annotation on the tests module tells Rust to compile and run the test code only when you run cargo test, not when you run cargo build. 
More to https://doc.rust-lang.org/book/ch11-03-test-organization.html#the-tests-module-and-cfgtest

## Changelog

- Improvement

## Related Issues

#232 

## Test Plan

UnitTests