### PR TITLE
fuse-test: Support error message(stderr) to *.result 

### DIFF
--- a/tests/fuse-test
+++ b/tests/fuse-test
@@ -418,8 +418,7 @@ def main(args):
 
 
 def get_additional_client_options(args):
-    # For MySQL client with header and table format
-    return ' -v -t --force '
+    return args.options
 
 
 def get_additional_client_options_url(args):
@@ -431,6 +430,7 @@ if __name__ == '__main__':
     parser.add_argument('-q', '--queries', help='Path to queries dir')
     parser.add_argument('-b', '--binary', default='fuse-query', help='Path to fuse-query binary or name of binary in PATH')
     parser.add_argument('-c', '--client', default='mysql -uroot -h127.0.0.1 -P3307 -s ', help='Client program')
+    parser.add_argument('-opt', '--options', default=' -v -t --force ', help="Client program options")
     parser.add_argument('--tmp', help='Path to tmp dir')
     parser.add_argument('-t', '--timeout', type=int, default=600, help='Timeout for each test case in seconds')
     parser.add_argument('test', nargs='*', help='Optional test case name regex')

--- a/tests/fuse-test
+++ b/tests/fuse-test
@@ -59,7 +59,7 @@ def run_single_test(args, ext, client_options, case_file, stdout_file, stderr_fi
         'stderr': stderr_file,
     }
 
-    pattern = '{test} > {stdout} 2> {stderr}'
+    pattern = '{test} > {stdout} 2>&1'
 
     if ext == '.sql':
         pattern = "{client} {options} < " + pattern
@@ -76,7 +76,6 @@ def run_single_test(args, ext, client_options, case_file, stdout_file, stderr_fi
 
     # Normalize randomized database names in stdout, stderr files.
     os.system("LC_ALL=C sed -i -e 's/{test_db}/default/g' {file}".format(test_db=args.database, file=stdout_file))
-    os.system("LC_ALL=C sed -i -e 's/{test_db}/default/g' {file}".format(test_db=args.database, file=stderr_file))
 
     stdout = open(stdout_file, 'rb').read() if os.path.exists(stdout_file) else b''
     stdout = str(stdout, errors='replace', encoding='utf-8')
@@ -420,7 +419,7 @@ def main(args):
 
 def get_additional_client_options(args):
     # For MySQL client with header and table format
-    return ' -v -t '
+    return ' -v -t --force '
 
 
 def get_additional_client_options_url(args):

--- a/tests/queries/0_stateless/00_0000_dummy_select_1.result
+++ b/tests/queries/0_stateless/00_0000_dummy_select_1.result
@@ -7,3 +7,17 @@ SELECT 1
 +------+
 |    1 |
 +------+
+--------------
+SELECT x
+--------------
+
+ERROR 1105 (HY000) at line 2: Code: 1002, displayText = Invalid argument error: Unable to get field named "x". Valid fields: ["dummy"].
+--------------
+SELECT 'a'
+--------------
+
++------+
+| a    |
++------+
+| a    |
++------+

--- a/tests/queries/0_stateless/00_0000_dummy_select_1.sql
+++ b/tests/queries/0_stateless/00_0000_dummy_select_1.sql
@@ -1,1 +1,3 @@
-SELECT 1
+SELECT 1;
+SELECT x;
+SELECT 'a';

--- a/tests/queries/0_stateless/07_0000_use_database.result
+++ b/tests/queries/0_stateless/07_0000_use_database.result
@@ -1,0 +1,1 @@
+ERROR 1105 (HY000) at line 1: Code: 3, displayText = Database not_exists_db  doesn't exist..

--- a/tests/queries/0_stateless/07_0000_use_database.sql
+++ b/tests/queries/0_stateless/07_0000_use_database.sql
@@ -1,1 +1,2 @@
+USE not_exists_db;
 USE default;


### PR DESCRIPTION
## Summary

Support error message(stderr) to *.result, we can test error for normal case.

## Changelog

- Build/Testing/CI


## Related Issues

Fixes #403 

## Test Plan

Stateless Tests
