### PR TITLE
Remove the unused max threads for tokio runtime in on_query

### DIFF
--- a/common/planners/src/plan_rewriter.rs
+++ b/common/planners/src/plan_rewriter.rs
@@ -344,7 +344,7 @@ impl PlanRewriter {
 
     pub fn exprs_to_names(exprs: &[ExpressionAction], names: &mut HashSet<String>) -> Result<()> {
         for expr in exprs {
-            let name = String::from(format!("{:?}", expr).as_str());
+            let name = format!("{:?}", expr);
             names.insert(name.clone());
         }
         Ok(())

--- a/common/runtime/src/runtime.rs
+++ b/common/runtime/src/runtime.rs
@@ -13,13 +13,12 @@ use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 /// Tokio Runtime wrapper.
-/// If a runtime is in an asynchronous context, we will the shutdown it first.
-#[allow(dead_code)]
+/// If a runtime is in an asynchronous context, shutdown it first.
 pub struct Runtime {
-    // Use to receive a drop signal when dropper is dropped.
-    dropper: Dropper,
     // Handle to runtime.
-    handle: Handle
+    handle: Handle,
+    // Use to receive a drop signal when dropper is dropped.
+    _dropper: Dropper
 }
 
 impl Runtime {
@@ -48,7 +47,7 @@ impl Runtime {
 
         Ok(Runtime {
             handle,
-            dropper: Dropper {
+            _dropper: Dropper {
                 close: Some(send_stop)
             }
         })
@@ -59,13 +58,13 @@ impl Runtime {
     /// its executor.
     pub fn with_default_worker_threads() -> Result<Self> {
         let mut runtime = tokio::runtime::Builder::new_multi_thread();
-        let builder = runtime.enable_io().enable_time();
+        let builder = runtime.enable_all();
         Self::create(builder)
     }
 
     pub fn with_worker_threads(workers: usize) -> Result<Self> {
         let mut runtime = tokio::runtime::Builder::new_multi_thread();
-        let builder = runtime.worker_threads(workers).enable_io().enable_time();
+        let builder = runtime.enable_all().worker_threads(workers);
         Self::create(builder)
     }
 

--- a/fusequery/query/src/servers/mysql/mysql_handler.rs
+++ b/fusequery/query/src/servers/mysql/mysql_handler.rs
@@ -67,10 +67,9 @@ impl<W: io::Write> MysqlShim<W> for Session {
         self.ctx.reset().unwrap();
         let start = Instant::now();
 
-        fn build_runtime(_max_threads: u64) -> Result<Runtime> {
+        fn build_runtime() -> Result<Runtime> {
             tokio::runtime::Builder::new_multi_thread()
-                .enable_io()
-                .enable_time()
+                .enable_all()
                 .build()
                 .map_err(|tokio_error| ErrorCodes::TokioError(format!("{}", tokio_error)))
         }
@@ -89,9 +88,8 @@ impl<W: io::Write> MysqlShim<W> for Session {
         let output = PlanParser::create(self.ctx.clone())
             .build_from_sql(query)
             .and_then(|built_plan| InterpreterFactory::get(self.ctx.clone(), built_plan))
+            .zip(build_runtime())
             // Execute query and get result
-            .zip(self.ctx.get_max_threads())
-            .left_and_then(build_runtime)
             .and_then_tuple(receive_data_set)
             // Push result set to client
             .and_match(done(writer));


### PR DESCRIPTION
## Summary
Remove the unused max threads for tokio runtime in on_query

## Changelog

- Improvement


## Related Issues


## Test Plan

Unit Tests
Stateless Tests
