### PR TITLE
[store]: dfs with a naive central meta service.

### DIFF
--- a/common/flights/src/store_do_get.rs
+++ b/common/flights/src/store_do_get.rs
@@ -4,15 +4,10 @@
 
 /// Actions for store do_get.
 use std::convert::TryInto;
-use std::io::Cursor;
 
 use common_arrow::arrow_flight::Ticket;
 use common_planners::Partitions;
 use common_planners::PlanNode;
-use prost::Message;
-use tonic::Request;
-
-use crate::protobuf::FlightStoreRequest;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ReadAction {
@@ -20,44 +15,37 @@ pub struct ReadAction {
     pub push_down: PlanNode
 }
 
+/// Pull a file. This is used to replicate data between store servers, which is only used internally.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct PullAction {
+    pub key: String
+}
+
 // Action wrapper for do_get.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub enum StoreDoGet {
-    Read(ReadAction)
+    Read(ReadAction),
+    Pull(PullAction)
 }
 
-/// Try convert tonic::Request<Ticket> to DoGetAction.
+/// Try convert tonic::Request<Ticket> to StoreDoGet.
 impl TryInto<StoreDoGet> for tonic::Request<Ticket> {
     type Error = tonic::Status;
 
     fn try_into(self) -> Result<StoreDoGet, Self::Error> {
         let ticket = self.into_inner();
-        let mut buf = Cursor::new(&ticket.ticket);
+        let buf = ticket.ticket;
 
-        // Decode FlightRequest from buffer.
-        let request: FlightStoreRequest = FlightStoreRequest::decode(&mut buf)
-            .map_err(|e| tonic::Status::internal(e.to_string()))?;
+        let action = serde_json::from_slice::<StoreDoGet>(&buf)
+            .map_err(|e| tonic::Status::invalid_argument(e.to_string()))?;
 
-        // Decode DoGetAction from request body.
-        let json_str = request.body.as_str();
-        let action = serde_json::from_str::<StoreDoGet>(json_str)
-            .map_err(|e| tonic::Status::internal(e.to_string()))?;
         Ok(action)
     }
 }
 
