### PR TITLE
[store] meta: support remote write; refactor boot()

### DIFF
--- a/fusestore/store/src/dfs/distributed_fs.rs
+++ b/fusestore/store/src/dfs/distributed_fs.rs
@@ -2,15 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
-use tonic::transport::channel::Channel;
 
 use crate::fs::IFileSystem;
 use crate::fs::ListResult;
 use crate::localfs::LocalFS;
 use crate::meta_service::ClientRequest;
 use crate::meta_service::Cmd;
-use crate::meta_service::MetaServiceClient;
+use crate::meta_service::MetaNode;
 
 /// DFS is a distributed file system impl.
 /// When a file is added, it stores it locally, commit the this action into distributed meta data(something like a raft group).
@@ -22,25 +23,19 @@ pub struct Dfs {
     /// The local fs to store data copies.
     /// The distributed fs is a cluster of local-fs organized with a meta data service.
     pub local_fs: LocalFS,
-    pub meta_service_addr: String
+    pub meta_node: Arc<MetaNode>
 }
 
 impl Dfs {
-    pub fn create(local_fs: LocalFS, meta_service_addr: String) -> Dfs {
+    pub fn create(local_fs: LocalFS, meta_node: Arc<MetaNode>) -> Dfs {
         Dfs {
             local_fs,
-            meta_service_addr
+            meta_node
         }
     }
 }
 
-impl Dfs {
-    pub async fn make_client(&self) -> anyhow::Result<MetaServiceClient<Channel>> {
-        let client =
-            MetaServiceClient::connect(format!("http://{}", self.meta_service_addr)).await?;
-        Ok(client)
-    }
-}
+impl Dfs {}
 
 #[async_trait]
 impl IFileSystem for Dfs {
@@ -51,7 +46,6 @@ impl IFileSystem for Dfs {
 
         // update meta, other store nodes will be informed about this change and then pull the data to complete replication.
 
-        let mut client = self.make_client().await?;
         let req = ClientRequest {
             txid: None,
             cmd: Cmd::AddFile {
@@ -59,7 +53,7 @@ impl IFileSystem for Dfs {
                 value: "".into()
             }
         };
-        client.write(req).await?;
+        let _resp = self.meta_node.write(req).await?;
         Ok(())
     }
 

--- a/fusestore/store/src/meta_service/meta_service_impl.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl.rs
@@ -17,7 +17,7 @@ pub struct MetaServiceImpl {
 }
 
 impl MetaServiceImpl {
-    pub async fn create(meta_node: Arc<MetaNode>) -> Self {
+    pub fn create(meta_node: Arc<MetaNode>) -> Self {
         Self { meta_node }
     }
 }

--- a/fusestore/store/src/meta_service/meta_service_impl_test.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl_test.rs
@@ -20,11 +20,11 @@ use crate::tests::rand_local_addr;
 async fn test_meta_server_set_get() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
-    let mn = MetaNode::new(0).await;
-    let rst = mn.boot(addr.clone()).await;
+    let rst = MetaNode::boot(0, addr.clone()).await;
     assert!(rst.is_ok());
+    let mn = rst.unwrap();
 
-    let meta_srv_impl = MetaServiceImpl::create(mn).await;
+    let meta_srv_impl = MetaServiceImpl::create(mn);
     let meta_srv = MetaServiceServer::new(meta_srv_impl);
 
     serve_grpc!(addr, meta_srv);


### PR DESCRIPTION
- Dfs: operates meta through MetaNode, instead of through RPC.

- MetaNode: separate initialization functions:
    - MetaNode::boot() to setup a new cluster with one node.
    - MetaNode::boot_non_voter() to initialize a node that is going to
      be added to an existent cluster.
    - MetaNode::new() to start a initialized node that belongs to a
      cluster.

- MetaNode: new() now gets everything ready. There is no need to start
  meta-grpc manually.

- MetaNode: add several util func to operating on cluster info, such as
  get_node_addr() and add_node().

- MetaNode: remove cached metrics data. Use raft metrics channel
  instead, which provides blocking watch and data cache.

- MetaNode: add builder() to create a customizable constructor.

- MetaNode: support forwarded write to the remote leader. A non-leader node
  use MetaNode::write() to commit a meta changes.

- MetaNode: get_leader() to retrieve the latest leader the node knows
  of.



## Changelog

- New Feature
- Improvement


## Related Issues

#271 

