### PR TITLE
[store] refactor: move meta into standalone struct.

### DIFF
--- a/fusestore/store/src/dfs/distributed_fs.rs
+++ b/fusestore/store/src/dfs/distributed_fs.rs
@@ -54,7 +54,7 @@ impl IFileSystem for Dfs {
         let mut client = self.make_client().await?;
         let req = ClientRequest {
             txid: None,
-            cmd: Cmd::Add {
+            cmd: Cmd::AddFile {
                 key: path,
                 value: "".into()
             }

--- a/fusestore/store/src/lib.rs
+++ b/fusestore/store/src/lib.rs
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[allow(clippy::all)]
+pub mod protobuf {
+    // tonic::include_proto!("store_meta");
+    include!(concat!(env!("OUT_DIR"), concat!("/store_meta.rs")));
+}
+
 #[cfg(test)]
 #[macro_use]
 pub mod tests;
@@ -15,9 +21,3 @@ pub mod fs;
 pub mod localfs;
 pub mod meta_service;
 pub mod metrics;
-
-#[allow(clippy::all)]
-pub mod protobuf {
-    // tonic::include_proto!("store_meta");
-    include!(concat!(env!("OUT_DIR"), concat!("/store_meta.rs")));
-}

--- a/fusestore/store/src/meta_service/meta.rs
+++ b/fusestore/store/src/meta_service/meta.rs
@@ -2,22 +2,26 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::hash::Hash;
-use std::hash::Hasher;
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
 
-use async_trait::async_trait;
+use serde::Deserialize;
+use serde::Serialize;
 
-#[async_trait]
-pub trait IMeta {
-    async fn add(&mut self, key: String, value: String) -> anyhow::Result<()>;
-    // async fn remove(&self, key: String) -> anyhow::Result<()>;
-}
+use crate::meta_service::ClientRequest;
+use crate::meta_service::ClientResponse;
+use crate::meta_service::Cmd;
+use crate::meta_service::IPlacement;
+use crate::meta_service::NodeId;
 
-/// Distributed FS meta data manager
-#[derive(Default)]
+/// Meta data of a Dfs.
+/// Includes:
+/// - what files are stored in this Dfs.
+/// - the algo about how to distribute files to nodes.
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Meta {
     /// The file names stored in this cluster
     pub keys: BTreeMap<String, String>,
@@ -27,53 +31,77 @@ pub struct Meta {
     pub nodes: HashMap<NodeId, Node>
 }
 
+impl Meta {
+    // Apply an op from client.
+    pub fn apply(&mut self, data: &ClientRequest) -> anyhow::Result<ClientResponse> {
+        match data.cmd {
+            Cmd::AddFile { ref key, ref value } => {
+                if self.keys.contains_key(key) {
+                    let prev = self.keys.get(key);
+                    Ok((prev.cloned(), None).into())
+                } else {
+                    let prev = self.keys.insert(key.clone(), value.clone());
+                    Ok((prev, Some(value.clone())).into())
+                }
+            }
+
+            Cmd::SetFile { ref key, ref value } => {
+                let prev = self.keys.insert(key.clone(), value.clone());
+                Ok((prev, Some(value.clone())).into())
+            }
+
+            Cmd::AddNode {
+                ref node_id,
+                ref node
+            } => {
+                if self.nodes.contains_key(node_id) {
+                    let prev = self.nodes.get(node_id);
+                    Ok((prev.cloned(), None).into())
+                } else {
+                    let prev = self.nodes.insert(*node_id, node.clone());
+                    Ok((prev, Some(node.clone())).into())
+                }
+            }
+        }
+    }
+
+    pub fn get_file(&self, key: &str) -> Option<String> {
+        let x = self.keys.get(key);
+        x.cloned()
+    }
+
+    pub fn get_node(&self, node_id: &NodeId) -> Option<Node> {
+        let x = self.nodes.get(node_id);
+        x.cloned()
+    }
+}
+
 /// A slot is a virtual and intermediate allocation unit in a distributed storage.
 /// The key of an object is mapped to a slot by some hashing algo.
 /// A slot is assigned to several physical servers(normally 3 for durability).
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Slot {
-    node_ids: Vec<i64>
+    pub node_ids: Vec<NodeId>
 }
 
-pub type NodeId = i64;
-
-#[derive(Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Node {
     pub name: String,
     pub address: String
 }
 
-#[async_trait]
-impl IMeta for Meta {
-    async fn add(&mut self, key: String, value: String) -> anyhow::Result<()> {
-        self.keys.insert(key, value);
-        Ok(())
+impl Display for Node {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}={}", self.name, self.address)
     }
 }
 
-impl Meta {
-    pub fn empty() -> Self {
-        Self {
-            ..Default::default()
-        }
+impl IPlacement for Meta {
+    fn get_slots(&self) -> &[Slot] {
+        &self.slots
     }
 
-    /// Returns the slot index to store a file.
-    pub fn slot_index_for_key(&self, key: &str) -> u64 {
-        // TODO use consistent hash if need to extend cluster.
-        let mut hasher = DefaultHasher::new();
-        key.hash(&mut hasher);
-        let hsh = hasher.finish();
-        hsh % self.slots.len() as u64
-    }
-
-    /// Returns the Node-s that keeps a copy of a file.
-    pub fn nodes_to_store_key(&self, key: &str) -> Vec<Node> {
-        let slot_idx = self.slot_index_for_key(key);
-        let slot = &self.slots[slot_idx as usize];
-
-        slot.node_ids
-            .iter()
-            .map(|nid| (*self.nodes.get(nid).unwrap()).clone())
-            .collect()
+    fn get_node(&self, node_id: &u64) -> Option<&Node> {
+        self.nodes.get(node_id)
     }
 }

--- a/fusestore/store/src/meta_service/meta_service_impl.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl.rs
@@ -37,7 +37,7 @@ impl MetaService for MetaServiceImpl {
         // TODO: handle ForwardToLeader error
         let resp = self
             .meta_node
-            .local_set(req)
+            .write_to_local_leader(req)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
@@ -51,14 +51,14 @@ impl MetaService for MetaServiceImpl {
         request: tonic::Request<GetReq>
     ) -> Result<tonic::Response<GetReply>, tonic::Status> {
         let req = request.into_inner();
-        let resp = self.meta_node.local_get(req.key.clone()).await;
+        let resp = self.meta_node.get_file(&req.key).await;
         let rst = match resp {
-            Ok(v) => GetReply {
+            Some(v) => GetReply {
                 ok: true,
                 key: req.key,
                 value: v
             },
-            Err(_) => GetReply {
+            None => GetReply {
                 ok: false,
                 key: req.key,
                 value: "".into()

--- a/fusestore/store/src/meta_service/meta_service_impl_test.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl_test.rs
@@ -35,14 +35,21 @@ async fn test_meta_server_set_get() -> anyhow::Result<()> {
         // add: ok
         let req = ClientRequest {
             txid: None,
-            cmd: Cmd::Add {
+            cmd: Cmd::AddFile {
                 key: "foo".to_string(),
                 value: "bar".to_string()
             }
         };
         let rst = client.write(req).await?.into_inner();
         let resp: ClientResponse = rst.into();
-        assert_eq!("bar".to_string(), resp.result.unwrap());
+        match resp {
+            ClientResponse::String { prev: _, result } => {
+                assert_eq!("bar".to_string(), result.unwrap());
+            }
+            _ => {
+                panic!("not string")
+            }
+        }
 
         // get the stored value
 
@@ -55,27 +62,41 @@ async fn test_meta_server_set_get() -> anyhow::Result<()> {
         // add: conflict with existent.
         let req = ClientRequest {
             txid: None,
-            cmd: Cmd::Add {
+            cmd: Cmd::AddFile {
                 key: "foo".to_string(),
                 value: "bar".to_string()
             }
         };
         let rst = client.write(req).await?.into_inner();
         let resp: ClientResponse = rst.into();
-        assert!(resp.result.is_none());
+        match resp {
+            ClientResponse::String { prev: _, result } => {
+                assert!(result.is_none());
+            }
+            _ => {
+                panic!("not string")
+            }
+        }
     }
     {
         // set: overrde. ok.
         let req = ClientRequest {
             txid: None,
-            cmd: Cmd::Set {
+            cmd: Cmd::SetFile {
                 key: "foo".to_string(),
                 value: "bar2".to_string()
             }
         };
         let rst = client.write(req).await?.into_inner();
         let resp: ClientResponse = rst.into();
-        assert_eq!(Some("bar2".to_string()), resp.result);
+        match resp {
+            ClientResponse::String { prev: _, result } => {
+                assert_eq!(Some("bar2".to_string()), result);
+            }
+            _ => {
+                panic!("not string")
+            }
+        }
 
         // get the stored value
 

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -4,14 +4,15 @@
 
 mod meta;
 mod meta_service_impl;
+mod placement;
 mod raftmeta;
 
-pub use meta::IMeta;
+pub use async_raft::NodeId;
 pub use meta::Meta;
 pub use meta::Node;
-pub use meta::NodeId;
 pub use meta::Slot;
 pub use meta_service_impl::MetaServiceImpl;
+pub use placement::IPlacement;
 pub use raftmeta::ClientRequest;
 pub use raftmeta::ClientResponse;
 pub use raftmeta::Cmd;

--- a/fusestore/store/src/meta_service/placement.rs
+++ b/fusestore/store/src/meta_service/placement.rs
@@ -1,0 +1,53 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
+
+use crate::meta_service::Node;
+use crate::meta_service::NodeId;
+use crate::meta_service::Slot;
+/// IPlacement defines the behavior of an algo to assign file to nodes.
+/// An placement algo considers the replication config, such as number of copies,
+/// and workload balancing etc.
+///
+/// A placement algo is a two-level mapping:
+/// The first is about how to assign files(identified by keys) to a virtual bucket(AKA slot),
+/// and the second is about how to assign a slot to nodes.
+///
+/// Data migration should be impl on only the second level, in which way only a small piece of metadata
+/// will be modified when repairing a damaged server or when extending the cluster.
+///
+/// A default consistent-hash like impl is provided for most cases.
+/// With this algo user only need to impl two methods: get_slots() and get_node().
+pub trait IPlacement {
+    /// Returns the Node-s that are responsible to store a copy of a file.
+    fn nodes_to_store_key(&self, key: &str) -> Vec<Node> {
+        let slot_idx = self.slot_index_for_key(key);
+        let slot = self.get_slot(slot_idx);
+
+        slot.node_ids
+            .iter()
+            .map(|nid| (*self.get_node(nid).unwrap()).clone())
+            .collect()
+    }
+
+    /// Returns the slot index to store a file.
+    fn slot_index_for_key(&self, key: &str) -> u64 {
+        // TODO use consistent hash if need to extend cluster.
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        let hsh = hasher.finish();
+        hsh % self.get_slots().len() as u64
+    }
+
+    fn get_slot(&self, slot_idx: u64) -> &Slot {
+        &self.get_slots()[slot_idx as usize]
+    }
+
+    fn get_slots(&self) -> &[Slot];
+
+    fn get_node(&self, node_id: &NodeId) -> Option<&Node>;
+}

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -42,7 +42,9 @@ use tokio::sync::RwLockReadGuard;
 use tokio::sync::RwLockWriteGuard;
 use tonic::transport::channel::Channel;
 
+use crate::meta_service::Meta;
 use crate::meta_service::MetaServiceClient;
+use crate::meta_service::Node;
 use crate::meta_service::RaftMes;
 
 const ERR_INCONSISTENT_LOG: &str =
@@ -53,32 +55,37 @@ const ERR_INCONSISTENT_LOG: &str =
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Cmd {
     // AKA put-if-absent. add a key-value record only when key is absent.
-    Add { key: String, value: String },
+    AddFile { key: String, value: String },
     // Override the record with key.
-    Set { key: String, value: String }
+    SetFile { key: String, value: String },
+    // Add node if absent
+    AddNode { node_id: NodeId, node: Node }
 }
 
 impl fmt::Display for Cmd {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Cmd::Add { key, value } => {
-                write!(f, "add:{}={}", key, value)
+            Cmd::AddFile { key, value } => {
+                write!(f, "addfile:{}={}", key, value)
             }
-            Cmd::Set { key, value } => {
-                write!(f, "set:{}={}", key, value)
+            Cmd::SetFile { key, value } => {
+                write!(f, "setfile:{}={}", key, value)
+            }
+            Cmd::AddNode { node_id, node } => {
+                write!(f, "addnode:{}={}", node_id, node)
             }
         }
     }
 }
 
-/// RaftTxId is the enssential info to identify an write operation to raft.
+/// RaftTxId is the essential info to identify an write operation to raft.
 /// Logs with the same RaftTxId are considered the same and only the first of them will be applied.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RaftTxId {
     /// The ID of the client which has sent the request.
     pub client: String,
     /// The serial number of this request.
-    /// TODO(xp): a client msut generate consistent `client` and globally unique serial.
+    /// TODO(xp): a client must generate consistent `client` and globally unique serial.
     /// TODO(xp): in this impl the state machine records only one serial, which implies serial must be monotonic incremental for every client.
     pub serial: u64
 }
@@ -116,6 +123,30 @@ impl tonic::IntoRequest<RaftMes> for ClientRequest {
         tonic::Request::new(mes)
     }
 }
+impl tonic::IntoRequest<RaftMes> for AppendEntriesRequest<ClientRequest> {
+    fn into_request(self) -> tonic::Request<RaftMes> {
+        let mes = RaftMes {
+            data: serde_json::to_vec(&self).expect("fail to serialize")
+        };
+        tonic::Request::new(mes)
+    }
+}
+impl tonic::IntoRequest<RaftMes> for InstallSnapshotRequest {
+    fn into_request(self) -> tonic::Request<RaftMes> {
+        let mes = RaftMes {
+            data: serde_json::to_vec(&self).expect("fail to serialize")
+        };
+        tonic::Request::new(mes)
+    }
+}
+impl tonic::IntoRequest<RaftMes> for VoteRequest {
+    fn into_request(self) -> tonic::Request<RaftMes> {
+        let mes = RaftMes {
+            data: serde_json::to_vec(&self).expect("fail to serialize")
+        };
+        tonic::Request::new(mes)
+    }
+}
 
 impl TryFrom<RaftMes> for ClientRequest {
     type Error = tonic::Status;
@@ -129,11 +160,17 @@ impl TryFrom<RaftMes> for ClientRequest {
 
 /// The application data response type which the `MemStore` works with.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct ClientResponse {
-    // The value before applying a ClientRequest.
-    pub prev: Option<String>,
-    // The value after applying a ClientRequest.
-    pub result: Option<String>
+pub enum ClientResponse {
+    String {
+        // The value before applying a ClientRequest.
+        prev: Option<String>,
+        // The value after applying a ClientRequest.
+        result: Option<String>
+    },
+    Node {
+        prev: Option<Node>,
+        result: Option<Node>
+    }
 }
 
 impl AppDataResponse for ClientResponse {}
@@ -148,6 +185,22 @@ impl From<RaftMes> for ClientResponse {
     fn from(msg: RaftMes) -> Self {
         let resp: ClientResponse = serde_json::from_slice(&msg.data).expect("fail to deserialize");
         resp
+    }
+}
+impl From<(Option<String>, Option<String>)> for ClientResponse {
+    fn from(v: (Option<String>, Option<String>)) -> Self {
+        ClientResponse::String {
+            prev: v.0,
+            result: v.1
+        }
+    }
+}
+impl From<(Option<Node>, Option<Node>)> for ClientResponse {
+    fn from(v: (Option<Node>, Option<Node>)) -> Self {
+        ClientResponse::Node {
+            prev: v.0,
+            result: v.1
+        }
     }
 }
 
@@ -178,17 +231,12 @@ pub struct MemStoreStateMachine {
     /// A mapping of client IDs to their state info:
     /// (serial, ClientResponse)
     pub client_serial_responses: HashMap<String, (u64, ClientResponse)>,
-    pub kvs: HashMap<String, String>
+
+    pub meta: Meta
 }
 
 impl MemStoreStateMachine {
     /// Apply an log entry to state machine.
-    ///
-    /// For an `Add` command, if the specified key presents, the returned ClientResponse set result
-    /// to None and prev to the previous value.
-    ///
-    /// For an `Set` command, it always succeeds. and returns the previous value and the value
-    /// client specified.
     ///
     /// If a duplicated log entry is detected by checking data.txid, no update
     /// will be made and the previous resp is returned. In this way a client is able to re-send a
@@ -204,24 +252,7 @@ impl MemStoreStateMachine {
             }
         }
 
-        let (prev, rst): (Option<String>, Option<String>) = match data.cmd {
-            Cmd::Add { ref key, ref value } => {
-                if self.kvs.contains_key(key) {
-                    let prev = self.kvs.get(key);
-                    (prev.cloned(), None)
-                } else {
-                    let prev = self.kvs.insert(key.clone(), value.clone());
-                    (prev, Some(value.clone()))
-                }
-            }
-
-            Cmd::Set { ref key, ref value } => {
-                let prev = self.kvs.insert(key.clone(), value.clone());
-                (prev, Some(value.clone()))
-            }
-        };
-
-        let resp = ClientResponse { prev, result: rst };
+        let resp = self.meta.apply(data)?;
 
         if let Some(ref txid) = data.txid {
             self.client_serial_responses
@@ -232,9 +263,6 @@ impl MemStoreStateMachine {
 }
 
 /// An in-memory storage system implementing the `async_raft::RaftStorage` trait.
-///
-/// TODO: support at least 3 data set: nodes in cluster, block distribution and dfs-file metas.
-///       See: meta::Meta
 pub struct MemStore {
     /// The ID of the Raft node for which this memory storage instances is configured.
     id: NodeId,
@@ -574,12 +602,27 @@ pub struct Network {
 }
 
 impl Network {
-    pub fn new(m: Arc<MemStore>) -> Network {
-        Network { sto: m }
+    pub fn new(sto: Arc<MemStore>) -> Network {
+        Network { sto }
     }
-    pub async fn make_client(&self, addr: String) -> anyhow::Result<MetaServiceClient<Channel>> {
+
+    pub async fn make_client(
+        &self,
+        node_id: &NodeId
+    ) -> anyhow::Result<MetaServiceClient<Channel>> {
+        let addr = self.get_node_addr(node_id).await?;
         let client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
         Ok(client)
+    }
+
+    pub async fn get_node_addr(&self, node_id: &NodeId) -> anyhow::Result<String> {
+        let addr = self
+            .sto
+            .get_node(node_id)
+            .await
+            .map(|n| n.address)
+            .ok_or_else(|| anyhow::anyhow!("node not found {}", node_id))?;
+        Ok(addr)
     }
 }
 
@@ -591,13 +634,8 @@ impl RaftNetwork<ClientRequest> for Network {
         target: NodeId,
         rpc: AppendEntriesRequest<ClientRequest>
     ) -> Result<AppendEntriesResponse> {
-        let addr = self.sto.get_node_addr(target).await?;
-        let data = serde_json::to_vec(&rpc)?;
-
-        let req = tonic::Request::new(RaftMes { data });
-
-        let mut client = self.make_client(addr).await?;
-        let resp = client.append_entries(req).await?;
+        let mut client = self.make_client(&target).await?;
+        let resp = client.append_entries(rpc).await?;
         let mes = resp.into_inner();
         let resp = serde_json::from_slice(&mes.data)?;
 
@@ -610,13 +648,8 @@ impl RaftNetwork<ClientRequest> for Network {
         target: NodeId,
         rpc: InstallSnapshotRequest
     ) -> Result<InstallSnapshotResponse> {
-        let addr = self.sto.get_node_addr(target).await?;
-        let data = serde_json::to_vec(&rpc)?;
-
-        let req = tonic::Request::new(RaftMes { data });
-
-        let mut client = self.make_client(addr).await?;
-        let resp = client.install_snapshot(req).await?;
+        let mut client = self.make_client(&target).await?;
+        let resp = client.install_snapshot(rpc).await?;
         let mes = resp.into_inner();
         let resp = serde_json::from_slice(&mes.data)?;
 
@@ -625,13 +658,8 @@ impl RaftNetwork<ClientRequest> for Network {
 
     #[tracing::instrument(level = "info", skip(self))]
     async fn vote(&self, target: NodeId, rpc: VoteRequest) -> Result<VoteResponse> {
-        let addr = self.sto.get_node_addr(target).await?;
-        let data = serde_json::to_vec(&rpc)?;
-
-        let req = tonic::Request::new(RaftMes { data });
-
-        let mut client = self.make_client(addr).await?;
-        let resp = client.vote(req).await?;
+        let mut client = self.make_client(&target).await?;
+        let resp = client.vote(rpc).await?;
         let mes = resp.into_inner();
         let resp = serde_json::from_slice(&mes.data)?;
 
@@ -651,37 +679,24 @@ pub struct MetaNode {
 }
 
 impl MemStore {
-    // build a meta data key of node in the cluster.
-    pub fn node_key(&self, node_id: NodeId) -> String {
-        format!("node/{:}", node_id)
-    }
+    pub async fn get_node(&self, node_id: &NodeId) -> Option<Node> {
+        let sm = self.sm.read().await;
 
-    pub async fn get_node_addr(&self, node_id: NodeId) -> anyhow::Result<String> {
-        let key = self.node_key(node_id);
-        let ns = self.sm.read().await;
-
-        let addr = ns
-            .kvs
-            .get(&key)
-            .ok_or_else(|| anyhow::anyhow!("node not found: {:}", key))?;
-        Ok(addr.clone())
+        sm.meta.get_node(node_id)
     }
 
     pub async fn list_added_non_voters(&self) -> HashSet<NodeId> {
-        // TODO: impl a hierarchical structure in storage.
-
         let mut rst = HashSet::new();
         let sm = self.sm.read().await;
         let ms = self
             .get_membership_config()
             .await
             .expect("fail to get membership");
-        // TODO: there is no iteration in store. Using a for loop to iterate nodes for now.
-        for i in 0..100 {
-            let key = self.node_key(i);
+
+        for i in sm.meta.nodes.keys() {
             // it has been added into this cluster and is not a voter.
-            if sm.kvs.contains_key(&key) && !ms.contains(&i) {
-                rst.insert(i);
+            if !ms.contains(i) {
+                rst.insert(*i);
             }
         }
         rst
@@ -746,12 +761,17 @@ impl MetaNode {
 
         tracing::info!("booted, rst: {:?}", rst);
 
-        let key = self.sto.node_key(self.sto.id);
         // TODO: use txid?
         let _resp = self
-            .local_set(ClientRequest {
+            .write_to_local_leader(ClientRequest {
                 txid: None,
-                cmd: Cmd::Add { key, value: addr }
+                cmd: Cmd::AddNode {
+                    node_id: self.sto.id,
+                    node: Node {
+                        name: "".to_string(),
+                        address: addr
+                    }
+                }
             })
             .await
             .expect("fail to add myself");
@@ -774,23 +794,30 @@ impl MetaNode {
         Ok(())
     }
 
-    // get meta data from local state, most business logic without strong consistency requirement should use this to access meta.
+    // get a file from local meta state, most business logic without strong consistency requirement should use this to access meta.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn local_get(&self, key: String) -> anyhow::Result<String> {
+    pub async fn get_file(&self, key: &str) -> Option<String> {
         // inconsistent get: from local state machine
 
         let sm = self.sto.sm.read().await;
-        let v = sm
-            .kvs
-            .get(&key)
-            .ok_or_else(|| anyhow::anyhow!("meta data key not found: {:}", key))?;
-        Ok(v.clone())
+        sm.meta.get_file(key)
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn get_node(&self, node_id: &NodeId) -> Option<Node> {
+        // inconsistent get: from local state machine
+
+        let sm = self.sto.sm.read().await;
+        sm.meta.get_node(node_id)
     }
 
     /// Write a meta record through local raft node.
     /// It works only when this node is the leader.
     #[tracing::instrument(level = "info", skip(self))]
-    pub async fn local_set(&self, req: ClientRequest) -> anyhow::Result<ClientResponse> {
+    pub async fn write_to_local_leader(
+        &self,
+        req: ClientRequest
+    ) -> anyhow::Result<ClientResponse> {
         // TODO: respond ForwardToLeader error
         let write_rst = self.raft.client_write(ClientWriteRequest::new(req)).await;
 

--- a/fusestore/store/src/meta_service/raftmeta_test.rs
+++ b/fusestore/store/src/meta_service/raftmeta_test.rs
@@ -16,6 +16,7 @@ use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
 use crate::meta_service::MetaServiceImpl;
 use crate::meta_service::MetaServiceServer;
+use crate::meta_service::Node;
 use crate::meta_service::RaftTxId;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -68,13 +69,13 @@ async fn test_state_machine_apply_add() -> anyhow::Result<()> {
     for (name, txid, k, v, want_prev, want_result) in cases.iter() {
         let resp = sm.apply(5, &ClientRequest {
             txid: txid.clone(),
-            cmd: Cmd::Add {
+            cmd: Cmd::AddFile {
                 key: k.to_string(),
                 value: v.to_string()
             }
         });
         assert_eq!(
-            ClientResponse {
+            ClientResponse::String {
                 prev: want_prev.clone(),
                 result: want_result.clone()
             },
@@ -144,13 +145,13 @@ async fn test_state_machine_apply_set() -> anyhow::Result<()> {
     for (name, txid, k, v, want_prev, want_result) in cases.iter() {
         let resp = sm.apply(5, &ClientRequest {
             txid: txid.clone(),
-            cmd: Cmd::Set {
+            cmd: Cmd::SetFile {
                 key: k.to_string(),
                 value: v.to_string()
             }
         });
         assert_eq!(
-            ClientResponse {
+            ClientResponse::String {
                 prev: want_prev.clone(),
                 result: want_result.clone()
             },
@@ -176,8 +177,8 @@ async fn test_meta_node_boot() -> anyhow::Result<()> {
     let resp = mn.boot(addr.clone()).await;
     assert!(resp.is_ok());
 
-    let got = mn.local_get(mn.sto.node_key(0)).await;
-    assert_eq!(addr, got.unwrap());
+    let got = mn.get_node(&0).await;
+    assert_eq!(addr, got.unwrap().address);
     Ok(())
 }
 
@@ -223,8 +224,8 @@ async fn test_meta_node_add_non_voter() -> anyhow::Result<()> {
         let resp = mn0.boot(addr0.clone()).await;
         assert!(resp.is_ok());
 
-        let got = mn0.local_get(mn0.sto.node_key(nid0)).await;
-        assert_eq!(addr0, got.unwrap(), "nid1 is added");
+        let got = mn0.get_node(&nid0).await;
+        assert_eq!(addr0, got.unwrap().address, "nid1 is added");
 
         wait_for("nid0 to be leader", &mut mrx0, |x| x.state == State::Leader).await;
         wait_for("nid0 current_leader==0", &mut mrx0, |x| {
@@ -235,17 +236,26 @@ async fn test_meta_node_add_non_voter() -> anyhow::Result<()> {
 
     {
         // add node-1 to cluster as non-voter
-        let key = mn0.sto.node_key(nid1);
         let resp = mn0
-            .local_set(ClientRequest {
+            .write_to_local_leader(ClientRequest {
                 txid: None,
-                cmd: Cmd::Set {
-                    key: key,
-                    value: addr1.clone()
+                cmd: Cmd::AddNode {
+                    node_id: nid1,
+                    node: Node {
+                        name: "".to_string(),
+                        address: addr1.clone()
+                    }
                 }
             })
             .await;
-        assert_eq!(addr1, resp.unwrap().result.unwrap());
+        match resp.unwrap() {
+            ClientResponse::Node { prev: _, result } => {
+                assert_eq!(addr1, result.unwrap().address);
+            }
+            _ => {
+                panic!("expect node")
+            }
+        }
     }
 
     wait_for("nid1 current_leader==0", &mut mrx1, |x| {


### PR DESCRIPTION
## Summary

- Add struct Meta containing all dfs meta data, such as file keys and
  nodes in cluster.

- Provides 3 commands to write metadata: AddFile, SetFile and AddNode.

- Seperate keys and nodes read API: Meta::get_file() and Meta:get_node().
  Writing to meta is still done with a single API, in the raft manner:
  applying an raft log entry to the meta.





## Changelog


- Improvement