-/// Try convert DoGetAction to tonic::Request<Ticket>.
-impl TryInto<Request<Ticket>> for &StoreDoGet {
-    type Error = anyhow::Error;
-
-    fn try_into(self) -> Result<Request<Ticket>, Self::Error> {
-        let flight_request = FlightStoreRequest {
-            body: serde_json::to_string(&self)?
-        };
-
-        let mut buf = vec![];
-        flight_request.encode(&mut buf)?;
-        let request = tonic::Request::new(Ticket { ticket: buf });
-        Ok(request)
+impl From<&StoreDoGet> for tonic::Request<Ticket> {
+    fn from(v: &StoreDoGet) -> Self {
+        let ticket = serde_json::to_vec(v).unwrap();
+        tonic::Request::new(Ticket { ticket })
     }
 }

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -44,13 +44,13 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
 threadpool = "1.8.1"
+tempfile = "3.2.0"
 tokio = { version = "1.5", features = ["macros", "rt","rt-multi-thread", "sync"] }
 tokio-stream = "0.1"
 tonic = "0.4"
 
 [dev-dependencies]
 pretty_assertions = "0.7"
-tempfile = "3.2.0"
 
 [build-dependencies]
 tonic-build = "0.4"

--- a/fusestore/store/proto/store_meta.proto
+++ b/fusestore/store/proto/store_meta.proto
@@ -43,3 +43,28 @@ message CmdCreateTable {
   string table_name = 30;
   Table table = 40;
 }
+
+// meta service
+
+message SetReq {
+  string key = 1;
+  string value = 2;
+
+  // if_absent==true:  AKA add. write key=value only when key is absent.
+  // if_absent==false: AKA set. always overrides.
+  bool if_absent = 3;
+}
+message SetReply { bool ok = 1; }
+
+message GetReq { string key = 1; }
+message GetReply {
+  bool ok = 1;
+  string key = 2;
+  string value = 3;
+}
+
+service MetaService {
+
+  rpc Set(SetReq) returns (SetReply) {}
+  rpc Get(GetReq) returns (GetReply) {}
+}

--- a/fusestore/store/src/api/mod.rs
+++ b/fusestore/store/src/api/mod.rs
@@ -7,4 +7,4 @@
 pub mod rpc;
 mod rpc_service;
 
-pub use rpc_service::RpcService;
+pub use rpc_service::StoreServer;

--- a/fusestore/store/src/api/rpc/flight_service_test.rs
+++ b/fusestore/store/src/api/rpc/flight_service_test.rs
@@ -13,7 +13,7 @@ async fn test_flight_create_database() -> anyhow::Result<()> {
     use common_planners::DatabaseEngineType;
 
     // 1. Service starts.
-    let addr = crate::tests::start_one_service().await?;
+    let addr = crate::tests::start_store_server().await?;
 
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -69,7 +69,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
     info!("init logging");
 
     // 1. Service starts.
-    let addr = crate::tests::start_one_service().await?;
+    let addr = crate::tests::start_store_server().await?;
 
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 

--- a/fusestore/store/src/api/rpc/mod.rs
+++ b/fusestore/store/src/api/rpc/mod.rs
@@ -8,5 +8,5 @@ mod flight_service_test;
 mod flight_service;
 mod metrics;
 
-pub use flight_service::FlightServiceImpl;
 pub use flight_service::FlightStream;
+pub use flight_service::StoreFlightImpl;

--- a/fusestore/store/src/bin/fuse-store.rs
+++ b/fusestore/store/src/bin/fuse-store.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use fuse_store::api::RpcService;
+use fuse_store::api::StoreServer;
 use fuse_store::configs::Config;
 use fuse_store::metrics::MetricService;
 use log::info;
@@ -29,9 +29,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // RPC API service.
     {
-        let srv = RpcService::create(conf.clone());
+        let srv = StoreServer::create(conf.clone());
         info!("RPC API server listening on {}", conf.rpc_api_address);
-        srv.make_server().await.expect("RPC service error");
+        srv.serve().await.expect("RPC service error");
     }
 
     Ok(())

--- a/fusestore/store/src/dfs/distributed_fs.rs
+++ b/fusestore/store/src/dfs/distributed_fs.rs
@@ -1,0 +1,90 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use async_trait::async_trait;
+use tonic::transport::channel::Channel;
+
+use crate::fs::IFileSystem;
+use crate::fs::ListResult;
+use crate::localfs::LocalFS;
+use crate::meta_service::MetaServiceClient;
+use crate::meta_service::SetReq;
+
+/// DFS is a distributed file system impl.
+/// When a file is added, it stores it locally, commit the this action into distributed meta data(something like a raft group).
+/// Then notifies client Ok.
+/// The replication is done by 2 other nodes, by subscribing meta data changes, and pulling the file.
+/// TODO: There is a chance the node receiving the upload fails before replication is done, which results in a data loss.
+///       A synchronous quorum write is required to solve this.
+pub struct Dfs {
+    /// The local fs to store data copies.
+    /// The distributed fs is a cluster of local-fs organized with a meta data service.
+    pub local_fs: LocalFS,
+    pub meta_service_addr: String
+}
+
+impl Dfs {
+    pub fn create(local_fs: LocalFS, meta_service_addr: String) -> Dfs {
+        Dfs {
+            local_fs,
+            meta_service_addr
+        }
+    }
+}
+
+impl Dfs {
+    pub async fn make_client(&self) -> anyhow::Result<MetaServiceClient<Channel>> {
+        let client =
+            MetaServiceClient::connect(format!("http://{}", self.meta_service_addr)).await?;
+        Ok(client)
+    }
+}
+
+#[async_trait]
+impl IFileSystem for Dfs {
+    async fn add<'a>(&'a self, path: String, data: &[u8]) -> anyhow::Result<()> {
+        // add the file to local fs
+
+        self.local_fs.add(path.clone(), data).await?;
+
+        // update meta, other store nodes will be informed about this change and then pull the data to complete replication.
+
+        let mut client = self.make_client().await?;
+        client
+            .set(tonic::Request::new(SetReq {
+                key: path,
+                value: "".into(),
+                if_absent: true
+            }))
+            .await?;
+        Ok(())
+    }
+
+    async fn read_all<'a>(&'a self, path: String) -> anyhow::Result<Vec<u8>> {
+        // TODO read local cached meta first
+        self.local_fs.read_all(path).await
+    }
+
+    async fn list<'a>(&'a self, path: String) -> anyhow::Result<ListResult> {
+        let _key = path;
+
+        // TODO read local meta cache to list
+
+        // let meta = self.meta.lock().await;
+        // let mut files = vec![];
+        // for (k, _v) in meta.keys.range(key.clone()..) {
+        //     if !k.starts_with(key.as_str()) {
+        //         break;
+        //     }
+        //     files.push(k.to_string());
+        // }
+
+        // Ok(ListResult {
+        //     dirs: vec![],
+        //     files,
+        // })
+
+        todo!("dirs and files")
+    }
+}

