### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ in Rust, inspired by [ClickHouse](https://github.com/ClickHouse/ClickHouse) and 
 
 |Query |FuseQuery (v0.1)| ClickHouse (v21.2.1)|
 |-------------------------------|---------------| ----|
-|SELECT avg(number) FROM numbers_mt | (3.11 s.)| **×3.14 slow, (9.77 s.)** <br /> 10.24 billion rows/s., 81.92 GB/s.|
-|SELECT sum(number) FROM numbers_mt | (2.96 s.)| **×2.02 slow, (5.97 s.)** <br /> 16.75 billion rows/s., 133.97 GB/s.|
-|SELECT min(number) FROM numbers_mt | (3.57 s.)| **×3.90 slow, (13.93 s.)** <br /> 7.18 billion rows/s., 57.44 GB/s.|
-|SELECT max(number) FROM numbers_mt | (3.59 s.)| **×4.09 slow, (14.70 s.)** <br /> 6.80 billion rows/s., 54.44 GB/s.|
-|SELECT count(number) FROM numbers_mt | (1.76 s.)| **×2.22 slow, (3.91 s.)** <br /> 25.58 billion rows/s., 204.65 GB/s.|
-|SELECT sum(number+number+number) FROM numbers_mt | (23.14 s.)|**×5.47 slow, (126.67 s.)** <br /> 789.47 million rows/s., 6.32 GB/s.|
-|SELECT sum(number) / count(number) FROM numbers_mt | (3.09 s.) | **×1.96 slow, (6.07 s.)** <br /> 16.48 billion rows/s., 131.88 GB/s.|
-|SELECT sum(number) / count(number), max(number), min(number) FROM numbers_mt |(6.73 s.)| **×4.01 slow, (27.59 s.)** <br /> 3.62 billion rows/s., 28.99 GB/s.|
+|SELECT avg(number) FROM numbers_mt(10000000000) | (3.11 s.)| **×3.14 slow, (9.77 s.)** <br /> 10.24 billion rows/s., 81.92 GB/s.|
+|SELECT sum(number) FROM numbers_mt(10000000000) | (2.96 s.)| **×2.02 slow, (5.97 s.)** <br /> 16.75 billion rows/s., 133.97 GB/s.|
+|SELECT min(number) FROM numbers_mt(10000000000) | (3.57 s.)| **×3.90 slow, (13.93 s.)** <br /> 7.18 billion rows/s., 57.44 GB/s.|
+|SELECT max(number) FROM numbers_mt(10000000000) | (3.59 s.)| **×4.09 slow, (14.70 s.)** <br /> 6.80 billion rows/s., 54.44 GB/s.|
+|SELECT count(number) FROM numbers_mt(10000000000) | (1.76 s.)| **×2.22 slow, (3.91 s.)** <br /> 25.58 billion rows/s., 204.65 GB/s.|
+|SELECT sum(number+number+number) FROM numbers_mt(10000000000) | (23.14 s.)|**×5.47 slow, (126.67 s.)** <br /> 789.47 million rows/s., 6.32 GB/s.|
+|SELECT sum(number) / count(number) FROM numbers_mt(10000000000) | (3.09 s.) | **×1.96 slow, (6.07 s.)** <br /> 16.48 billion rows/s., 131.88 GB/s.|
+|SELECT sum(number) / count(number), max(number), min(number) FROM numbers_mt(10000000000) |(6.73 s.)| **×4.01 slow, (27.59 s.)** <br /> 3.62 billion rows/s., 28.99 GB/s.|
 |SELECT number FROM numbers_mt(10000000000) ORDER BY number DESC LIMIT 1000|(6.91 s.)| **×1.42 slow, (9.83 s.)** <br /> 1.02 billion rows/s., 8.14 GB/s.|
 |SELECT max(number),sum(number) FROM numbers_mt(1000000000) GROUP BY number % 3, number % 4, number % 5 |(10.87 s.)| **×1.95 fast, (5.58 s.)** <br /> 179.23 million rows/s., 1.43 GB/s.|
 


### PR DESCRIPTION
change number_mt to numbers_mt(10000000000)

## Summary

SELECT avg(number) FROM numbers_mt;
ERROR 1105 (HY000): DataSource Error: Unknown table: 'numbers_mt'

Stack backtrace:
   0: anyhow::private::new_adhoc
             at /root/.cargo/registry/src/github.com-1ecc6299db9ec823/anyhow-1.0.40/src/lib.rs:632:36
      <fuse_query::datasources::local::local_database::LocalDatabase as fuse_query::datasources::database::IDatabase>::get_table::{{closure}}
             at ./fusequery/query/src/datasources/local/local_database.rs:48:28
      core::option::Option<T>::ok_or_else
             at /rustc/673d0db5e393e9c64897005b4

## Changelog

- Documentation (changelog entry is not required)


## Test Plan

mysql> SELECT avg(number) FROM numbers_mt(10000000000);
+--------------------+
| avg(number)        |
+--------------------+
| 1310651184.7580898 |
+--------------------+
1 row in set (1.00 sec)
