### PR TITLE
[store] add Cmd to define meta OP. explain metadata components

### DIFF
--- a/fusestore/store/src/meta_service/meta_service_impl.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl.rs
@@ -44,6 +44,7 @@ impl MetaService for MetaServiceImpl {
         m.keys.insert(req.key, req.value);
         return Ok(tonic::Response::new(SetReply { ok: true }));
     }
+
     #[tracing::instrument(level = "info", skip(self))]
     async fn get(
         &self,

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -14,6 +14,7 @@ pub use meta::Slot;
 pub use meta_service_impl::MetaServiceImpl;
 pub use raftmeta::ClientRequest;
 pub use raftmeta::ClientResponse;
+pub use raftmeta::Cmd;
 pub use raftmeta::MemStore;
 pub use raftmeta::MemStoreStateMachine;
 pub use raftmeta::MetaNode;

--- a/website/datafuse/docs/rfcs/store/2021-04-22-store-design.md
+++ b/website/datafuse/docs/rfcs/store/2021-04-22-store-design.md
@@ -80,6 +80,42 @@ Every other node is a **learner**, which does not elect but just subscribes
 meta change message from the 5 candidates.
 
 
+## In-process metadata components
+
+A FuseStore process includes two grpc API: the flight service and the meta
+service.
+
+- Meta related components are wrapped into `MetaNode`, in which a `Raft` instance
+    is maintained along with storage and netowrk engines.
+
+    `MetaNode` is the only entry for other FuseStore components to access meta data.
+
+- `RaftNode` communicates with remote RaftNode through `Network`, which send
+    messages to meta-grpc service on other FuseStore nodes.
+
+- `Network` relies on `Storage` to find out info of other nodes.
+
+
+```
+FuseStore components:
+.---------------------------.
+|                           |
+| flight-grpc     meta-grpc |
+|     |               |     |
+|     '--.      .-----'     |
+|        v      v           |
+|        MetaNode           |
+|        |     |            |
+|        |     v            |
+|        |    RaftNode      |
+|        |  .--'   |        |
+|        v  v      v        |
+|      Storage <- Network   |
+|                           |
+'---------------------------'
+```
+
+
 ## Meta data structure
 
 Meta data includes hardware information: nodes, the file information: keys and


### PR DESCRIPTION
## Summary

- Introduce `Cmd` to define meta-operation actions.

- Explains the organization of metadata-related components.

- Refactor: refine type names to reflect their actual purpose.


## Changelog

- New Feature
- Documentation


## Related Issues

fixes #494