--- a/fusestore/store/src/dfs/distributed_fs_test.rs
+++ b/fusestore/store/src/dfs/distributed_fs_test.rs
@@ -1,0 +1,43 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-Lise-Identifier: Apache-2.0.
+
+use pretty_assertions::assert_eq;
+use tempfile::tempdir;
+
+use crate::dfs::Dfs;
+use crate::fs::IFileSystem;
+use crate::localfs::LocalFS;
+use crate::meta_service::GetReq;
+use crate::meta_service::MetaServiceClient;
+use crate::meta_service::MetaServiceImpl;
+use crate::meta_service::MetaServiceServer;
+use crate::tests::rand_local_addr;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_distributed_fs() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+
+    let fs = LocalFS::try_create(root.to_str().unwrap().to_string())?;
+
+    let meta_addr = rand_local_addr();
+    let meta_srv_impl = MetaServiceImpl::create();
+    let meta_srv = MetaServiceServer::new(meta_srv_impl);
+    serve_grpc!(meta_addr, meta_srv);
+
+    let dfs = Dfs::create(fs, meta_addr.clone());
+    {
+        let rst = dfs.add("foo".into(), "bar".as_bytes()).await;
+        rst.unwrap();
+        // check meta changes
+
+        let mut client = MetaServiceClient::connect(format!("http://{}", meta_addr)).await?;
+        let req = tonic::Request::new(GetReq { key: "foo".into() });
+        let rst = client.get(req).await?.into_inner();
+        assert_eq!("", rst.value);
+
+        // TODO read file data and check result.
+    }
+    Ok(())
+}

--- a/fusestore/store/src/dfs/mod.rs
+++ b/fusestore/store/src/dfs/mod.rs
@@ -1,0 +1,9 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+pub mod distributed_fs;
+
+pub use distributed_fs::Dfs;
+
+#[cfg(test)]
+mod distributed_fs_test;

--- a/fusestore/store/src/executor/action_handler_test.rs
+++ b/fusestore/store/src/executor/action_handler_test.rs
@@ -1,0 +1,52 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-Lise-Identifier: Apache-2.0.
+
+use std::sync::Arc;
+
+use common_arrow::arrow_flight::FlightData;
+use pretty_assertions::assert_eq;
+use tempfile::tempdir;
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::Sender;
+
+use crate::dfs::Dfs;
+use crate::executor::ActionHandler;
+use crate::fs::IFileSystem;
+use crate::localfs::LocalFS;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_action_handler_do_pull_file() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let root = dir.path();
+
+    let fs = LocalFS::try_create(root.to_str().unwrap().to_string())?;
+    fs.add("foo".into(), "bar".as_bytes()).await?;
+
+    let meta_addr = "127.0.0.1:10999".into();
+
+    let dfs = Dfs::create(fs, meta_addr);
+    let hdlr = ActionHandler::create(Arc::new(dfs));
+    {
+        // pull file
+        let (tx, mut rx): (
+            Sender<Result<FlightData, tonic::Status>>,
+            Receiver<Result<FlightData, tonic::Status>>
+        ) = tokio::sync::mpsc::channel(2);
+
+        hdlr.do_pull_file("foo".into(), tx).await?;
+        let rst = rx.recv().await;
+        match rst {
+            Some(r) => {
+                //
+                let r = r?;
+                let body = r.data_body;
+                assert_eq!("bar", std::str::from_utf8(&body)?);
+            }
+            None => {
+                panic!("should not be None");
+            }
+        }
+    }
+    Ok(())
+}

--- a/fusestore/store/src/executor/mod.rs
+++ b/fusestore/store/src/executor/mod.rs
@@ -5,3 +5,6 @@
 mod action_handler;
 
 pub use action_handler::ActionHandler;
+
+#[cfg(test)]
+mod action_handler_test;

--- a/fusestore/store/src/fs/ifs.rs
+++ b/fusestore/store/src/fs/ifs.rs
@@ -1,7 +1,6 @@
 // Copyright 2020-2021 The Datafuse Authors.
 //
 // SPDX-License-Identifier: Apache-2.0.
-use std::path::Path;
 
 use async_trait::async_trait;
 
@@ -9,20 +8,18 @@ use crate::fs::ListResult;
 
 /// Abstract storage layer API.
 #[async_trait]
