### PR TITLE
fix http api port info

### DIFF
--- a/fusequery/query/src/bin/fuse-query.rs
+++ b/fusequery/query/src/bin/fuse-query.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tokio::spawn(async move {
             srv.make_server().await.expect("HTTP service error");
         });
-        info!("HTTP API server listening on {}", conf.metric_api_address);
+        info!("HTTP API server listening on {}", conf.http_api_address);
     }
 
     // RPC API service.


### PR DESCRIPTION
## Summary

fix the startup info

## Changelog

- Bug Fix

## Related Issues

No

## Test Plan

checkout the info

before
```
[2021-04-07T09:52:48Z INFO  fuse_query] Metric API server listening on 127.0.0.1:7070
[2021-04-07T09:52:48Z INFO  fuse_query] HTTP API server listening on 127.0.0.1:7070
[2021-04-07T09:52:48Z INFO  fuse_query] RPC API server listening on 127.0.0.1:9090
[2021-04-07T09:52:48Z INFO  warp::server] Server::run; addr=127.0.0.1:8080
[2021-04-07T09:52:48Z INFO  warp::server] listening on http://127.0.0.1:8080 
```

after
```
[2021-04-07T09:46:41Z INFO  fuse_query] Metric API server listening on 127.0.0.1:7070
[2021-04-07T09:46:41Z INFO  fuse_query] HTTP API server listening on 127.0.0.1:8080
[2021-04-07T09:46:41Z INFO  fuse_query] RPC API server listening on 127.0.0.1:9090
[2021-04-07T09:46:41Z INFO  warp::server] Server::run; addr=127.0.0.1:8080
[2021-04-07T09:46:41Z INFO  warp::server] listening on http://127.0.0.1:8080 
```
