### PR TITLE
add helm chart for datafuse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ lint:
 docker:
 	docker build --network host -f docker/Dockerfile -t ${HUB}/fuse-query:${TAG} .
 
+helm:
+	helm upgrade --install --debug datafuse ./charts/datafuse
+
 coverage:
 	bash ./scripts/dev_codecov.sh
 

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ lint:
 docker:
 	docker build --network host -f docker/Dockerfile -t ${HUB}/fuse-query:${TAG} .
 
-helm: docker
-	helm upgrade --install --debug datafuse ./charts/datafuse
+runhelm:
+	helm upgrade --install datafuse ./charts/datafuse
 
 coverage:
 	bash ./scripts/dev_codecov.sh

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lint:
 docker:
 	docker build --network host -f docker/Dockerfile -t ${HUB}/fuse-query:${TAG} .
 
-helm:
+helm: docker
 	helm upgrade --install --debug datafuse ./charts/datafuse
 
 coverage:

--- a/charts/datafuse/.helmignore
+++ b/charts/datafuse/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/datafuse/Chart.yaml
+++ b/charts/datafuse/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: datafuse
+description: A Helm chart for datafuse
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/datafuse/templates/NOTES.txt
+++ b/charts/datafuse/templates/NOTES.txt
@@ -1,22 +1,6 @@
-1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
-{{- end }}
-{{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "datafuse.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "datafuse.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "datafuse.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "datafuse.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
-{{- end }}
+1. connect to fuse-query mysql port:
+export FUSE_MYSQL_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "datafuse.fullname" . }})
+mysql -h127.0.0.1 -P$FUSE_MYSQL_PORT
+
+export FUSE_HTTP_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[2].nodePort}" services {{ include "datafuse.fullname" . }})
+curl http://127.0.0.1:$FUSE_HTTP_PORT/v1/configs

--- a/charts/datafuse/templates/NOTES.txt
+++ b/charts/datafuse/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "datafuse.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "datafuse.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "datafuse.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "datafuse.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/datafuse/templates/_helpers.tpl
+++ b/charts/datafuse/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "datafuse.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "datafuse.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "datafuse.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "datafuse.labels" -}}
+helm.sh/chart: {{ include "datafuse.chart" . }}
+{{ include "datafuse.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "datafuse.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "datafuse.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "datafuse.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "datafuse.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/datafuse/templates/configmap.yaml
+++ b/charts/datafuse/templates/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "datafuse.fullname" . }}
+  labels:
+    {{- include "datafuse.labels" . | nindent 4 }}
+data:
+  RUST_LOG: info

--- a/charts/datafuse/templates/configmap.yaml
+++ b/charts/datafuse/templates/configmap.yaml
@@ -5,4 +5,8 @@ metadata:
   labels:
     {{- include "datafuse.labels" . | nindent 4 }}
 data:
-  RUST_LOG: info
+  FUSE_QUERY_HTTP_API_ADDRESS: 0.0.0.0:8080
+  FUSE_QUERY_MYSQL_HANDLER_HOST: 0.0.0.0
+  FUSE_QUERY_METRIC_API_ADDRESS: 0.0.0.0:7070
+  FUSE_QUERY_RPC_API_ADDRESS: 0.0.0.0:9090
+  FUSE_QUERY_CLICKHOUSE_HANDLER_HOST: 0.0.0.0

--- a/charts/datafuse/templates/deployment.yaml
+++ b/charts/datafuse/templates/deployment.yaml
@@ -40,14 +40,17 @@ spec:
             - name: mysql
               containerPort: 3307
               protocol: TCP