-pub trait IFileSystem {
+pub trait IFileSystem
+where Self: Sync + Send
+{
     /// Add file atomically.
     /// AKA put_if_absent
-    async fn add<'a>(
-        &'a self,
-        path: impl AsRef<Path> + Send + 'a,
-        data: &[u8]
-    ) -> anyhow::Result<()>;
+    async fn add<'a>(&'a self, path: String, data: &[u8]) -> anyhow::Result<()>;
 
     /// read all bytes from a file
-    async fn read_all<'a>(&'a self, path: impl AsRef<Path> + Send + 'a) -> anyhow::Result<Vec<u8>>;
+    async fn read_all<'a>(&'a self, path: String) -> anyhow::Result<Vec<u8>>;
 
     /// List dir and returns directories and files.
-    async fn list<'a>(&'a self, path: impl AsRef<Path> + Send + 'a) -> anyhow::Result<ListResult>;
+    async fn list<'a>(&'a self, path: String) -> anyhow::Result<ListResult>;
 
     // async fn read(
     //     path: &str,

--- a/fusestore/store/src/fs/mod.rs
+++ b/fusestore/store/src/fs/mod.rs
@@ -4,11 +4,6 @@
 
 pub use ifs::IFileSystem;
 pub use list_result::ListResult;
-pub use localfs::LocalFS;
 
 pub mod ifs;
 mod list_result;
-pub mod localfs;
-
-#[cfg(test)]
-mod localfs_test;

--- a/fusestore/store/src/lib.rs
+++ b/fusestore/store/src/lib.rs
@@ -3,13 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 #[cfg(test)]
+#[macro_use]
 pub mod tests;
 
 pub mod api;
 pub mod configs;
+pub mod dfs;
 pub mod engine;
 pub mod executor;
 pub mod fs;
+pub mod localfs;
+pub mod meta_service;
 pub mod metrics;
 
 #[allow(clippy::all)]

--- a/fusestore/store/src/localfs/local_fs_test.rs
+++ b/fusestore/store/src/localfs/local_fs_test.rs
@@ -6,17 +6,17 @@ use tempfile::tempdir;
 
 use crate::fs::IFileSystem;
 use crate::fs::ListResult;
