### PR TITLE
[store] support restarting a MetaNode.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,8 +129,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9e14ce344bff51ccc1d430c2c93f84ca3320b3f86f69550871f6ae6957697a"
+source = "git+https://github.com/drmingdrmer/async-raft?branch=fix-non-voter-restart#786f091dd691c3189c477a5e0050eef60ef0f9b3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -26,7 +26,9 @@ common-planners = {path = "../../common/planners"}
 
 # Crates.io dependencies
 anyhow = "1.0.40"
-async-raft = "0.6.0"
+#a bug fix on this repo: https://github.com/async-raft/async-raft/pull/114
+async-raft = { git = "https://github.com/drmingdrmer/async-raft", branch = "fix-non-voter-restart" }
+#async-raft = "0.6.0"
 async-trait = "0.1"
 env_logger = "0.8"
 futures = "0.3"

--- a/fusestore/store/proto/store_meta.proto
+++ b/fusestore/store/proto/store_meta.proto
@@ -7,6 +7,7 @@ syntax = "proto3";
 // meta data types for FuseStore
 package store_meta;
 
+// TODO(zbr): keep it or remove
 message Db {
   int64 db_id = 1;
   // Every modification has a corresponding unique ver.
@@ -15,6 +16,7 @@ message Db {
   map<int64, Table> tables = 3;
 }
 
+// TODO(zbr): keep it or remove
 message Table {
   int64 table_id = 1;
   // Every modification has a corresponding unique ver.
@@ -33,11 +35,13 @@ message Table {
 // A Cmd serves as a raft log entry to commit an atomic operation into meta data
 // storage.
 
+// TODO(zbr): keep it or remove
 message CmdCreateDatabase {
   string db_name = 20;
   Db db = 50;
 }
 
+// TODO(zbr): keep it or remove
 message CmdCreateTable {
   string db_name = 20;
   string table_name = 30;
@@ -53,7 +57,7 @@ message GetReply {
   string value = 3;
 }
 
-message RaftMes { bytes data = 1; }
+message RaftMes { string data = 1; }
 
 service MetaService {
 

--- a/fusestore/store/src/dfs/distributed_fs.rs
+++ b/fusestore/store/src/dfs/distributed_fs.rs
@@ -39,7 +39,7 @@ impl Dfs {}
 
 #[async_trait]
 impl IFileSystem for Dfs {
-    async fn add<'a>(&'a self, path: String, data: &[u8]) -> anyhow::Result<()> {
+    async fn add(&self, path: String, data: &[u8]) -> anyhow::Result<()> {
         // add the file to local fs
 
         self.local_fs.add(path.clone(), data).await?;
@@ -57,12 +57,12 @@ impl IFileSystem for Dfs {
         Ok(())
     }
 
-    async fn read_all<'a>(&'a self, path: String) -> anyhow::Result<Vec<u8>> {
+    async fn read_all(&self, path: String) -> anyhow::Result<Vec<u8>> {
         // TODO read local cached meta first
         self.local_fs.read_all(path).await
     }
 
-    async fn list<'a>(&'a self, path: String) -> anyhow::Result<ListResult> {
+    async fn list(&self, path: String) -> anyhow::Result<ListResult> {
         let _key = path;
 
         // TODO read local meta cache to list

--- a/fusestore/store/src/meta_service/meta.rs
+++ b/fusestore/store/src/meta_service/meta.rs
@@ -33,6 +33,7 @@ pub struct Meta {
 
 impl Meta {
     // Apply an op from client.
+    #[tracing::instrument(level = "info", skip(self))]
     pub fn apply(&mut self, data: &ClientRequest) -> anyhow::Result<ClientResponse> {
         match data.cmd {
             Cmd::AddFile { ref key, ref value } => {
@@ -41,12 +42,14 @@ impl Meta {
                     Ok((prev.cloned(), None).into())
                 } else {
                     let prev = self.keys.insert(key.clone(), value.clone());
+                    tracing::info!("applied AddFile: {}={}", key, value);
                     Ok((prev, Some(value.clone())).into())
                 }
             }
 
             Cmd::SetFile { ref key, ref value } => {
                 let prev = self.keys.insert(key.clone(), value.clone());
+                tracing::info!("applied SetFile: {}={}", key, value);
                 Ok((prev, Some(value.clone())).into())
             }
 
@@ -59,14 +62,18 @@ impl Meta {
                     Ok((prev.cloned(), None).into())
                 } else {
                     let prev = self.nodes.insert(*node_id, node.clone());
+                    tracing::info!("applied AddNode: {}={:?}", node_id, node);
                     Ok((prev, Some(node.clone())).into())
                 }
             }
         }
     }
 
+    #[tracing::instrument(level = "info", skip(self))]
     pub fn get_file(&self, key: &str) -> Option<String> {
+        tracing::info!("meta::get_file: {}", key);
         let x = self.keys.get(key);
+        tracing::info!("meta::get_file: {}={:?}", key, x);
         x.cloned()
     }
 

--- a/fusestore/store/src/meta_service/meta_service_impl.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl.rs
@@ -75,8 +75,8 @@ impl MetaService for MetaServiceImpl {
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
         let req = request.into_inner();
 
-        let ae_req = serde_json::from_slice(&req.data)
-            .map_err(|x| tonic::Status::internal(x.to_string()))?;
+        let ae_req =
+            serde_json::from_str(&req.data).map_err(|x| tonic::Status::internal(x.to_string()))?;
 
         let resp = self
             .meta_node
@@ -84,7 +84,7 @@ impl MetaService for MetaServiceImpl {
             .append_entries(ae_req)
             .await
             .map_err(|x| tonic::Status::internal(x.to_string()))?;
-        let data = serde_json::to_vec(&resp).expect("fail to serialize resp");
+        let data = serde_json::to_string(&resp).expect("fail to serialize resp");
         let mes = RaftMes { data };
 
         Ok(tonic::Response::new(mes))
@@ -97,8 +97,8 @@ impl MetaService for MetaServiceImpl {
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
         let req = request.into_inner();
 
-        let is_req = serde_json::from_slice(&req.data)
-            .map_err(|x| tonic::Status::internal(x.to_string()))?;
+        let is_req =
+            serde_json::from_str(&req.data).map_err(|x| tonic::Status::internal(x.to_string()))?;
 
         let resp = self
             .meta_node
@@ -106,7 +106,7 @@ impl MetaService for MetaServiceImpl {
             .install_snapshot(is_req)
             .await
             .map_err(|x| tonic::Status::internal(x.to_string()))?;
-        let data = serde_json::to_vec(&resp).expect("fail to serialize resp");
+        let data = serde_json::to_string(&resp).expect("fail to serialize resp");
         let mes = RaftMes { data };
 
         Ok(tonic::Response::new(mes))
@@ -119,8 +119,8 @@ impl MetaService for MetaServiceImpl {
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
         let req = request.into_inner();
 
-        let v_req = serde_json::from_slice(&req.data)
-            .map_err(|x| tonic::Status::internal(x.to_string()))?;
+        let v_req =
+            serde_json::from_str(&req.data).map_err(|x| tonic::Status::internal(x.to_string()))?;
 
         let resp = self
             .meta_node
@@ -128,7 +128,7 @@ impl MetaService for MetaServiceImpl {
             .vote(v_req)
             .await
             .map_err(|x| tonic::Status::internal(x.to_string()))?;
-        let data = serde_json::to_vec(&resp).expect("fail to serialize resp");
+        let data = serde_json::to_string(&resp).expect("fail to serialize resp");
         let mes = RaftMes { data };
 
         Ok(tonic::Response::new(mes))

--- a/website/datafuse/docs/rfcs/store/2021-04-22-store-design.md
+++ b/website/datafuse/docs/rfcs/store/2021-04-22-store-design.md
@@ -52,7 +52,7 @@ Schema related operations such as `create table` or `create database` are wrappe
 Data operation such as reading or writing a block are done with
 `FlightService::do_get` and `FlightService::do_put`.
 
-See [common/flights/src/store_client.rs](../../../common/flights/src/store_client.rs).
+See `common/flights/src/store_client.rs`.
 
 
 # DFS


### PR DESCRIPTION
## Summary

- Fix: update async-raft to an unmerged version to fix NonVoter restart bug:
   A restarted NonVoter node should not be initialized with the role Follower.
   See: https://github.com/async-raft/async-raft/pull/114

- Feature: add a channel(`applied_rx`) to raft store to watch applied index changes.

- Feature: add MetaNode::stop() to gracefully shut a node down.

- Refactor: Use string instead [u8] as raft message body, to make it easier to debug.

- Refactor: add more From/Into impl to simplify message transform.

- Refactor: add raft node id to tracing.

- Doc: describes cluster startup process.

- Test: add test of restarting a MetaNode, ensures state consistency, along with other lifecycle-related tests and consistency test.


## Changelog

- New Feature
- Bug Fix
- Improvement
- Build/Testing/CI
- Documentation

## Related Issues

#271


