### PR TITLE
Fix up order by projection #381

### DIFF
--- a/common/planners/src/plan_builder.rs
+++ b/common/planners/src/plan_builder.rs
@@ -104,7 +104,7 @@ impl PlanBuilder {
         group_expr: Vec<ExpressionPlan>
     ) -> Result<Self> {
         let input_schema = self.plan.schema();
-        let aggr_fields = self.exprs_to_fields(&aggr_expr, &input_schema)?;
+        let aggr_projection_fields = self.exprs_to_fields(&aggr_expr, &input_schema)?;
 
         Ok(match mode {
             AggregateMode::Partial => {
@@ -118,7 +118,7 @@ impl PlanBuilder {
                 input: Arc::new(self.plan.clone()),
                 aggr_expr,
                 group_expr,
-                schema: Arc::new(DataSchema::new(aggr_fields))
+                schema: Arc::new(DataSchema::new(aggr_projection_fields))
             }))
         })
     }


### PR DESCRIPTION
## Summary

`SELECT name FROM system.tables ORDER BY database, name`
the last projection is: name, so the order by item `database` can not be found here.
Need push the `order by` front of the projection in common query.

But for the aggregation query, we keep after the aggregation projection.

## Changelog


- Bug Fix


## Related Issues

Fixs #381 

## Test Plan

Stateless Tests