-use crate::fs::LocalFS;
+use crate::localfs::LocalFS;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_localfs_read_all() -> anyhow::Result<()> {
     let dir = tempdir()?;
     let root = dir.path();
 
-    let f = LocalFS::try_create(root)?;
+    let f = LocalFS::try_create(root.to_str().unwrap().to_string())?;
     {
         // read absent file
-        let got = f.read_all("foo.txt").await;
+        let got = f.read_all("foo.txt".into()).await;
         assert_eq!(
             "No such file or directory (os error 2)",
             got.err().unwrap().root_cause().to_string()
@@ -25,7 +25,7 @@ async fn test_localfs_read_all() -> anyhow::Result<()> {
     {
         // add foo.txt and read
         f.add("foo.txt".to_string(), "123".as_bytes()).await?;
-        let got = f.read_all("foo.txt").await?;
+        let got = f.read_all("foo.txt".into()).await?;
         assert_eq!("123", std::str::from_utf8(&got)?);
     }
     {
@@ -38,20 +38,20 @@ async fn test_localfs_read_all() -> anyhow::Result<()> {
     }
     {
         // add long/bar.txt and read
-        f.add("long/bar.txt", "456".as_bytes()).await?;
-        let got = f.read_all("long/bar.txt").await?;
+        f.add("long/bar.txt".into(), "456".as_bytes()).await?;
+        let got = f.read_all("long/bar.txt".into()).await?;
         assert_eq!("456", std::str::from_utf8(&got)?);
     }
 
     {
         // add long/path/file.txt and read
-        f.add("long/path/file.txt", "789".as_bytes()).await?;
-        let got = f.read_all("long/path/file.txt").await?;
+        f.add("long/path/file.txt".into(), "789".as_bytes()).await?;
+        let got = f.read_all("long/path/file.txt".into()).await?;
         assert_eq!("789", std::str::from_utf8(&got)?);
     }
     {
         // list
-        let got = f.list("long").await?;
+        let got = f.list("long".into()).await?;
         assert_eq!(
             ListResult {
                 dirs: vec!["path".into()],

--- a/fusestore/store/src/localfs/mod.rs
+++ b/fusestore/store/src/localfs/mod.rs
@@ -1,0 +1,10 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+pub mod local_fs;
+
+pub use local_fs::LocalFS;
+
+#[cfg(test)]
+mod local_fs_test;

--- a/fusestore/store/src/meta_service/meta.rs
+++ b/fusestore/store/src/meta_service/meta.rs
@@ -1,0 +1,79 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::collections::hash_map::DefaultHasher;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::hash::Hasher;
+
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait IMeta {
+    async fn add(&mut self, key: String, value: String) -> anyhow::Result<()>;
+    // async fn remove(&self, key: String) -> anyhow::Result<()>;
+}
+
+/// Distributed FS meta data manager
+#[derive(Default)]
+pub struct Meta {
+    /// The file names stored in this cluster
+    pub keys: BTreeMap<String, String>,
+
+    // cluster nodes, key distribution etc.
+    pub slots: Vec<Slot>,
+    pub nodes: HashMap<NodeId, Node>
+}
+
+/// A slot is a virtual and intermediate allocation unit in a distributed storage.
+/// The key of an object is mapped to a slot by some hashing algo.
+/// A slot is assigned to several physical servers(normally 3 for durability).
+pub struct Slot {
+    node_ids: Vec<i64>
+}
+
+pub type NodeId = i64;
+
+#[derive(Debug, Clone)]
+pub struct Node {
+    pub name: String,
+    pub address: String
+}
+
+#[async_trait]
+impl IMeta for Meta {
+    async fn add(&mut self, key: String, value: String) -> anyhow::Result<()> {
+        self.keys.insert(key, value);
+        Ok(())
+    }
+}
+
+impl Meta {
+    pub fn empty() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+
+    /// Returns the slot index to store a file.
+    pub fn slot_index_for_key(&self, key: &str) -> u64 {
+        // TODO use consistent hash if need to extend cluster.
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        let hsh = hasher.finish();
+        hsh % self.slots.len() as u64
+    }
+
+    /// Returns the Node-s that keeps a copy of a file.
+    pub fn nodes_to_store_key(&self, key: &str) -> Vec<Node> {
+        let slot_idx = self.slot_index_for_key(key);
+        let slot = &self.slots[slot_idx as usize];
+
+        slot.node_ids
+            .iter()
+            .map(|nid| (*self.nodes.get(nid).unwrap()).clone())
+            .collect()
+    }
+}

--- a/fusestore/store/src/meta_service/meta_service_impl.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl.rs
@@ -1,0 +1,64 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use crate::meta_service::GetReply;
+use crate::meta_service::GetReq;
+use crate::meta_service::Meta;
+use crate::meta_service::MetaService;
+use crate::meta_service::SetReply;
+use crate::meta_service::SetReq;
+
+pub struct MetaServiceImpl {
+    pub metadata: Arc<Mutex<Meta>>
+}
+
+impl MetaServiceImpl {
+    pub fn create() -> Self {
+        Self {
+            metadata: Arc::new(Mutex::new(Meta::empty()))
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl MetaService for MetaServiceImpl {
+    async fn set(
+        &self,
+        request: tonic::Request<SetReq>
+    ) -> Result<tonic::Response<SetReply>, tonic::Status> {
+        let req = request.into_inner();
+        let mut m = self.metadata.lock().await;
+        if req.if_absent && m.keys.contains_key(&req.key) {
+            return Ok(tonic::Response::new(SetReply { ok: false }));
+        }
+        m.keys.insert(req.key, req.value);
+        return Ok(tonic::Response::new(SetReply { ok: true }));
+    }
+    async fn get(
+        &self,
+        request: tonic::Request<GetReq>
+    ) -> Result<tonic::Response<GetReply>, tonic::Status> {
+        let req = request.into_inner();
+        let m = self.metadata.lock().await;
+        let v = m.keys.get(&req.key);
+        let rst = match v {
+            Some(v) => GetReply {
+                ok: true,
+                key: req.key,
+                value: v.clone()
+            },
+            None => GetReply {
+                ok: false,
+                key: req.key,
+                value: "".into()
+            }
+        };
+
+        Ok(tonic::Response::new(rst))
+    }
+}

--- a/fusestore/store/src/meta_service/meta_service_impl_test.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl_test.rs
@@ -1,0 +1,72 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+#[allow(unused_imports)]
+use log::info;
+use pretty_assertions::assert_eq;
+
+use crate::meta_service::GetReq;
+use crate::meta_service::MetaServiceClient;
+use crate::meta_service::MetaServiceImpl;
+use crate::meta_service::MetaServiceServer;
+use crate::meta_service::SetReq;
+use crate::tests::rand_local_addr;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_server_set_get() -> anyhow::Result<()> {
+    let addr = rand_local_addr();
+
+    let meta_srv_impl = MetaServiceImpl::create();
+    let meta_srv = MetaServiceServer::new(meta_srv_impl);
+
+    serve_grpc!(addr, meta_srv);
+
+    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+
+    {
+        // add: ok
+        let req = tonic::Request::new(SetReq {
+            key: "foo".into(),
+            value: "bar".into(),
+            if_absent: true
+        });
+        let rst = client.set(req).await?.into_inner();
+        assert_eq!(true, rst.ok);
+
+        // get the stored value
+
+        let req = tonic::Request::new(GetReq { key: "foo".into() });
+        let rst = client.get(req).await?.into_inner();
+        assert_eq!("bar", rst.value);
+    }
+
+    {
+        // add: conflict with existent.
+        let req = tonic::Request::new(SetReq {
+            key: "foo".into(),
+            value: "bar".into(),
+            if_absent: true
+        });
+        let rst = client.set(req).await?.into_inner();
+        assert_eq!(false, rst.ok);
+    }
+    {
+        // set: overrde. ok.
+        let req = tonic::Request::new(SetReq {
+            key: "foo".into(),
+            value: "bar2".into(),
+            if_absent: false
+        });
+        let rst = client.set(req).await?.into_inner();
+        assert_eq!(true, rst.ok);
+
+        // get the stored value
+
+        let req = tonic::Request::new(GetReq { key: "foo".into() });
+        let rst = client.get(req).await?.into_inner();
+        assert_eq!("bar2", rst.value);
+    }
+
+    Ok(())
+}

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -1,0 +1,24 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+mod meta;
+mod meta_service_impl;
+
+pub use meta::IMeta;
+pub use meta::Meta;
+pub use meta::Node;
+pub use meta::NodeId;
+pub use meta::Slot;
+pub use meta_service_impl::MetaServiceImpl;
+
+pub use crate::protobuf::meta_service_client::MetaServiceClient;
+pub use crate::protobuf::meta_service_server::MetaService;
+pub use crate::protobuf::meta_service_server::MetaServiceServer;
+pub use crate::protobuf::GetReply;
+pub use crate::protobuf::GetReq;
+pub use crate::protobuf::SetReply;
+pub use crate::protobuf::SetReq;
+
+#[cfg(test)]
+mod meta_service_impl_test;

--- a/fusestore/store/src/tests/mod.rs
+++ b/fusestore/store/src/tests/mod.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-mod service;
+#[macro_use]
+pub mod service;
 
-pub use service::start_one_service;
+pub use service::rand_local_addr;
+pub use service::start_store_server;

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -5,24 +5,46 @@
 use anyhow::Result;
 use rand::Rng;
 
-use crate::api::RpcService;
+use crate::api::StoreServer;
 use crate::configs::Config;
 
 // Start one random service and get the session manager.
-pub async fn start_one_service() -> Result<String> {
-    let mut rng = rand::thread_rng();
-    let port: u32 = rng.gen_range(10000..11000);
-    let addr = format!("127.0.0.1:{}", port);
+pub async fn start_store_server() -> Result<String> {
+    let addr = rand_local_addr();
 
     let mut conf = Config::default();
     conf.rpc_api_address = addr.clone();
 
-    let srv = RpcService::create(conf);
+    let srv = StoreServer::create(conf);
     tokio::spawn(async move {
-        srv.make_server().await?;
+        srv.serve().await?;
         Ok::<(), anyhow::Error>(())
     });
 
     tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
     Ok(addr)
+}
+
+pub fn rand_local_addr() -> String {
+    let mut rng = rand::thread_rng();
+    let port: u32 = rng.gen_range(10000..11000);
+    let addr = format!("127.0.0.1:{}", port);
+    return addr;
+}
+
+macro_rules! serve_grpc {
+    ($addr:expr, $srv:expr) => {
+        let addr = $addr.parse::<std::net::SocketAddr>()?;
+
+        let srv = tonic::transport::Server::builder().add_service($srv);
+
+        tokio::spawn(async move {
+            srv.serve(addr)
+                .await
+                .map_err(|e| anyhow::anyhow!("Flight service error: {:?}", e))?;
+            Ok::<(), anyhow::Error>(())
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    };
 }


### PR DESCRIPTION
- add a single node meta service to estimate framework design.

- add distributed fs, support only "add" operation. It writes the data file
  locally and update changes to meta service.

- store flight service API: do_get() support pulling a file for replication.



## Changelog

- New Feature
- Refactor