### PR TITLE
[store] update dep: async-raft tracks the latest self maintained version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,8 +128,8 @@ dependencies = [
 
 [[package]]
 name = "async-raft"
-version = "0.6.0"
-source = "git+https://github.com/drmingdrmer/async-raft?branch=fix-non-voter-restart#786f091dd691c3189c477a5e0050eef60ef0f9b3"
+version = "0.6.1"
+source = "git+https://github.com/drmingdrmer/async-raft?branch=rc#3dce97c5a42e6ddbd3e13b058dc657315ceae897"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -26,8 +26,8 @@ common-planners = {path = "../../common/planners"}
 
 # Crates.io dependencies
 anyhow = "1.0.40"
-#a bug fix on this repo: https://github.com/async-raft/async-raft/pull/114
-async-raft = { git = "https://github.com/drmingdrmer/async-raft", branch = "fix-non-voter-restart" }
+# track self maintained branch with hot fixes
+async-raft = { git = "https://github.com/drmingdrmer/async-raft", branch = "rc" }
 #async-raft = "0.6.0"
 async-trait = "0.1"
 env_logger = "0.8"


### PR DESCRIPTION
async-raft merged the pr that fix follower-non-voter bug, update to track the latest rev.

## Changelog


- Improvement
