### PR TITLE
Add timeout(10s) for CI port check

### DIFF
--- a/scripts/ci/fusequery-cluster-3-nodes.sh
+++ b/scripts/ci/fusequery-cluster-3-nodes.sh
@@ -7,25 +7,19 @@ echo 'start cluster-1'
 nohup target/debug/fuse-query -c scripts/ci/config/fusequery-cluster-1.toml &
 
 echo "Waiting on cluster-1..."
-while ! nc -z -w 5 0.0.0.0 9091; do
-  sleep 1
-done
+timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' 0.0.0.0 9091
 
 echo 'start cluster-2'
 nohup target/debug/fuse-query -c scripts/ci/config/fusequery-cluster-2.toml &
 
 echo "Waiting on cluster-2..."
-while ! nc -z -w 5 0.0.0.0 9092; do
-  sleep 1
-done
+timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' 0.0.0.0 9092
 
 echo 'start cluster-3'
 nohup target/debug/fuse-query -c scripts/ci/config/fusequery-cluster-3.toml &
 
 echo "Waiting on cluster-3..."
-while ! nc -z -w 5 0.0.0.0 9093; do
-  sleep 1
-done
+timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' 0.0.0.0 9093
 
 curl http://127.0.0.1:8081/v1/cluster/add -X POST -H "Content-Type: application/json" -d '{"name":"cluster1","address":"0.0.0.0:9091", "priority":3, "cpus":8}'
 curl http://127.0.0.1:8081/v1/cluster/add -X POST -H "Content-Type: application/json" -d '{"name":"cluster2","address":"0.0.0.0:9092", "priority":3, "cpus":8}'

--- a/scripts/ci/fusequery-standalone.sh
+++ b/scripts/ci/fusequery-standalone.sh
@@ -6,7 +6,5 @@ sleep 1
 echo 'Start...'
 nohup target/debug/fuse-query -c scripts/ci/config/fusequery-cluster-1.toml &
 
-echo "Waiting on..."
-while ! nc -z -w 5 0.0.0.0 3307; do
-  sleep 1
-done
+echo "Waiting on 10 seconds..."
+timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' 0.0.0.0 3307


### PR DESCRIPTION
## Summary

Add timeout(10s) for CI port check

## Changelog

- Build/Testing/CI


## Related Issues

Fixes #456 

## Test Plan

Stateless Tests