### PR TITLE
Introduce plan visitor to refine optimizer

### DIFF
--- a/common/planners/src/lib.rs
+++ b/common/planners/src/lib.rs
@@ -64,6 +64,7 @@ mod plan_sort;
 mod plan_stage;
 mod plan_statistics;
 mod plan_use_database;
+mod plan_visitor;
 mod plan_walker;
 
 pub use crate::plan_aggregator_final::AggregatorFinalPlan;
@@ -105,3 +106,4 @@ pub use crate::plan_stage::StagePlan;
 pub use crate::plan_stage::StageState;
 pub use crate::plan_statistics::Statistics;
 pub use crate::plan_use_database::UseDatabasePlan;
+pub use crate::plan_visitor::PlanVisitor;

--- a/common/planners/src/plan_aggregator_final.rs
+++ b/common/planners/src/plan_aggregator_final.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::ExpressionAction;
 use crate::PlanNode;
@@ -27,8 +26,7 @@ impl AggregatorFinalPlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_aggregator_partial.rs
+++ b/common/planners/src/plan_aggregator_partial.rs
@@ -25,7 +25,7 @@ impl AggregatorPartialPlan {
         self.input.clone()
     }
 
-        pub fn set_input(&mut self, input: &PlanNode) {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
     }
 }

--- a/common/planners/src/plan_aggregator_partial.rs
+++ b/common/planners/src/plan_aggregator_partial.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::ExpressionAction;
 use crate::PlanNode;
@@ -26,8 +25,7 @@ impl AggregatorPartialPlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+        pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_display.rs
+++ b/common/planners/src/plan_display.rs
@@ -26,7 +26,7 @@ impl PlanNode {
                     Ok(())
                 };
 