-#          livenessProbe:
-#            httpGet:
-#              path: /
-#              port: http
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: http
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /v1/hello
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /v1/configs
+              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/datafuse/templates/deployment.yaml
+++ b/charts/datafuse/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "datafuse.fullname" . }}
+  labels:
+    {{- include "datafuse.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "datafuse.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "datafuse.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "datafuse.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "datafuse.fullname" . }}
+          ports:
+            - name: mysql
+              containerPort: 3307
+              protocol: TCP
+#          livenessProbe:
+#            httpGet:
+#              path: /
+#              port: http
+#          readinessProbe:
+#            httpGet:
+#              path: /
+#              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/datafuse/templates/hpa.yaml
+++ b/charts/datafuse/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "datafuse.fullname" . }}
+  labels:
+    {{- include "datafuse.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "datafuse.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/datafuse/templates/ingress.yaml
+++ b/charts/datafuse/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "datafuse.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "datafuse.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/datafuse/templates/service.yaml
+++ b/charts/datafuse/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "datafuse.fullname" . }}
+  labels:
+    {{- include "datafuse.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 3307
+      protocol: TCP
+      name: mysql
+  selector:
+    {{- include "datafuse.selectorLabels" . | nindent 4 }}

--- a/charts/datafuse/templates/service.yaml
+++ b/charts/datafuse/templates/service.yaml
@@ -7,9 +7,25 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: 3307
       targetPort: 3307
       protocol: TCP
       name: mysql
+    - port: 7070
+      targetPort: 7070
+      protocol: TCP
+      name: metrics
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: http
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      name: clickhouse
+    - port: 9090
+      targetPort: 9090
+      protocol: TCP
+      name: rpc
   selector:
     {{- include "datafuse.selectorLabels" . | nindent 4 }}

--- a/charts/datafuse/templates/serviceaccount.yaml
+++ b/charts/datafuse/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "datafuse.serviceAccountName" . }}
+  labels:
+    {{- include "datafuse.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/datafuse/templates/tests/test-connection.yaml
+++ b/charts/datafuse/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "datafuse.fullname" . }}-test-connection"
+  labels:
+    {{- include "datafuse.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "datafuse.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/datafuse/values.yaml
+++ b/charts/datafuse/values.yaml
@@ -1,0 +1,79 @@
+# Default values for datafuse.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: datafusedev/fuse-query
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: NodePort
+  port: 3307
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/datafuse/values.yaml
+++ b/charts/datafuse/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: datafusedev/fuse-query
+  repository: datafuselabs/fuse-query
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
@@ -46,8 +46,9 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: chart-example.local
-      paths: []
+    - host: localhost
+      paths:
+        - path: /v1/
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/docs/overview/building-and-running.md
+++ b/docs/overview/building-and-running.md
@@ -48,7 +48,36 @@ $ cd query
 $ make run
 ```
 
-## 4. Connect
+## 4. Run in Kubernetes using Helm
+### 4.1 Dependencies
+
+1. Clone:
+
+```text
+git clone https://github.com/datafuselabs/datafuse.git
+```
+
+2. Make sure you have [Kubernetes](https://kubernetes.io/) cluster running
+### 4.3 Build Image
+`make docker` to build image `datafuselabs/fuse-query`
+
+### 4.2 Run Helm 
+`make runhelm` in project root directory,
+
+when successful install you will get a note like this,
+```
+NOTES:
+1. connect to fuse-query mysql port:
+export FUSE_MYSQL_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services datafuse)
+mysql -h127.0.0.1 -P$FUSE_MYSQL_PORT
+
+export FUSE_HTTP_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[2].nodePort}" services datafuse)
+curl http://127.0.0.1:$FUSE_HTTP_PORT/v1/configs
+```
+following the note you should be able to connect to `fusequery` through NodePort
+
+
+## 5. Connect
 
  Connect FuseQuery with MySQL client
 


### PR DESCRIPTION
## Summary

Adding a helm chart to deploy datafuse to k8s, 

## Changelog

-Build/Testing/Packaging Improvement

## Test Plan

run
`make helm` and use mysql to connect to the NodePort following the helm Note:
```
NOTES:
1. connect to fuse-query mysql port:
export FUSE_MYSQL_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services datafuse)
mysql -h127.0.0.1 -P$FUSE_MYSQL_PORT

export FUSE_HTTP_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[2].nodePort}" services datafuse)
curl http://127.0.0.1:$FUSE_HTTP_PORT/v1/configs
```

