### PR TITLE
[store] meta data cluster impl with raft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-raft"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9e14ce344bff51ccc1d430c2c93f84ca3320b3f86f69550871f6ae6957697a"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes 1.0.1",
+ "derive_more",
+ "futures",
+ "log",
+ "rand 0.7.3",
+ "serde",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +976,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b1b72f1263f214c0f823371768776c4f5841b942c9883aa8e5ec584fd0ba6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1249,7 @@ name = "fuse-store"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-raft",
  "async-trait",
  "common-arrow",
  "common-datablocks",
@@ -1244,11 +1276,15 @@ dependencies = [
  "serde_json",
  "structopt",
  "tempfile",
+ "thiserror",
  "threadpool",
  "tokio",
  "tokio-stream",
  "tonic",
  "tonic-build",
+ "tracing",
+ "tracing-futures",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1825,6 +1861,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matches"
@@ -2821,6 +2866,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
  "byteorder",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3059,6 +3105,15 @@ dependencies = [
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -3376,6 +3431,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3621,9 +3685,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -3645,9 +3709,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
 ]
@@ -3660,6 +3724,49 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -26,6 +26,7 @@ common-planners = {path = "../../common/planners"}
 
 # Crates.io dependencies
 anyhow = "1.0.40"
+async-raft = "0.6.0"
 async-trait = "0.1"
 env_logger = "0.8"
 futures = "0.3"
@@ -43,11 +44,16 @@ rand = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = "0.3"
-threadpool = "1.8.1"
 tempfile = "3.2.0"
+thiserror = "1.0.24"
+threadpool = "1.8.1"
 tokio = { version = "1.5", features = ["macros", "rt","rt-multi-thread", "sync"] }
 tokio-stream = "0.1"
 tonic = "0.4"
+tracing = "0.1.26"
+tracing-futures = { version = "0.2.5", default-features = false }
+tracing-subscriber = "0.2.18"
+
 
 [dev-dependencies]
 pretty_assertions = "0.7"

--- a/fusestore/store/proto/store_meta.proto
+++ b/fusestore/store/proto/store_meta.proto
@@ -63,8 +63,16 @@ message GetReply {
   string value = 3;
 }
 
+message RaftMes { bytes data = 1; }
+
 service MetaService {
 
   rpc Set(SetReq) returns (SetReply) {}
   rpc Get(GetReq) returns (GetReply) {}
+
+  // raft RPC
+
+  rpc AppendEntries(RaftMes) returns (RaftMes);
+  rpc InstallSnapshot(RaftMes) returns (RaftMes);
+  rpc vote(RaftMes) returns (RaftMes);
 }

--- a/fusestore/store/src/dfs/distributed_fs_test.rs
+++ b/fusestore/store/src/dfs/distributed_fs_test.rs
@@ -9,6 +9,7 @@ use crate::dfs::Dfs;
 use crate::fs::IFileSystem;
 use crate::localfs::LocalFS;
 use crate::meta_service::GetReq;
+use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
 use crate::meta_service::MetaServiceImpl;
 use crate::meta_service::MetaServiceServer;
@@ -22,7 +23,10 @@ async fn test_distributed_fs() -> anyhow::Result<()> {
     let fs = LocalFS::try_create(root.to_str().unwrap().to_string())?;
 
     let meta_addr = rand_local_addr();
-    let meta_srv_impl = MetaServiceImpl::create();
+
+    let mn = MetaNode::new(0).await;
+
+    let meta_srv_impl = MetaServiceImpl::create(mn).await;
     let meta_srv = MetaServiceServer::new(meta_srv_impl);
     serve_grpc!(meta_addr, meta_srv);
 

--- a/fusestore/store/src/meta_service/meta_service_impl_test.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl_test.rs
@@ -7,6 +7,7 @@ use log::info;
 use pretty_assertions::assert_eq;
 
 use crate::meta_service::GetReq;
+use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
 use crate::meta_service::MetaServiceImpl;
 use crate::meta_service::MetaServiceServer;
@@ -17,7 +18,9 @@ use crate::tests::rand_local_addr;
 async fn test_meta_server_set_get() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
-    let meta_srv_impl = MetaServiceImpl::create();
+    let mn = MetaNode::new(0).await;
+
+    let meta_srv_impl = MetaServiceImpl::create(mn).await;
     let meta_srv = MetaServiceServer::new(meta_srv_impl);
 
     serve_grpc!(addr, meta_srv);

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -4,6 +4,7 @@
 
 mod meta;
 mod meta_service_impl;
+mod raftmeta;
 
 pub use meta::IMeta;
 pub use meta::Meta;
@@ -11,14 +12,24 @@ pub use meta::Node;
 pub use meta::NodeId;
 pub use meta::Slot;
 pub use meta_service_impl::MetaServiceImpl;
+pub use raftmeta::ClientRequest;
+pub use raftmeta::ClientResponse;
+pub use raftmeta::MemStore;
+pub use raftmeta::MemStoreStateMachine;
+pub use raftmeta::MetaNode;
+pub use raftmeta::Network;
+pub use raftmeta::ShutdownError;
 
 pub use crate::protobuf::meta_service_client::MetaServiceClient;
 pub use crate::protobuf::meta_service_server::MetaService;
 pub use crate::protobuf::meta_service_server::MetaServiceServer;
 pub use crate::protobuf::GetReply;
 pub use crate::protobuf::GetReq;
+pub use crate::protobuf::RaftMes;
 pub use crate::protobuf::SetReply;
 pub use crate::protobuf::SetReq;
 
 #[cfg(test)]
 mod meta_service_impl_test;
+#[cfg(test)]
+mod raftmeta_test;

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -1,0 +1,708 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::io::Cursor;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_raft::async_trait::async_trait;
+use async_raft::config::Config;
+use async_raft::raft::AppendEntriesRequest;
+use async_raft::raft::AppendEntriesResponse;
+use async_raft::raft::ClientWriteRequest;
+use async_raft::raft::Entry;
+use async_raft::raft::EntryPayload;
+use async_raft::raft::InstallSnapshotRequest;
+use async_raft::raft::InstallSnapshotResponse;
+use async_raft::raft::MembershipConfig;
+use async_raft::raft::VoteRequest;
+use async_raft::raft::VoteResponse;
+use async_raft::storage::CurrentSnapshotData;
+use async_raft::storage::HardState;
+use async_raft::storage::InitialState;
+use async_raft::AppData;
+use async_raft::AppDataResponse;
+use async_raft::NodeId;
+use async_raft::Raft;
+use async_raft::RaftMetrics;
+use async_raft::RaftNetwork;
+use async_raft::RaftStorage;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+use tokio::sync::watch;
+use tokio::sync::RwLock;
+use tokio::sync::RwLockReadGuard;
+use tokio::sync::RwLockWriteGuard;
+use tonic::transport::channel::Channel;
+
+use crate::meta_service::MetaServiceClient;
+use crate::meta_service::RaftMes;
+
+const ERR_INCONSISTENT_LOG: &str =
+    "a query was received which was expecting data to be in place which does not exist in the log";
+
+/// The application data request type which the `MemStore` works with.
+///
+/// Conceptually, for demo purposes, this represents an update to a client's status info,
+/// returning the previously recorded status.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ClientRequest {
+    /// The ID of the client which has sent the request.
+    pub client: String,
+    /// The serial number of this request.
+    pub serial: u64,
+    /// A string describing the status of the client. For a real application, this should probably
+    /// be an enum representing all of the various types of requests / operations which a client
+    /// can perform.
+    pub status: String
+}
+
+impl AppData for ClientRequest {}
+
+/// The application data response type which the `MemStore` works with.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ClientResponse {
+    // The value before applying a ClientRequest.
+    pub prev: Option<String>,
+    // The value after applying a ClientRequest.
+    pub result: Option<String>
+}
+
+impl AppDataResponse for ClientResponse {}
+
+/// Error used to trigger Raft shutdown from storage.
+#[derive(Clone, Debug, Error)]
+pub enum ShutdownError {
+    #[error("unsafe storage error")]
+    UnsafeStorageError
+}
+
+/// The application snapshot type which the `MemStore` works with.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MemStoreSnapshot {
+    /// The last index covered by this snapshot.
+    pub index: u64,
+    /// The term of the last index covered by this snapshot.
+    pub term: u64,
+    /// The last memberhsip config included in this snapshot.
+    pub membership: MembershipConfig,
+    /// The data of the state machine at the time of this snapshot.
+    pub data: Vec<u8>
+}
+
+/// The state machine of the `MemStore`.
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct MemStoreStateMachine {
+    pub last_applied_log: u64,
+    /// A mapping of client IDs to their state info.
+    pub client_serial_responses: HashMap<String, (u64, Option<String>)>,
+    /// The current status of a client by ID.
+    pub client_status: HashMap<String, String>
+}
+
+/// An in-memory storage system implementing the `async_raft::RaftStorage` trait.
+pub struct MemStore {
+    /// The ID of the Raft node for which this memory storage instances is configured.
+    id: NodeId,
+    /// The Raft log.
+    log: RwLock<BTreeMap<u64, Entry<ClientRequest>>>,
+    /// The Raft state machine.
+    sm: RwLock<MemStoreStateMachine>,
+    /// The current hard state.
+    hs: RwLock<Option<HardState>>,
+    /// The current snapshot.
+    current_snapshot: RwLock<Option<MemStoreSnapshot>>
+}
+
+impl MemStore {
+    /// Create a new `MemStore` instance.
+    pub fn new(id: NodeId) -> Self {
+        let log = RwLock::new(BTreeMap::new());
+        let sm = RwLock::new(MemStoreStateMachine::default());
+        let hs = RwLock::new(None);
+        let current_snapshot = RwLock::new(None);
+        Self {
+            id,
+            log,
+            sm,
+            hs,
+            current_snapshot
+        }
+    }
+
+    /// Create a new `MemStore` instance with some existing state (for testing).
+    #[cfg(test)]
+    pub fn new_with_state(
+        id: NodeId,
+        log: BTreeMap<u64, Entry<ClientRequest>>,
+        sm: MemStoreStateMachine,
+        hs: Option<HardState>,
+        current_snapshot: Option<MemStoreSnapshot>
+    ) -> Self {
+        let log = RwLock::new(log);
+        let sm = RwLock::new(sm);
+        let hs = RwLock::new(hs);
+        let current_snapshot = RwLock::new(current_snapshot);
+        Self {
+            id,
+            log,
+            sm,
+            hs,
+            current_snapshot
+        }
+    }
+
+    /// Get a handle to the log for testing purposes.
+    pub async fn get_log(&self) -> RwLockWriteGuard<'_, BTreeMap<u64, Entry<ClientRequest>>> {
+        self.log.write().await
+    }
+
+    /// Get a handle to the state machine for testing purposes.
+    pub async fn get_state_machine(&self) -> RwLockWriteGuard<'_, MemStoreStateMachine> {
+        self.sm.write().await
+    }
+
+    /// Get a handle to the current hard state for testing purposes.
+    pub async fn read_hard_state(&self) -> RwLockReadGuard<'_, Option<HardState>> {
+        self.hs.read().await
+    }
+}
+
+#[async_trait]
+impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
+    type Snapshot = Cursor<Vec<u8>>;
+    type ShutdownError = ShutdownError;
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn get_membership_config(&self) -> Result<MembershipConfig> {
+        let log = self.log.read().await;
+        let cfg_opt = log.values().rev().find_map(|entry| match &entry.payload {
+            EntryPayload::ConfigChange(cfg) => Some(cfg.membership.clone()),
+            EntryPayload::SnapshotPointer(snap) => Some(snap.membership.clone()),
+            _ => None
+        });
+        Ok(match cfg_opt {
+            Some(cfg) => cfg,
+            None => MembershipConfig::new_initial(self.id)
+        })
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn get_initial_state(&self) -> Result<InitialState> {
+        let membership = self.get_membership_config().await?;
+        let mut hs = self.hs.write().await;
+        let log = self.log.read().await;
+        let sm = self.sm.read().await;
+        match &mut *hs {
+            Some(inner) => {
+                let (last_log_index, last_log_term) = match log.values().rev().next() {
+                    Some(log) => (log.index, log.term),
+                    None => (0, 0)
+                };
+                let last_applied_log = sm.last_applied_log;
+                let st = InitialState {
+                    last_log_index,
+                    last_log_term,
+                    last_applied_log,
+                    hard_state: inner.clone(),
+                    membership
+                };
+                tracing::info!("build initial state from storage: {:?}", st);
+                Ok(st)
+            }
+            None => {
+                let new = InitialState::new_initial(self.id);
+                tracing::info!("create initial state: {:?}", new);
+                *hs = Some(new.hard_state.clone());
+                Ok(new)
+            }
+        }
+    }
+
+    #[tracing::instrument(level = "info", skip(self, hs))]
+    async fn save_hard_state(&self, hs: &HardState) -> Result<()> {
+        *self.hs.write().await = Some(hs.clone());
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn get_log_entries(&self, start: u64, stop: u64) -> Result<Vec<Entry<ClientRequest>>> {
+        // Invalid request, return empty vec.
+        if start > stop {
+            tracing::error!("invalid request, start > stop");
+            return Ok(vec![]);
+        }
+        let log = self.log.read().await;
+        Ok(log.range(start..stop).map(|(_, val)| val.clone()).collect())
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn delete_logs_from(&self, start: u64, stop: Option<u64>) -> Result<()> {
+        if stop.as_ref().map(|stop| &start > stop).unwrap_or(false) {
+            tracing::error!("invalid request, start > stop");
+            return Ok(());
+        }
+        let mut log = self.log.write().await;
+
+        // If a stop point was specified, delete from start until the given stop point.
+        if let Some(stop) = stop.as_ref() {
+            for key in start..*stop {
+                log.remove(&key);
+            }
+            return Ok(());
+        }
+        // Else, just split off the remainder.
+        log.split_off(&start);
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "info", skip(self, entry))]
+    async fn append_entry_to_log(&self, entry: &Entry<ClientRequest>) -> Result<()> {
+        let mut log = self.log.write().await;
+        log.insert(entry.index, entry.clone());
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "info", skip(self, entries))]
+    async fn replicate_to_log(&self, entries: &[Entry<ClientRequest>]) -> Result<()> {
+        let mut log = self.log.write().await;
+        for entry in entries {
+            log.insert(entry.index, entry.clone());
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn apply_entry_to_state_machine(
+        &self,
+        index: &u64,
+        data: &ClientRequest
+    ) -> Result<ClientResponse> {
+        let mut sm = self.sm.write().await;
+        sm.last_applied_log = *index;
+        if let Some((serial, res)) = sm.client_serial_responses.get(&data.client) {
+            if serial == &data.serial {
+                return Ok(ClientResponse {
+                    // TODO client_serial_responses save prev and result?
+                    prev: None,
+                    result: res.clone()
+                });
+            }
+        }
+        let previous = sm
+            .client_status
+            .insert(data.client.clone(), data.status.clone());
+        sm.client_serial_responses
+            .insert(data.client.clone(), (data.serial, previous.clone()));
+        Ok(ClientResponse {
+            prev: previous,
+            result: Some(data.status.clone())
+        })
+    }
+
+    #[tracing::instrument(level = "info", skip(self, entries))]
+    async fn replicate_to_state_machine(&self, entries: &[(&u64, &ClientRequest)]) -> Result<()> {
+        let mut sm = self.sm.write().await;
+        for (index, data) in entries {
+            sm.last_applied_log = **index;
+            if let Some((serial, _)) = sm.client_serial_responses.get(&data.client) {
+                if serial == &data.serial {
+                    continue;
+                }
+            }
+            let previous = sm
+                .client_status
+                .insert(data.client.clone(), data.status.clone());
+            sm.client_serial_responses
+                .insert(data.client.clone(), (data.serial, previous.clone()));
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn do_log_compaction(&self) -> Result<CurrentSnapshotData<Self::Snapshot>> {
+        let (data, last_applied_log);
+        {
+            // Serialize the data of the state machine.
+            let sm = self.sm.read().await;
+            data = serde_json::to_vec(&*sm)?;
+            last_applied_log = sm.last_applied_log;
+        } // Release state machine read lock.
+
+        let membership_config;
+        {
+            // Go backwards through the log to find the most recent membership config <= the `through` index.
+            let log = self.log.read().await;
+            membership_config = log
+                .values()
+                .rev()
+                .skip_while(|entry| entry.index > last_applied_log)
+                .find_map(|entry| match &entry.payload {
+                    EntryPayload::ConfigChange(cfg) => Some(cfg.membership.clone()),
+                    _ => None
+                })
+                .unwrap_or_else(|| MembershipConfig::new_initial(self.id));
+        } // Release log read lock.
+
+        let snapshot_bytes: Vec<u8>;
+        let term;
+        {
+            let mut log = self.log.write().await;
+            let mut current_snapshot = self.current_snapshot.write().await;
+            term = log
+                .get(&last_applied_log)
+                .map(|entry| entry.term)
+                .ok_or_else(|| anyhow::anyhow!(ERR_INCONSISTENT_LOG))?;
+            *log = log.split_off(&last_applied_log);
+            log.insert(
+                last_applied_log,
+                Entry::new_snapshot_pointer(
+                    last_applied_log,
+                    term,
+                    "".into(),
+                    membership_config.clone()
+                )
+            );
+
+            let snapshot = MemStoreSnapshot {
+                index: last_applied_log,
+                term,
+                membership: membership_config.clone(),
+                data
+            };
+            snapshot_bytes = serde_json::to_vec(&snapshot)?;
+            *current_snapshot = Some(snapshot);
+        } // Release log & snapshot write locks.
+
+        tracing::info!(
+            { snapshot_size = snapshot_bytes.len() },
+            "log compaction complete"
+        );
+        Ok(CurrentSnapshotData {
+            term,
+            index: last_applied_log,
+            membership: membership_config.clone(),
+            snapshot: Box::new(Cursor::new(snapshot_bytes))
+        })
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn create_snapshot(&self) -> Result<(String, Box<Self::Snapshot>)> {
+        Ok((String::from(""), Box::new(Cursor::new(Vec::new())))) // Snapshot IDs are insignificant to this storage engine.
+    }
+
+    #[tracing::instrument(level = "info", skip(self, snapshot))]
+    async fn finalize_snapshot_installation(
+        &self,
+        index: u64,
+        term: u64,
+        delete_through: Option<u64>,
+        id: String,
+        snapshot: Box<Self::Snapshot>
+    ) -> Result<()> {
+        tracing::info!(
+            { snapshot_size = snapshot.get_ref().len() },
+            "decoding snapshot for installation"
+        );
+        let raw = serde_json::to_string_pretty(snapshot.get_ref().as_slice())?;
+        println!("JSON SNAP:\n{}", raw);
+        let new_snapshot: MemStoreSnapshot = serde_json::from_slice(snapshot.get_ref().as_slice())?;
+        // Update log.
+        {
+            // Go backwards through the log to find the most recent membership config <= the `through` index.
+            let mut log = self.log.write().await;
+            let membership_config = log
+                .values()
+                .rev()
+                .skip_while(|entry| entry.index > index)
+                .find_map(|entry| match &entry.payload {
+                    EntryPayload::ConfigChange(cfg) => Some(cfg.membership.clone()),
+                    _ => None
+                })
+                .unwrap_or_else(|| MembershipConfig::new_initial(self.id));
+
+            match &delete_through {
+                Some(through) => {
+                    *log = log.split_off(&(through + 1));
+                }
+                None => log.clear()
+            }
+            log.insert(
+                index,
+                Entry::new_snapshot_pointer(index, term, id, membership_config)
+            );
+        }
+
+        // Update the state machine.
+        {
+            let new_sm: MemStoreStateMachine = serde_json::from_slice(&new_snapshot.data)?;
+            let mut sm = self.sm.write().await;
+            *sm = new_sm;
+        }
+
+        // Update current snapshot.
+        let mut current_snapshot = self.current_snapshot.write().await;
+        *current_snapshot = Some(new_snapshot);
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn get_current_snapshot(&self) -> Result<Option<CurrentSnapshotData<Self::Snapshot>>> {
+        match &*self.current_snapshot.read().await {
+            Some(snapshot) => {
+                let reader = serde_json::to_vec(&snapshot)?;
+                Ok(Some(CurrentSnapshotData {
+                    index: snapshot.index,
+                    term: snapshot.term,
+                    membership: snapshot.membership.clone(),
+                    snapshot: Box::new(Cursor::new(reader))
+                }))
+            }
+            None => Ok(None)
+        }
+    }
+}
+
+pub struct Network {
+    sto: Arc<MemStore>
+}
+
+impl Network {
+    pub fn new(m: Arc<MemStore>) -> Network {
+        Network { sto: m }
+    }
+    pub async fn make_client(&self, addr: String) -> anyhow::Result<MetaServiceClient<Channel>> {
+        let client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+        Ok(client)
+    }
+}
+
+#[async_trait]
+impl RaftNetwork<ClientRequest> for Network {
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn append_entries(
+        &self,
+        target: NodeId,
+        rpc: AppendEntriesRequest<ClientRequest>
+    ) -> Result<AppendEntriesResponse> {
+        let addr = self.sto.get_node_addr(target).await?;
+        let data = serde_json::to_vec(&rpc)?;
+
+        let req = tonic::Request::new(RaftMes { data });
+
+        let mut client = self.make_client(addr).await?;
+        let resp = client.append_entries(req).await?;
+        let mes = resp.into_inner();
+        let resp = serde_json::from_slice(&mes.data)?;
+
+        Ok(resp)
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn install_snapshot(
+        &self,
+        target: NodeId,
+        rpc: InstallSnapshotRequest
+    ) -> Result<InstallSnapshotResponse> {
+        let addr = self.sto.get_node_addr(target).await?;
+        let data = serde_json::to_vec(&rpc)?;
+
+        let req = tonic::Request::new(RaftMes { data });
+
+        let mut client = self.make_client(addr).await?;
+        let resp = client.install_snapshot(req).await?;
+        let mes = resp.into_inner();
+        let resp = serde_json::from_slice(&mes.data)?;
+
+        Ok(resp)
+    }
+
+    #[tracing::instrument(level = "info", skip(self))]
+    async fn vote(&self, target: NodeId, rpc: VoteRequest) -> Result<VoteResponse> {
+        let addr = self.sto.get_node_addr(target).await?;
+        let data = serde_json::to_vec(&rpc)?;
+
+        let req = tonic::Request::new(RaftMes { data });
+
+        let mut client = self.make_client(addr).await?;
+        let resp = client.vote(req).await?;
+        let mes = resp.into_inner();
+        let resp = serde_json::from_slice(&mes.data)?;
+
+        Ok(resp)
+    }
+}
+
+// MetaRaft is a impl of the generic Raft handling meta data R/W.
+pub type MetaRaft = Raft<ClientRequest, ClientResponse, Network, MemStore>;
+
+// MetaNode is the container of meta data related components and threads, such as storage, the raft node and a raft-state monitor.
+pub struct MetaNode {
+    // metrics subscribes raft state changes. The most important field is the leader node id, to which all write operations should be forward.
+    pub metrics: Arc<RwLock<RaftMetrics>>,
+    pub sto: Arc<MemStore>,
+    pub raft: MetaRaft
+}
+
+impl MemStore {
+    // build a meta data key of node in the cluster.
+    pub fn node_key(&self, node_id: NodeId) -> String {
+        format!("node/{:}", node_id)
+    }
+
+    pub async fn get_node_addr(&self, node_id: NodeId) -> anyhow::Result<String> {
+        let key = self.node_key(node_id);
+        let ns = self.sm.read().await;
+
+        let addr = ns
+            .client_status
+            .get(&key)
+            .ok_or_else(|| anyhow::anyhow!("node not found: {:}", key))?;
+        Ok(addr.clone())
+    }
+
+    pub async fn list_added_non_voters(&self) -> HashSet<NodeId> {
+        // TODO: impl a hierarchical structure in storage.
+
+        let mut rst = HashSet::new();
+        let sm = self.sm.read().await;
+        let ms = self
+            .get_membership_config()
+            .await
+            .expect("fail to get membership");
+        // TODO: there is no iteration in store. Using a for loop to iterate nodes for now.
+        for i in 0..100 {
+            let key = self.node_key(i);
+            // it has been added into this cluster and is not a voter.
+            if sm.client_status.contains_key(&key) && !ms.contains(&i) {
+                rst.insert(i);
+            }
+        }
+        rst
+    }
+}
+
+impl MetaNode {
+    pub async fn new(node_id: NodeId) -> Arc<MetaNode> {
+        let config = Config::build("foo_cluster".into())
+            .validate()
+            .expect("fail to build raft config");
+
+        let sto = Arc::new(MemStore::new(node_id));
+        let net = Network::new(sto.clone());
+
+        let raft = MetaRaft::new(node_id, Arc::new(config), Arc::new(net), sto.clone());
+        let metrics_rx = raft.metrics();
+        let metrics = metrics_rx.borrow().clone();
+        let metrics = Arc::new(RwLock::new(metrics));
+
+        let mn = Arc::new(MetaNode { metrics, sto, raft });
+
+        Self::spawn_metrics_monitor(mn.clone(), metrics_rx);
+
+        mn
+    }
+
+    // spawn a monitor to watch leader changes,
+    // and feed the chagne to a local cache.
+    pub fn spawn_metrics_monitor(mn: Arc<Self>, mut metrics_rx: watch::Receiver<RaftMetrics>) {
+        tokio::task::spawn(async move {
+            loop {
+                let changed = metrics_rx.changed().await;
+                if changed.is_ok() {
+                    let mm = metrics_rx.borrow().clone();
+                    *mn.metrics.write().await = mm;
+                    // TODO: check result
+                    let _rst = mn
+                        .add_configured_non_voters()
+                        .await
+                        .expect("fail to update non-voter");
+                } else {
+                    // shutting down
+                    break;
+                }
+            }
+        });
+    }
+
+    /// boot is called only once when booting up a cluster.
+    #[tracing::instrument(level = "info", skip(self))]
+    pub async fn boot(&self, addr: String) -> anyhow::Result<()> {
+        let node_id = self.sto.id;
+        let mut cluster_node_ids = HashSet::new();
+        cluster_node_ids.insert(node_id);
+
+        let rst = self
+            .raft
+            .initialize(cluster_node_ids)
+            .await
+            .map_err(|x| anyhow::anyhow!("{:?}", x))?;
+
+        tracing::info!("booted, rst: {:?}", rst);
+
+        let key = self.sto.node_key(self.sto.id);
+        let _resp = self.local_set(key, addr).await.expect("fail to add myself");
+        Ok(())
+    }
+
+    /// When a leader is established, it is the leader's responsibility to setup replication from itself to non-voters, AKA learners.
+    /// async-raft does not persist the node set of non-voters, thus we need to do it manually.
+    /// This fn should be called once a node found it becomes leader.
+    #[tracing::instrument(level = "info", skip(self))]
+    pub async fn add_configured_non_voters(&self) -> anyhow::Result<()> {
+        // TODO after leader established, add non-voter through apis
+        let node_ids = self.sto.list_added_non_voters().await;
+        for i in node_ids.iter() {
+            self.raft
+                .add_non_voter(*i)
+                .await
+                .expect("fail to add non-voter");
+        }
+        Ok(())
+    }
+
+    // get meta data from local state, most business logic without strong consistency requirement should use this to access meta.
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn get(&self, key: String) -> anyhow::Result<String> {
+        // inconsistent get: from local state machine
+
+        let sm = self.sto.sm.read().await;
+        let v = sm
+            .client_status
+            .get(&key)
+            .ok_or_else(|| anyhow::anyhow!("meta data key not found: {:}", key))?;
+        Ok(v.clone())
+    }
+
+    /// Write a meta record through local raft node.
+    /// It works only when this node is the leader.
+    #[tracing::instrument(level = "info", skip(self))]
+    pub async fn local_set(&self, key: String, value: String) -> anyhow::Result<String> {
+        let write_rst = self
+            .raft
+            .client_write(ClientWriteRequest::new(ClientRequest {
+                client: key,
+                serial: 0,
+                status: value
+            }))
+            .await;
+
+        tracing::info!("raft.client_write rst: {:?}", write_rst);
+
+        let resp = match write_rst {
+            Ok(v) => v,
+            // ClientWriteError::RaftError(re)
+            // ClientWriteError::ForwardToLeader(_req, _node_id)
+            Err(e) => return Err(anyhow::anyhow!("{:}", e))
+        };
+
+        let d = resp.data;
+
+        Ok(d.result.unwrap())
+    }
+}

--- a/fusestore/store/src/meta_service/raftmeta_test.rs
+++ b/fusestore/store/src/meta_service/raftmeta_test.rs
@@ -1,0 +1,123 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use async_raft::RaftMetrics;
+use async_raft::State;
+use pretty_assertions::assert_eq;
+use tokio::sync::watch::Receiver;
+
+use crate::meta_service::GetReq;
+use crate::meta_service::MetaNode;
+use crate::meta_service::MetaServiceClient;
+use crate::meta_service::MetaServiceImpl;
+use crate::meta_service::MetaServiceServer;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_node_boot() -> anyhow::Result<()> {
+    crate::tests::init_tracing();
+
+    // Start a single node meta service cluster.
+    // Test the single node is recorded by this cluster.
+
+    let mn = MetaNode::new(0).await;
+
+    let addr = "127.0.0.1:9000".to_string();
+    let resp = mn.boot(addr.clone()).await;
+    assert!(resp.is_ok());
+
+    let got = mn.get(mn.sto.node_key(0)).await;
+    assert_eq!(addr, got.unwrap());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_node_add_non_voter() -> anyhow::Result<()> {
+    crate::tests::init_tracing();
+
+    // Start a meta service cluster with one voter(leader) and one non-voter.
+
+    // node-0: voter
+    let nid0 = 0;
+    let addr0 = "127.0.0.1:19000".to_string();
+    let mn0 = MetaNode::new(nid0).await;
+    let mut mrx0 = mn0.raft.metrics();
+    let srv0 = MetaServiceImpl::create(mn0.clone()).await;
+    let srv0 = MetaServiceServer::new(srv0);
+    serve_grpc!(addr0, srv0);
+
+    check_connection(addr0.clone()).await?;
+
+    // node-1: non-voter
+    let nid1 = 1;
+    let addr1 = "127.0.0.1:19001".to_string();
+    let mn1 = MetaNode::new(1).await;
+    let mut mrx1 = mn1.raft.metrics();
+    let srv1 = MetaServiceImpl::create(mn1.clone()).await;
+    let srv1 = MetaServiceServer::new(srv1);
+    serve_grpc!(addr1, srv1);
+
+    check_connection(addr1.clone()).await?;
+
+    wait_for("nid0 to be non-voter", &mut mrx0, |x| {
+        x.state == State::NonVoter
+    })
+    .await;
+    wait_for("nid1 to be non-voter", &mut mrx1, |x| {
+        x.state == State::NonVoter
+    })
+    .await;
+
+    {
+        // boot up a single-node cluster
+        let resp = mn0.boot(addr0.clone()).await;
+        assert!(resp.is_ok());
+
+        let got = mn0.get(mn0.sto.node_key(nid0)).await;
+        assert_eq!(addr0, got.unwrap(), "nid1 is added");
+
+        wait_for("nid0 to be leader", &mut mrx0, |x| x.state == State::Leader).await;
+        wait_for("nid0 current_leader==0", &mut mrx0, |x| {
+            x.current_leader == Some(0)
+        })
+        .await;
+    }
+
+    {
+        // add node-1 to cluster as non-voter
+        let key = mn0.sto.node_key(nid1);
+        let resp = mn0.local_set(key, addr1.clone()).await;
+        assert_eq!(addr1, resp.unwrap());
+    }
+
+    wait_for("nid1 current_leader==0", &mut mrx1, |x| {
+        x.current_leader == Some(0)
+    })
+    .await;
+
+    Ok(())
+}
+
+async fn check_connection(addr: String) -> anyhow::Result<()> {
+    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+    let req = tonic::Request::new(GetReq { key: "foo".into() });
+    let rst = client.get(req).await?.into_inner();
+    assert_eq!("", rst.value, "connected");
+    Ok(())
+}
+
+// wait for raft metrics to a state that satisfies `func`.
+#[tracing::instrument(level = "info", skip(func, mrx))]
+async fn wait_for<T>(msg: &str, mrx: &mut Receiver<RaftMetrics>, func: T) -> RaftMetrics
+where T: Fn(&RaftMetrics) -> bool {
+    loop {
+        let latest = mrx.borrow().clone();
+        tracing::info!("wait for {:} metrics: {:?}", msg, latest);
+        if func(&latest) {
+            return latest;
+        }
+
+        let changed = mrx.changed().await;
+        assert!(changed.is_ok());
+    }
+}

--- a/fusestore/store/src/tests/logging.rs
+++ b/fusestore/store/src/tests/logging.rs
@@ -1,0 +1,26 @@
+use std::sync::Once;
+
+use tracing_subscriber::fmt;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Registry;
+
+pub fn init_tracing() {
+    static START: Once = Once::new();
+
+    START.call_once(|| {
+        // init without span:
+        // fmt::init();
+
+        let fmt_layer = fmt::Layer::default()
+            .with_span_events(fmt::format::FmtSpan::FULL)
+            .with_ansi(false);
+
+        let subscriber = Registry::default()
+            .with(EnvFilter::from_default_env())
+            .with(fmt_layer);
+
+        tracing::subscriber::set_global_default(subscriber)
+            .expect("error setting global tracing subscriber");
+    });
+}

--- a/fusestore/store/src/tests/mod.rs
+++ b/fusestore/store/src/tests/mod.rs
@@ -4,6 +4,8 @@
 
 #[macro_use]
 pub mod service;
+pub mod logging;
 
+pub use logging::init_tracing;
 pub use service::rand_local_addr;
 pub use service::start_store_server;


### PR DESCRIPTION
Using async-raft as a consensus engine to set up a strongly consistent kv
store as metadata service.

A store node maintains two services: meta API and flight API.

In this commit, the raft is backed with a pure memory store.
And unit test only covers single-node cluster and
one-leader-one-learner(non-voter) cluster.

```
flight-grpc     meta-grpc
    |               |
    '--.      .-----'
       |      |
       MetaNode
       |     |
       |    RaftNode
       |  .--'   |
       |  |      |
     Storage   Network

```


## Changelog

- New Feature

## Related Issues

Fix #490 