-                self.0.walk_preorder(|node| {
+                self.0.walk_preorder(&mut |node| {
                     write_indent(f)?;
                     match node {
                         PlanNode::Stage(plan) => {

--- a/common/planners/src/plan_display.rs
+++ b/common/planners/src/plan_display.rs
@@ -26,7 +26,7 @@ impl PlanNode {
                     Ok(())
                 };
 
-                self.0.walk_preorder(&mut |node| {
+                self.0.walk_preorder(|node| {
                     write_indent(f)?;
                     match node {
                         PlanNode::Stage(plan) => {

--- a/common/planners/src/plan_explain.rs
+++ b/common/planners/src/plan_explain.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::PlanNode;
 
@@ -31,8 +30,7 @@ impl ExplainPlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+        pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_explain.rs
+++ b/common/planners/src/plan_explain.rs
@@ -30,7 +30,7 @@ impl ExplainPlan {
         self.input.clone()
     }
 
-        pub fn set_input(&mut self, input: &PlanNode) {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
     }
 }

--- a/common/planners/src/plan_expression.rs
+++ b/common/planners/src/plan_expression.rs
@@ -26,7 +26,7 @@ impl ExpressionPlan {
         self.input.clone()
     }
 
-        pub fn set_input(&mut self, input: &PlanNode) {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
     }
 }

--- a/common/planners/src/plan_expression.rs
+++ b/common/planners/src/plan_expression.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::ExpressionAction;
 use crate::PlanNode;
@@ -27,8 +26,7 @@ impl ExpressionPlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+        pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_filter.rs
+++ b/common/planners/src/plan_filter.rs
@@ -26,7 +26,7 @@ impl FilterPlan {
         self.input.clone()
     }
 
-        pub fn set_input(&mut self, input: &PlanNode) {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
     }
 }

--- a/common/planners/src/plan_filter.rs
+++ b/common/planners/src/plan_filter.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::ExpressionAction;
 use crate::PlanNode;
@@ -27,8 +26,7 @@ impl FilterPlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+        pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_having.rs
+++ b/common/planners/src/plan_having.rs
@@ -26,7 +26,7 @@ impl HavingPlan {
         self.input.clone()
     }
 
-        pub fn set_input(&mut self, input: &PlanNode) {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
     }
 }

--- a/common/planners/src/plan_having.rs
+++ b/common/planners/src/plan_having.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::ExpressionAction;
 use crate::PlanNode;
@@ -27,8 +26,7 @@ impl HavingPlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+        pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_limit.rs
+++ b/common/planners/src/plan_limit.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::PlanNode;
 
@@ -26,8 +25,7 @@ impl LimitPlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+        pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_limit.rs
+++ b/common/planners/src/plan_limit.rs
@@ -25,7 +25,7 @@ impl LimitPlan {
         self.input.clone()
     }
 
-        pub fn set_input(&mut self, input: &PlanNode) {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
     }
 }

--- a/common/planners/src/plan_node.rs
+++ b/common/planners/src/plan_node.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::AggregatorFinalPlan;
 use crate::AggregatorPartialPlan;
@@ -117,7 +116,7 @@ impl PlanNode {
         }
     }
 
-    pub fn set_input(&mut self, node: &PlanNode) -> Result<()> {
+    pub fn set_input(&mut self, node: &PlanNode) {
         match self {
             PlanNode::Stage(v) => v.set_input(node),
             PlanNode::Projection(v) => v.set_input(node),
@@ -131,7 +130,7 @@ impl PlanNode {
             PlanNode::Select(v) => v.set_input(node),
             PlanNode::Sort(v) => v.set_input(node),
 
-            _ => Ok(())
+            _ => {}
         }
     }
 }

--- a/common/planners/src/plan_projection.rs
+++ b/common/planners/src/plan_projection.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::ExpressionAction;
 use crate::PlanNode;
@@ -31,8 +30,7 @@ impl ProjectionPlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_select.rs
+++ b/common/planners/src/plan_select.rs
@@ -22,7 +22,7 @@ impl SelectPlan {
         self.input.clone()
     }
 
-        pub fn set_input(&mut self, input: &PlanNode) {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
     }
 }

--- a/common/planners/src/plan_select.rs
+++ b/common/planners/src/plan_select.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::PlanNode;
 
@@ -23,8 +22,7 @@ impl SelectPlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+        pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_sort.rs
+++ b/common/planners/src/plan_sort.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::ExpressionAction;
 use crate::PlanNode;
@@ -27,8 +26,7 @@ impl SortPlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+        pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_sort.rs
+++ b/common/planners/src/plan_sort.rs
@@ -26,7 +26,7 @@ impl SortPlan {
         self.input.clone()
     }
 
-        pub fn set_input(&mut self, input: &PlanNode) {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
     }
 }

--- a/common/planners/src/plan_stage.rs
+++ b/common/planners/src/plan_stage.rs
@@ -5,7 +5,6 @@
 use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
-use common_exception::Result;
 
 use crate::PlanNode;
 
@@ -35,8 +34,7 @@ impl StagePlan {
         self.input.clone()
     }
 
-    pub fn set_input(&mut self, input: &PlanNode) -> Result<()> {
+        pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
-        Ok(())
     }
 }

--- a/common/planners/src/plan_stage.rs
+++ b/common/planners/src/plan_stage.rs
@@ -34,7 +34,7 @@ impl StagePlan {
         self.input.clone()
     }
 
-        pub fn set_input(&mut self, input: &PlanNode) {
+    pub fn set_input(&mut self, input: &PlanNode) {
         self.input = Arc::new(input.clone());
     }
 }

--- a/common/planners/src/plan_visitor.rs
+++ b/common/planners/src/plan_visitor.rs
@@ -22,11 +22,6 @@ use crate::SortPlan;
 use crate::StagePlan;
 use crate::UseDatabasePlan;
 
-/// Default plan visitor that can walk through a entire plan.
-struct DefaultPlanVisitor {}
-
-impl<'plan> PlanVisitor<'plan> for DefaultPlanVisitor {}
-
 /// `PlanVisitor` implements visitor pattern(reference [syn](https://docs.rs/syn/1.0.72/syn/visit/trait.Visit.html)) for `PlanNode`.
 ///
 /// `PlanVisitor` would provide default implementations for each variant of `PlanNode` to visit a plan tree in preorder.

--- a/common/planners/src/plan_visitor.rs
+++ b/common/planners/src/plan_visitor.rs
@@ -1,0 +1,136 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use crate::AggregatorFinalPlan;
+use crate::AggregatorPartialPlan;
+use crate::CreateDatabasePlan;
+use crate::CreateTablePlan;
+use crate::EmptyPlan;
+use crate::ExplainPlan;
+use crate::ExpressionPlan;
+use crate::FilterPlan;
+use crate::HavingPlan;
+use crate::LimitPlan;
+use crate::PlanNode;
+use crate::ProjectionPlan;
+use crate::ReadDataSourcePlan;
+use crate::ScanPlan;
+use crate::SelectPlan;
+use crate::SettingPlan;
+use crate::SortPlan;
+use crate::StagePlan;
+use crate::UseDatabasePlan;
+
+/// Default plan visitor that can walk through a entire plan.
+struct DefaultPlanVisitor {}
+
+impl<'plan> PlanVisitor<'plan> for DefaultPlanVisitor {}
+
+/// `PlanVisitor` implements visitor pattern(reference [syn](https://docs.rs/syn/1.0.72/syn/visit/trait.Visit.html)) for `PlanNode`.
+///
+/// `PlanVisitor` would provide default implementations for each variant of `PlanNode` to visit a plan tree in preorder.
+/// You can customize the way to visit nodes by overriding corresponding methods.
+///
+/// Since a visitor will always modify itself during visiting, we pass `&mut self` to each visit method.
+///
+/// # Example
+/// Here's an example of printing table names of all `Scan` nodes in a plan tree:
+/// ```ignore
+/// struct MyVisitor {}
+///
+/// impl<'plan> PlanVisitor<'plan> for MyVisitor {
+///     fn visit_scan(&mut self, plan: &'plan ScanPlan) {
+///         println!("{}", plan.schema_name)
+///     }
+/// }
+///
+/// let visitor = MyVisitor {};
+/// let plan = PlanNode::Scan(ScanPlan {
+///     schema_name: "table",
+///     ...
+/// });
+/// visitor.visit_plan_node(&plan); // Output: table
+/// ```
+pub trait PlanVisitor<'plan> {
+    fn visit_plan_node(&mut self, node: &'plan PlanNode) {
+        match node {
+            PlanNode::AggregatorPartial(plan) => self.visit_aggregate_partial(plan),
+            PlanNode::AggregatorFinal(plan) => self.visit_aggregate_final(plan),
+            PlanNode::Empty(plan) => self.visit_empty(plan),
+            PlanNode::Projection(plan) => self.visit_projection(plan),
+            PlanNode::Filter(plan) => self.visit_filter(plan),
+            PlanNode::Sort(plan) => self.visit_sort(plan),
+            PlanNode::Limit(plan) => self.visit_limit(plan),
+            PlanNode::Scan(plan) => self.visit_scan(plan),
+            PlanNode::ReadSource(plan) => self.visit_read_data_source(plan),
+            PlanNode::Select(plan) => self.visit_select(plan),
+            PlanNode::Explain(plan) => self.visit_explain(plan),
+            PlanNode::CreateTable(plan) => self.visit_create_table(plan),
+            PlanNode::CreateDatabase(plan) => self.visit_create_database(plan),
+            PlanNode::UseDatabase(plan) => self.visit_use_database(plan),
+            PlanNode::SetVariable(plan) => self.visit_set_variable(plan),
+            PlanNode::Stage(plan) => self.visit_stage(plan),
+            PlanNode::Having(plan) => self.visit_having(plan),
+            PlanNode::Expression(plan) => self.visit_expression(plan)
+        }
+    }
+
+    fn visit_aggregate_partial(&mut self, plan: &'plan AggregatorPartialPlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_aggregate_final(&mut self, plan: &'plan AggregatorFinalPlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_empty(&mut self, _: &'plan EmptyPlan) {}
+
+    fn visit_stage(&mut self, plan: &'plan StagePlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_projection(&mut self, plan: &'plan ProjectionPlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_expression(&mut self, plan: &'plan ExpressionPlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_filter(&mut self, plan: &'plan FilterPlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_having(&mut self, plan: &'plan HavingPlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_sort(&mut self, plan: &'plan SortPlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_limit(&mut self, plan: &'plan LimitPlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_scan(&mut self, _: &'plan ScanPlan) {}
+
+    fn visit_read_data_source(&mut self, _: &'plan ReadDataSourcePlan) {}
+
+    fn visit_select(&mut self, plan: &'plan SelectPlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_explain(&mut self, plan: &'plan ExplainPlan) {
+        self.visit_plan_node(plan.input.as_ref());
+    }
+
+    fn visit_create_table(&mut self, _: &'plan CreateTablePlan) {}
+
+    fn visit_create_database(&mut self, _: &'plan CreateDatabasePlan) {}
+
+    fn visit_use_database(&mut self, _: &'plan UseDatabasePlan) {}
+
+    fn visit_set_variable(&mut self, _: &'plan SettingPlan) {}
+}

--- a/common/planners/src/plan_visitor.rs
+++ b/common/planners/src/plan_visitor.rs
@@ -47,6 +47,22 @@ use crate::UseDatabasePlan;
 /// });
 /// visitor.visit_plan_node(&plan); // Output: table
 /// ```
+///
+/// By default, `PlanVisitor` will visit all `PlanNode` with depth first traversal(i.e. recursively access children of a node).
+/// In some cases, people want to explicitly traverse the tree in pre-order or post-order, for whom the default implementation
+/// doesn't work. Here we provide an example of pre-order traversal:
+/// ```ignore
+/// struct PreOrder {
+///     pub process: FnMut(&PlanNode)
+/// }
+///
+/// impl<'plan> PlanVisitor<'plan> for PreOrder {
+///     fn visit_plan_node(&mut self, plan: &PlanNode) {
+///         self.process(plan); // Process current node first
+///         PlanVisitor::visit_plan_node(self, plan.input().as_ref()); // Then process children
+///     }
+/// }
+/// ```
 pub trait PlanVisitor<'plan> {
     fn visit_plan_node(&mut self, node: &'plan PlanNode) {
         match node {

--- a/common/planners/src/plan_walker.rs
+++ b/common/planners/src/plan_walker.rs
@@ -5,6 +5,7 @@
 use std::result::Result;
 
 use crate::PlanNode;
+use crate::PlanVisitor;
 
 #[derive(PartialEq)]
 enum WalkOrder {
@@ -12,33 +13,97 @@ enum WalkOrder {
     PostOrder
 }
 
+struct PreOrderWalker<'a, E> {
+    callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>,
+    state: Result<(), E>
+}
+
+impl<'plan, 'a, E> PlanVisitor<'plan> for PreOrderWalker<'a, E> {
+    fn visit_plan_node(&mut self, node: &PlanNode) {
+        if let PlanNode::Empty(_) = node {
+            return;
+        }
+        match (self.callback)(node) {
+            Ok(true) => {
+                println!("Preorder: visiting {}", node.name());
+                self.visit_plan_node(node.input().as_ref());
+            }
+            Ok(false) => {
+                return;
+            }
+            Err(e) => {
+                self.state = Result::Err(e);
+            }
+        }
+    }
+}
+
+impl<'a, E> PreOrderWalker<'a, E> {
+    fn new(callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>) -> PreOrderWalker<E> {
+        PreOrderWalker {
+            callback: callback,
+            state: Ok(())
+        }
+    }
+
+    fn finalize(self) -> Result<(), E> {
+        self.state
+    }
+}
+
+struct PostOrderWalker<'a, E> {
+    callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>,
+    state: Result<bool, E>
+}
+
+impl<'plan, 'a, E> PlanVisitor<'plan> for PostOrderWalker<'a, E> {
+    fn visit_plan_node(&mut self, node: &PlanNode) {
+        if let PlanNode::Empty(_) = node {
+            return;
+        }
+        self.visit_plan_node(node.input().as_ref());
+        match self.state {
+            Ok(true) => {
+                self.state = (self.callback)(node);
+            }
+            _ => {
+                return;
+            }
+        }
+    }
+}
+
+impl<'a, E> PostOrderWalker<'a, E> {
+    fn new(callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>) -> PostOrderWalker<E> {
+        PostOrderWalker {
+            callback: callback,
+            state: Ok(true)
+        }
+    }
+
+    fn finalize(self) -> Result<(), E> {
+        self.state.map(|_| ())
+    }
+}
+
 impl PlanNode {
-    fn walk_base<E>(
+    fn walk_base<'a, E>(
         order: WalkOrder,
         node: &PlanNode,
-        mut visitor: impl FnMut(&PlanNode) -> Result<bool, E>
+        callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>
     ) -> Result<(), E> {
-        let mut nodes = vec![];
-        let mut tmp = node.clone();
-
-        loop {
-            if let PlanNode::Empty(_) = tmp {
-                break;
+        match order {
+            WalkOrder::PreOrder => {
+                let mut visitor = PreOrderWalker::<'a, E>::new(callback);
+                visitor.visit_plan_node(node);
+                visitor.finalize()
             }
-            nodes.push(tmp.clone());
-            tmp = tmp.input().as_ref().clone();
-        }
-
-        if order == WalkOrder::PostOrder {
-            nodes.reverse();
-        }
-
-        for plan in nodes {
-            if !visitor(&plan)? {
-                return Ok(());
+            WalkOrder::PostOrder => {
+                let mut visitor = PostOrderWalker::<'a, E>::new(callback);
+                visitor.visit_plan_node(node);
+                visitor.finalize()
             }
         }
-        Ok(())
     }
 
     /// Preorder walk is when each node is visited before any of its inputs:
@@ -50,7 +115,7 @@ impl PlanNode {
     /// A Preorder walk of this graph is A B C
     pub fn walk_preorder<E>(
         &self,
-        visitor: impl FnMut(&PlanNode) -> Result<bool, E>
+        visitor: &mut dyn FnMut(&PlanNode) -> Result<bool, E>
     ) -> Result<(), E> {
         Self::walk_base(WalkOrder::PreOrder, self, visitor)
     }
@@ -64,7 +129,7 @@ impl PlanNode {
     /// A Postorder walk of this graph is C B A
     pub fn walk_postorder<E>(
         &self,
-        visitor: impl FnMut(&PlanNode) -> Result<bool, E>
+        visitor: &mut dyn FnMut(&PlanNode) -> Result<bool, E>
     ) -> Result<(), E> {
         Self::walk_base(WalkOrder::PostOrder, self, visitor)
     }

--- a/common/planners/src/plan_walker.rs
+++ b/common/planners/src/plan_walker.rs
@@ -115,9 +115,9 @@ impl PlanNode {
     /// A Preorder walk of this graph is A B C
     pub fn walk_preorder<E>(
         &self,
-        visitor: &mut dyn FnMut(&PlanNode) -> Result<bool, E>
+        mut visitor: impl FnMut(&PlanNode) -> Result<bool, E>
     ) -> Result<(), E> {
-        Self::walk_base(WalkOrder::PreOrder, self, visitor)
+        Self::walk_base(WalkOrder::PreOrder, self, &mut visitor)
     }
 
     /// Postorder walk is when each node is visited after all of its inputs:
@@ -129,8 +129,8 @@ impl PlanNode {
     /// A Postorder walk of this graph is C B A
     pub fn walk_postorder<E>(
         &self,
-        visitor: &mut dyn FnMut(&PlanNode) -> Result<bool, E>
+        mut visitor: impl FnMut(&PlanNode) -> Result<bool, E>
     ) -> Result<(), E> {
-        Self::walk_base(WalkOrder::PostOrder, self, visitor)
+        Self::walk_base(WalkOrder::PostOrder, self, &mut visitor)
     }
 }

--- a/common/planners/src/plan_walker_test.rs
+++ b/common/planners/src/plan_walker_test.rs
@@ -18,12 +18,13 @@ fn test_plan_walker() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // PreOrder.
     {
         let mut actual: Vec<String> = vec![];
-        plan.input().as_ref().walk_preorder(
-            |plan| -> Result<bool, Box<dyn std::error::Error>> {
-                actual.push(plan.name().to_string());
-                return Ok(true);
-            }
-        )?;
+        plan.input().as_ref().walk_preorder(&mut |plan| -> Result<
+            bool,
+            Box<dyn std::error::Error>
+        > {
+            actual.push(plan.name().to_string());
+            return Ok(true);
+        })?;
 
         let expect = vec![
             "AggregatorFinalPlan".to_string(),
@@ -36,12 +37,13 @@ fn test_plan_walker() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // PostOrder.
     {
         let mut actual: Vec<String> = vec![];
-        plan.input().as_ref().walk_postorder(
-            |plan| -> Result<bool, Box<dyn std::error::Error>> {
-                actual.push(plan.name().to_string());
-                return Ok(true);
-            }
-        )?;
+        plan.input().as_ref().walk_postorder(&mut |plan| -> Result<
+            bool,
+            Box<dyn std::error::Error>
+        > {
+            actual.push(plan.name().to_string());
+            return Ok(true);
+        })?;
 
         let expect = vec![
             "ReadSourcePlan".to_string(),

--- a/common/planners/src/plan_walker_test.rs
+++ b/common/planners/src/plan_walker_test.rs
@@ -18,7 +18,7 @@ fn test_plan_walker() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // PreOrder.
     {
         let mut actual: Vec<String> = vec![];
-        plan.input().as_ref().walk_preorder(&mut |plan| -> Result<
+        plan.input().as_ref().walk_preorder(|plan| -> Result<
             bool,
             Box<dyn std::error::Error>
         > {
@@ -37,7 +37,7 @@ fn test_plan_walker() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // PostOrder.
     {
         let mut actual: Vec<String> = vec![];
-        plan.input().as_ref().walk_postorder(&mut |plan| -> Result<
+        plan.input().as_ref().walk_postorder(|plan| -> Result<
             bool,
             Box<dyn std::error::Error>
         > {

--- a/fusequery/query/src/optimizers/optimizer_alias_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_alias_push_down.rs
@@ -35,7 +35,7 @@ impl IOptimizer for AliasPushDownOptimizer {
         });
 
         let projection_map = PlanRewriter::projection_to_map(plan)?;
-        plan.walk_postorder(&mut |node| -> Result<bool> {
+        plan.walk_postorder(|node| -> Result<bool> {
             match node {
                 PlanNode::Filter(plan) => {
                     let rewritten_expr =

--- a/fusequery/query/src/optimizers/optimizer_alias_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_alias_push_down.rs
@@ -44,7 +44,7 @@ impl IOptimizer for AliasPushDownOptimizer {
                         predicate: rewritten_expr,
                         input: rewritten_node.input()
                     });
-                    new_node.set_input(&rewritten_node)?;
+                    new_node.set_input(&rewritten_node);
                     rewritten_node = new_node;
                 }
                 PlanNode::AggregatorPartial(plan) => {
@@ -57,7 +57,7 @@ impl IOptimizer for AliasPushDownOptimizer {
                         aggr_expr,
                         input: rewritten_node.input()
                     });
-                    new_node.set_input(&rewritten_node)?;
+                    new_node.set_input(&rewritten_node);
                     rewritten_node = new_node;
                 }
                 PlanNode::AggregatorFinal(plan) => {
@@ -71,12 +71,12 @@ impl IOptimizer for AliasPushDownOptimizer {
                         input: rewritten_node.input(),
                         schema: plan.schema()
                     });
-                    new_node.set_input(&rewritten_node)?;
+                    new_node.set_input(&rewritten_node);
                     rewritten_node = new_node;
                 }
                 _ => {
                     let mut clone_node = node.clone();
-                    clone_node.set_input(&rewritten_node)?;
+                    clone_node.set_input(&rewritten_node);
                     rewritten_node = clone_node;
                 }
             }

--- a/fusequery/query/src/optimizers/optimizer_alias_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_alias_push_down.rs
@@ -35,7 +35,7 @@ impl IOptimizer for AliasPushDownOptimizer {
         });
 
         let projection_map = PlanRewriter::projection_to_map(plan)?;
-        plan.walk_postorder(|node| -> Result<bool> {
+        plan.walk_postorder(&mut |node| -> Result<bool> {
             match node {
                 PlanNode::Filter(plan) => {
                     let rewritten_expr =

--- a/fusequery/query/src/optimizers/optimizer_limit_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_limit_push_down.rs
@@ -44,7 +44,7 @@ impl IOptimizer for LimitPushDownOptimizer {
             schema: Arc::new(DataSchema::empty())
         });
 
-        plan.walk_postorder(|node| -> Result<bool> {
+        plan.walk_postorder(&mut |node| -> Result<bool> {
             if let PlanNode::Limit(LimitPlan { n, input: _ }) = node {
                 let mut new_node = limit_push_down(Some(*n), node)?;
                 new_node.set_input(&rewritten_node);

--- a/fusequery/query/src/optimizers/optimizer_limit_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_limit_push_down.rs
@@ -47,11 +47,11 @@ impl IOptimizer for LimitPushDownOptimizer {
         plan.walk_postorder(|node| -> Result<bool> {
             if let PlanNode::Limit(LimitPlan { n, input: _ }) = node {
                 let mut new_node = limit_push_down(Some(*n), node)?;
-                new_node.set_input(&rewritten_node)?;
+                new_node.set_input(&rewritten_node);
                 rewritten_node = new_node;
             } else {
                 let mut clone_node = node.clone();
-                clone_node.set_input(&rewritten_node)?;
+                clone_node.set_input(&rewritten_node);
                 rewritten_node = clone_node;
             }
             Ok(true)

--- a/fusequery/query/src/optimizers/optimizer_limit_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_limit_push_down.rs
@@ -44,7 +44,7 @@ impl IOptimizer for LimitPushDownOptimizer {
             schema: Arc::new(DataSchema::empty())
         });
 
-        plan.walk_postorder(&mut |node| -> Result<bool> {
+        plan.walk_postorder(|node| -> Result<bool> {
             if let PlanNode::Limit(LimitPlan { n, input: _ }) = node {
                 let mut new_node = limit_push_down(Some(*n), node)?;
                 new_node.set_input(&rewritten_node);

--- a/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
@@ -60,8 +60,7 @@ impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
         self.has_projection = true;
         self.visit_plan_node(&plan.input);
         let mut new_plan = plan.clone();
-        // TODO: check result
-        new_plan.set_input(&self.new_plan).unwrap();
+        new_plan.set_input(&self.new_plan);
         self.new_plan = PlanNode::Projection(new_plan);
     }
 
@@ -75,8 +74,7 @@ impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
         }
         self.visit_plan_node(&plan.input);
         let mut new_plan = plan.clone();
-        // TODO: check result
-        new_plan.set_input(&self.new_plan).unwrap();
+        new_plan.set_input(&self.new_plan);
         self.new_plan = PlanNode::Filter(new_plan);
     }
 
@@ -93,8 +91,7 @@ impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
         }
         self.visit_plan_node(&plan.input);
         let mut new_plan = plan.clone();
-        // TODO: check result
-        new_plan.set_input(&self.new_plan).unwrap();
+        new_plan.set_input(&self.new_plan);
         self.new_plan = PlanNode::AggregatorPartial(new_plan);
     }
 
@@ -111,8 +108,7 @@ impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
         }
         self.visit_plan_node(&plan.input);
         let mut new_plan = plan.clone();
-        // TODO: check result
-        new_plan.set_input(&self.new_plan).unwrap();
+        new_plan.set_input(&self.new_plan);
         self.new_plan = PlanNode::AggregatorFinal(new_plan);
     }
 
@@ -126,8 +122,7 @@ impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
         }
         self.visit_plan_node(&plan.input);
         let mut new_plan = plan.clone();
-        // TODO: check result
-        new_plan.set_input(&self.new_plan).unwrap();
+        new_plan.set_input(&self.new_plan);
         self.new_plan = PlanNode::Sort(new_plan);
     }
 
@@ -188,8 +183,7 @@ impl ProjectionPushDownImpl {
         }
         self.visit_plan_node(&plan.input());
         let mut new_plan = plan.clone();
-        // TODO: check result
-        new_plan.set_input(&self.new_plan).unwrap();
+        new_plan.set_input(&self.new_plan);
         self.new_plan = new_plan;
     }
 

--- a/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
@@ -36,6 +36,19 @@ struct ProjectionPushDownImpl {
 }
 
 impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
+    fn visit_plan_node(&mut self, plan: &PlanNode) {
+        match plan {
+            PlanNode::AggregatorPartial(plan) => self.visit_aggregate_partial(plan),
+            PlanNode::AggregatorFinal(plan) => self.visit_aggregate_final(plan),
+            PlanNode::Empty(plan) => self.visit_empty(plan),
+            PlanNode::Projection(plan) => self.visit_projection(plan),
+            PlanNode::Filter(plan) => self.visit_filter(plan),
+            PlanNode::Sort(plan) => self.visit_sort(plan),
+            PlanNode::ReadSource(plan) => self.visit_read_data_source(plan),
+            _ => self.visit(plan)
+        }
+    }
+
     fn visit_projection(&mut self, plan: &ProjectionPlan) {
         if self.state.is_err() {
             return;
@@ -45,9 +58,10 @@ impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
             return;
         }
         self.has_projection = true;
-        self.visit(&plan.input);
+        self.visit_plan_node(&plan.input);
         let mut new_plan = plan.clone();
-        new_plan.set_input(&self.new_plan);
+        // TODO: check result
+        new_plan.set_input(&self.new_plan).unwrap();
         self.new_plan = PlanNode::Projection(new_plan);
     }
 
@@ -59,9 +73,10 @@ impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
             self.state = Result::Err(e);
             return;
         }
-        self.visit(&plan.input);
+        self.visit_plan_node(&plan.input);
         let mut new_plan = plan.clone();
-        new_plan.set_input(&self.new_plan);
+        // TODO: check result
+        new_plan.set_input(&self.new_plan).unwrap();
         self.new_plan = PlanNode::Filter(new_plan);
     }
 
@@ -76,9 +91,10 @@ impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
             self.state = Result::Err(e);
             return;
         }
-        self.visit(&plan.input);
+        self.visit_plan_node(&plan.input);
         let mut new_plan = plan.clone();
-        new_plan.set_input(&self.new_plan);
+        // TODO: check result
+        new_plan.set_input(&self.new_plan).unwrap();
         self.new_plan = PlanNode::AggregatorPartial(new_plan);
     }
 
@@ -93,9 +109,10 @@ impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
             self.state = Result::Err(e);
             return;
         }
-        self.visit(&plan.input);
+        self.visit_plan_node(&plan.input);
         let mut new_plan = plan.clone();
-        new_plan.set_input(&self.new_plan);
+        // TODO: check result
+        new_plan.set_input(&self.new_plan).unwrap();
         self.new_plan = PlanNode::AggregatorFinal(new_plan);
     }
 
@@ -107,9 +124,10 @@ impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
             self.state = Result::Err(e);
             return;
         }
-        self.visit(&plan.input);
+        self.visit_plan_node(&plan.input);
         let mut new_plan = plan.clone();
-        new_plan.set_input(&self.new_plan);
+        // TODO: check result
+        new_plan.set_input(&self.new_plan).unwrap();
         self.new_plan = PlanNode::Sort(new_plan);
     }
 
@@ -170,7 +188,8 @@ impl ProjectionPushDownImpl {
         }
         self.visit_plan_node(&plan.input());
         let mut new_plan = plan.clone();
-        new_plan.set_input(&self.new_plan);
+        // TODO: check result
+        new_plan.set_input(&self.new_plan).unwrap();
         self.new_plan = new_plan;
     }
 

--- a/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use common_arrow::arrow::error::Result as ArrowResult;
 use common_datavalues::DataField;
@@ -12,10 +13,12 @@ use common_datavalues::DataSchemaRefExt;
 use common_exception::Result;
 use common_planners::AggregatorFinalPlan;
 use common_planners::AggregatorPartialPlan;
+use common_planners::EmptyPlan;
 use common_planners::ExpressionAction;
 use common_planners::FilterPlan;
 use common_planners::PlanNode;
 use common_planners::PlanRewriter;
+use common_planners::PlanVisitor;
 use common_planners::ProjectionPlan;
 use common_planners::ReadDataSourcePlan;
 use common_planners::SortPlan;
@@ -25,163 +28,196 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct ProjectionPushDownOptimizer {}
 
-impl ProjectionPushDownOptimizer {
-    pub fn create(_ctx: FuseQueryContextRef) -> Self {
-        ProjectionPushDownOptimizer {}
+struct ProjectionPushDownImpl {
+    pub required_columns: HashSet<String>,
+    pub new_plan: PlanNode,
+    pub has_projection: bool,
+    pub state: Result<()>
+}
+
+impl<'plan> PlanVisitor<'plan> for ProjectionPushDownImpl {
+    fn visit_projection(&mut self, plan: &ProjectionPlan) {
+        if self.state.is_err() {
+            return;
+        }
+        if let Result::Err(e) = self.collect_column_names_from_expr_vec(plan.expr.as_slice()) {
+            self.state = Result::Err(e);
+            return;
+        }
+        self.has_projection = true;
+        self.visit_plan_node(&plan.input);
+        let mut new_plan = plan.clone();
+        new_plan.set_input(&self.new_plan);
+        self.new_plan = PlanNode::Projection(new_plan);
+    }
+
+    fn visit_filter(&mut self, plan: &'plan FilterPlan) {
+        if self.state.is_err() {
+            return;
+        }
+        if let Result::Err(e) = self.collect_column_names_from_expr(&plan.predicate) {
+            self.state = Result::Err(e);
+            return;
+        }
+        self.visit_plan_node(&plan.input);
+        let mut new_plan = plan.clone();
+        new_plan.set_input(&self.new_plan);
+        self.new_plan = PlanNode::Filter(new_plan);
+    }
+
+    fn visit_aggregate_partial(&mut self, plan: &'plan AggregatorPartialPlan) {
+        if self.state.is_err() {
+            return;
+        }
+        if let Result::Err(e) = self
+            .collect_column_names_from_expr_vec(&plan.aggr_expr)
+            .and_then(|_| self.collect_column_names_from_expr_vec(&plan.group_expr))
+        {
+            self.state = Result::Err(e);
+            return;
+        }
+        self.visit_plan_node(&plan.input);
+        let mut new_plan = plan.clone();
+        new_plan.set_input(&self.new_plan);
+        self.new_plan = PlanNode::AggregatorPartial(new_plan);
+    }
+
+    fn visit_aggregate_final(&mut self, plan: &'plan AggregatorFinalPlan) {
+        if self.state.is_err() {
+            return;
+        }
+        if let Result::Err(e) = self
+            .collect_column_names_from_expr_vec(&plan.aggr_expr)
+            .and_then(|_| self.collect_column_names_from_expr_vec(&plan.group_expr))
+        {
+            self.state = Result::Err(e);
+            return;
+        }
+        self.visit_plan_node(&plan.input);
+        let mut new_plan = plan.clone();
+        new_plan.set_input(&self.new_plan);
+        self.new_plan = PlanNode::AggregatorFinal(new_plan);
+    }
+
+    fn visit_sort(&mut self, plan: &'plan SortPlan) {
+        if self.state.is_err() {
+            return;
+        }
+        if let Result::Err(e) = self.collect_column_names_from_expr_vec(&plan.order_by) {
+            self.state = Result::Err(e);
+            return;
+        }
+        self.visit_plan_node(&plan.input);
+        let mut new_plan = plan.clone();
+        new_plan.set_input(&self.new_plan);
+        self.new_plan = PlanNode::Sort(new_plan);
+    }
+
+    fn visit_read_data_source(&mut self, plan: &'plan ReadDataSourcePlan) {
+        if self.state.is_err() {
+            return;
+        }
+        match self.get_projected_schema(plan.schema.as_ref()) {
+            Ok(projected_schema) => {
+                self.new_plan = PlanNode::ReadSource(ReadDataSourcePlan {
+                    db: plan.db.to_string(),
+                    table: plan.table.to_string(),
+                    schema: projected_schema,
+                    partitions: plan.partitions.clone(),
+                    statistics: plan.statistics.clone(),
+                    description: plan.description.to_string()
+                })
+            }
+            Err(e) => {
+                self.state = Result::Err(e);
+            }
+        }
+    }
+
+    fn visit_empty(&mut self, plan: &'plan EmptyPlan) {
+        if self.state.is_err() {
+            return;
+        }
+        self.new_plan = PlanNode::Empty(plan.clone());
     }
 }
 
-// Recursively walk an expression tree, collecting the unique set of column names
-// referenced in the expression
-fn expr_to_column_names(expr: &ExpressionAction, accum: &mut HashSet<String>) -> Result<()> {
-    let expressions = PlanRewriter::expression_plan_children(expr)?;
-
-    let _expressions = expressions
-        .iter()
-        .map(|e| expr_to_column_names(e, accum))
-        .collect::<Result<Vec<_>>>()?;
-
-    if let ExpressionAction::Column(name) = expr {
-        accum.insert(name.clone());
-    }
-    Ok(())
-}
-
-// Recursively walk a list of expression trees, collecting the unique set of column
-// names referenced in the expression
-fn exprvec_to_column_names(expr: &[ExpressionAction], accum: &mut HashSet<String>) -> Result<()> {
-    for e in expr {
-        expr_to_column_names(e, accum)?;
-    }
-    Ok(())
-}
-
-fn get_projected_schema(
-    schema: &DataSchema,
-    required_columns: &HashSet<String>,
-    has_projection: bool
-) -> Result<DataSchemaRef> {
-    // Discard non-existing columns, e.g. when the column derives from aggregation
-    let mut projection: Vec<usize> = required_columns
-        .iter()
-        .map(|name| schema.index_of(name))
-        .filter_map(ArrowResult::ok)
-        .collect();
-    if projection.is_empty() {
-        if has_projection {
-            // Ensure reading at lease one column
-            projection.push(0);
-        } else {
-            // for table scan without projection
-            // just return all columns
-            projection = schema
-                .fields()
-                .iter()
-                .enumerate()
-                .map(|(i, _)| i)
-                .collect::<Vec<usize>>();
+impl ProjectionPushDownImpl {
+    pub fn new() -> ProjectionPushDownImpl {
+        ProjectionPushDownImpl {
+            required_columns: HashSet::new(),
+            new_plan: PlanNode::Empty(EmptyPlan {
+                schema: Arc::new(DataSchema::new(vec![]))
+            }),
+            has_projection: false,
+            state: Ok(())
         }
     }
-    // sort the projection to get deterministic behavior
-    projection.sort_unstable();
 
-    // create the projected schema
-    let mut projected_fields: Vec<DataField> = Vec::with_capacity(projection.len());
-    for i in &projection {
-        projected_fields.push(schema.fields()[*i].clone());
+    pub fn finalize(self) -> Result<PlanNode> {
+        match self.state {
+            Ok(_) => Ok(self.new_plan),
+            Err(e) => Err(e)
+        }
     }
-    Ok(DataSchemaRefExt::create(projected_fields))
-}
 
-fn optimize_plan(
-    optimizer: &ProjectionPushDownOptimizer,
-    plan: &PlanNode,
-    required_columns: &HashSet<String>,
-    has_projection: bool
-) -> Result<PlanNode> {
-    let mut new_required_columns = required_columns.clone();
-    match plan {
-        PlanNode::Projection(ProjectionPlan {
-            expr,
-            schema: _,
-            input
-        }) => {
-            exprvec_to_column_names(expr, &mut new_required_columns)?;
-            let new_input = optimize_plan(optimizer, &input, &new_required_columns, true)?;
-            let mut cloned_plan = plan.clone();
-            cloned_plan.set_input(&new_input)?;
-            Ok(cloned_plan)
+    // Recursively walk a list of expression trees, collecting the unique set of column
+    // names referenced in the expression
+    fn collect_column_names_from_expr_vec(&mut self, expr: &[ExpressionAction]) -> Result<()> {
+        for e in expr {
+            self.collect_column_names_from_expr(e)?;
         }
-        PlanNode::Filter(FilterPlan { predicate, input }) => {
-            expr_to_column_names(predicate, &mut new_required_columns)?;
-            let new_input =
-                optimize_plan(optimizer, &input, &new_required_columns, has_projection)?;
-            let mut cloned_plan = plan.clone();
-            cloned_plan.set_input(&new_input)?;
-            Ok(cloned_plan)
-        }
-        PlanNode::Sort(SortPlan { order_by, input }) => {
-            exprvec_to_column_names(order_by, &mut new_required_columns)?;
-            let new_input =
-                optimize_plan(optimizer, &input, &new_required_columns, has_projection)?;
-            let mut cloned_plan = plan.clone();
-            cloned_plan.set_input(&new_input)?;
-            Ok(cloned_plan)
-        }
-        PlanNode::AggregatorFinal(AggregatorFinalPlan {
-            aggr_expr,
-            group_expr,
-            schema: _,
-            input
-        }) => {
-            // final aggregate:
-            exprvec_to_column_names(group_expr, &mut new_required_columns)?;
-            exprvec_to_column_names(aggr_expr, &mut new_required_columns)?;
-            let new_input = optimize_plan(optimizer, &input, &new_required_columns, true)?;
-            let mut cloned_plan = plan.clone();
-            cloned_plan.set_input(&new_input)?;
-            Ok(cloned_plan)
-        }
-        PlanNode::AggregatorPartial(AggregatorPartialPlan {
-            aggr_expr,
-            group_expr,
-            input
-        }) => {
-            // Partial aggregate:
-            exprvec_to_column_names(group_expr, &mut new_required_columns)?;
-            exprvec_to_column_names(aggr_expr, &mut new_required_columns)?;
-            let new_input = optimize_plan(optimizer, &input, &new_required_columns, true)?;
-            let mut cloned_plan = plan.clone();
-            cloned_plan.set_input(&new_input)?;
-            Ok(cloned_plan)
-        }
-        PlanNode::ReadSource(ReadDataSourcePlan {
-            db,
-            table,
-            schema,
-            partitions,
-            statistics,
-            description
-        }) => {
-            let projected_schema = get_projected_schema(schema, required_columns, has_projection)?;
+        Ok(())
+    }
 
-            Ok(PlanNode::ReadSource(ReadDataSourcePlan {
-                db: db.to_string(),
-                table: table.to_string(),
-                schema: projected_schema,
-                partitions: partitions.clone(),
-                statistics: statistics.clone(),
-                description: description.to_string()
-            }))
+    // Recursively walk an expression tree, collecting the unique set of column names
+    // referenced in the expression
+    fn collect_column_names_from_expr(&mut self, expr: &ExpressionAction) -> Result<()> {
+        let expressions = PlanRewriter::expression_plan_children(expr)?;
+
+        let _expressions = expressions
+            .iter()
+            .map(|e| self.collect_column_names_from_expr(e))
+            .collect::<Result<Vec<_>>>()?;
+
+        if let ExpressionAction::Column(name) = expr {
+            self.required_columns.insert(name.clone());
         }
-        PlanNode::Empty(_) => Ok(plan.clone()),
-        _ => {
-            let input = plan.input();
-            let new_input = optimize_plan(optimizer, &input, &required_columns, has_projection)?;
-            let mut cloned_plan = plan.clone();
-            cloned_plan.set_input(&new_input)?;
-            Ok(cloned_plan)
+        Ok(())
+    }
+
+    fn get_projected_schema(&self, schema: &DataSchema) -> Result<DataSchemaRef> {
+        // Discard non-existing columns, e.g. when the column derives from aggregation
+        let mut projection: Vec<usize> = self
+            .required_columns
+            .iter()
+            .map(|name| schema.index_of(name))
+            .filter_map(ArrowResult::ok)
+            .collect();
+        if projection.is_empty() {
+            if self.has_projection {
+                // Ensure reading at lease one column
+                projection.push(0);
+            } else {
+                // for table scan without projection
+                // just return all columns
+                projection = schema
+                    .fields()
+                    .iter()
+                    .enumerate()
+                    .map(|(i, _)| i)
+                    .collect::<Vec<usize>>();
+            }
         }
+        // sort the projection to get deterministic behavior
+        projection.sort_unstable();
+
+        // create the projected schema
+        let mut projected_fields: Vec<DataField> = Vec::with_capacity(projection.len());
+        for i in &projection {
+            projected_fields.push(schema.fields()[*i].clone());
+        }
+        Ok(DataSchemaRefExt::create(projected_fields))
     }
 }
 
@@ -191,8 +227,14 @@ impl IOptimizer for ProjectionPushDownOptimizer {
     }
 
     fn optimize(&mut self, plan: &PlanNode) -> Result<PlanNode> {
-        let required_columns = HashSet::new();
-        let new_node = optimize_plan(self, plan, &required_columns, false)?;
-        Ok(new_node)
+        let mut visitor = ProjectionPushDownImpl::new();
+        visitor.visit_plan_node(plan);
+        visitor.finalize()
+    }
+}
+
+impl ProjectionPushDownOptimizer {
+    pub fn create(_ctx: FuseQueryContextRef) -> ProjectionPushDownOptimizer {
+        ProjectionPushDownOptimizer {}
     }
 }

--- a/fusequery/query/src/pipelines/processors/pipeline_builder.rs
+++ b/fusequery/query/src/pipelines/processors/pipeline_builder.rs
@@ -49,7 +49,7 @@ impl PipelineBuilder {
         info!("Received for plan:\n{:?}", self.plan);
 
         let mut limit = None;
-        self.plan.walk_preorder(|node| -> Result<bool> {
+        self.plan.walk_preorder(&mut |node| -> Result<bool> {
             match node {
                 PlanNode::Limit(ref limit_plan) => {
                     limit = Some(limit_plan.n);
@@ -60,7 +60,7 @@ impl PipelineBuilder {
         })?;
 
         let mut pipeline = Pipeline::create(self.ctx.clone());
-        self.plan.walk_postorder(|node| -> Result<bool> {
+        self.plan.walk_postorder(&mut |node| -> Result<bool> {
             match node {
                 PlanNode::Select(_) => Ok(true),
                 PlanNode::Stage(plan) => self.visit_stage_plan(&mut pipeline, &plan),

--- a/fusequery/query/src/pipelines/processors/pipeline_builder.rs
+++ b/fusequery/query/src/pipelines/processors/pipeline_builder.rs
@@ -49,7 +49,7 @@ impl PipelineBuilder {
         info!("Received for plan:\n{:?}", self.plan);
 
         let mut limit = None;
-        self.plan.walk_preorder(&mut |node| -> Result<bool> {
+        self.plan.walk_preorder(|node| -> Result<bool> {
             match node {
                 PlanNode::Limit(ref limit_plan) => {
                     limit = Some(limit_plan.n);
@@ -60,7 +60,7 @@ impl PipelineBuilder {
         })?;
 
         let mut pipeline = Pipeline::create(self.ctx.clone());
-        self.plan.walk_postorder(&mut |node| -> Result<bool> {
+        self.plan.walk_postorder(|node| -> Result<bool> {
             match node {
                 PlanNode::Select(_) => Ok(true),
                 PlanNode::Stage(plan) => self.visit_stage_plan(&mut pipeline, &plan),

--- a/fusequery/query/src/planners/plan_scheduler.rs
+++ b/fusequery/query/src/planners/plan_scheduler.rs
@@ -29,7 +29,7 @@ impl PlanScheduler {
         // Get the source plan node by walk
         let mut source_plan = ReadDataSourcePlan::empty();
         {
-            plan.walk_preorder(|plan| -> Result<bool> {
+            plan.walk_preorder(&mut |plan| -> Result<bool> {
                 match plan {
                     PlanNode::ReadSource(node) => {
                         source_plan = node.clone();
@@ -115,7 +115,7 @@ impl PlanScheduler {
                 });
 
                 // Walk and rewrite the plan from the source.
-                plan.walk_postorder(|node| -> Result<bool> {
+                plan.walk_postorder(&mut |node| -> Result<bool> {
                     if let PlanNode::ReadSource(_) = node {
                         rewritten_node = PlanNode::ReadSource(new_source_plan.clone());
                     } else {

--- a/fusequery/query/src/planners/plan_scheduler.rs
+++ b/fusequery/query/src/planners/plan_scheduler.rs
@@ -120,7 +120,7 @@ impl PlanScheduler {
                         rewritten_node = PlanNode::ReadSource(new_source_plan.clone());
                     } else {
                         let mut clone_node = node.clone();
-                        clone_node.set_input(&rewritten_node)?;
+                        clone_node.set_input(&rewritten_node);
                         rewritten_node = clone_node;
                     }
                     Ok(true)

--- a/fusequery/query/src/planners/plan_scheduler.rs
+++ b/fusequery/query/src/planners/plan_scheduler.rs
@@ -29,7 +29,7 @@ impl PlanScheduler {
         // Get the source plan node by walk
         let mut source_plan = ReadDataSourcePlan::empty();
         {
-            plan.walk_preorder(&mut |plan| -> Result<bool> {
+            plan.walk_preorder(|plan| -> Result<bool> {
                 match plan {
                     PlanNode::ReadSource(node) => {
                         source_plan = node.clone();
@@ -115,7 +115,7 @@ impl PlanScheduler {
                 });
 
                 // Walk and rewrite the plan from the source.
-                plan.walk_postorder(&mut |node| -> Result<bool> {
+                plan.walk_postorder(|node| -> Result<bool> {
                     if let PlanNode::ReadSource(_) = node {
                         rewritten_node = PlanNode::ReadSource(new_source_plan.clone());
                     } else {


### PR DESCRIPTION
## Summary

This PR introduce a `PlanVisitor` that implements visitor pattern, which reference a rust-idiomatic visitor [syn](https://docs.rs/syn/1.0.72/syn/visit/index.html).

The motivation I file this PR is to provide a better way to implement optimizer. When I was trying to write some heuristic optimization rules, I found it's inconvenient to maintain state and partially delegate the logic of traversal to default implementation with current framework.

In this PR I provide a `PlanVisitor` trait and refactor the `ProjectionPushDown` optimization with visitor pattern which has passed regression unit test.

## Changelog

- Improvement

## Related Issues


## Test Plan

Unit Tests
Stateless Tests

