### PR TITLE
fix typo `ErrorCodes::SyntexException`

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -69,7 +69,7 @@ build_exceptions! {
     UnImplement(2),
     UnknownDatabase(3),
     UnknownSetting(4),
-    SyntexException(5),
+    SyntaxException(5),
     BadArguments(6),
     IllegalDataType(7),
     UnknownFunction(8),

--- a/common/planners/src/plan_rewriter.rs
+++ b/common/planners/src/plan_rewriter.rs
@@ -245,7 +245,7 @@ impl RewriteHelper {
                     let hash_expr = format!("{:?}", expr);
 
                     if hash_result != hash_expr {
-                        return Result::Err(ErrorCodes::SyntexException(format!(
+                        return Result::Err(ErrorCodes::SyntaxException(format!(
                             "Planner Error: Different expressions with the same alias {}",
                             alias
                         )));
@@ -270,7 +270,7 @@ impl RewriteHelper {
 
                 // x + 1 --> y, y + 1 --> x
                 if data.inside_aliases.contains(field) {
-                    return Result::Err(ErrorCodes::SyntexException(format!(
+                    return Result::Err(ErrorCodes::SyntaxException(format!(
                         "Planner Error: Cyclic aliases: {}",
                         field
                     )));
@@ -319,7 +319,7 @@ impl RewriteHelper {
 
             ExpressionAction::Alias(alias, plan) => {
                 if data.inside_aliases.contains(alias) {
-                    return Result::Err(ErrorCodes::SyntexException(format!(
+                    return Result::Err(ErrorCodes::SyntaxException(format!(
                         "Planner Error: Cyclic aliases: {}",
                         alias
                     )));

--- a/fusequery/query/src/pipelines/transforms/transform_filter.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_filter.rs
@@ -29,7 +29,7 @@ impl FilterTransform {
     pub fn try_create(predicate: ExpressionAction, having: bool) -> Result<Self> {
         let func = predicate.to_function()?;
         if !having && func.is_aggregator() {
-            return Result::Err(ErrorCodes::SyntexException(format!(
+            return Result::Err(ErrorCodes::SyntaxException(format!(
                 "Aggregate function {:?} is found in WHERE in query",
                 predicate
             )));

--- a/fusequery/query/src/sql/plan_parser.rs
+++ b/fusequery/query/src/sql/plan_parser.rs
@@ -56,7 +56,7 @@ impl PlanParser {
                 .first()
                 .map(|statement| self.statement_to_plan(&statement))
                 .unwrap_or_else(|| {
-                    Result::Err(ErrorCodes::SyntexException("Only support single query"))
+                    Result::Err(ErrorCodes::SyntaxException("Only support single query"))
                 })
         })
     }
@@ -93,7 +93,7 @@ impl PlanParser {
             Statement::SetVariable {
                 variable, value, ..
             } => self.set_variable_to_plan(variable, value),
-            _ => Result::Err(ErrorCodes::SyntexException(format!(
+            _ => Result::Err(ErrorCodes::SyntaxException(format!(
                 "Unsupported statement {:?}",
                 statement
             )))
@@ -112,7 +112,7 @@ impl PlanParser {
     /// DfCreateDatabase to plan.
     pub fn sql_create_database_to_plan(&self, create: &DfCreateDatabase) -> Result<PlanNode> {
         if create.name.0.is_empty() {
-            return Result::Err(ErrorCodes::SyntexException("Create database name is empty"));
+            return Result::Err(ErrorCodes::SyntaxException("Create database name is empty"));
         }
         let name = create.name.0[0].value.clone();
 
@@ -132,7 +132,7 @@ impl PlanParser {
     /// DfDropDatabase to plan.
     pub fn sql_drop_database_to_plan(&self, drop: &DfDropDatabase) -> Result<PlanNode> {
         if drop.name.0.is_empty() {
-            return Result::Err(ErrorCodes::SyntexException("Drop database name is empty"));
+            return Result::Err(ErrorCodes::SyntaxException("Drop database name is empty"));
         }
         let name = drop.name.0[0].value.clone();
 
@@ -150,7 +150,7 @@ impl PlanParser {
     pub fn sql_create_table_to_plan(&self, create: &DfCreateTable) -> Result<PlanNode> {
         let mut db = self.ctx.get_current_database();
         if create.name.0.is_empty() {
-            return Result::Err(ErrorCodes::SyntexException("Create table name is empty"));
+            return Result::Err(ErrorCodes::SyntaxException("Create table name is empty"));
         }
         let mut table = create.name.0[0].value.clone();
         if create.name.0.len() > 1 {
@@ -194,7 +194,7 @@ impl PlanParser {
     pub fn sql_drop_table_to_plan(&self, drop: &DfDropTable) -> Result<PlanNode> {
         let mut db = self.ctx.get_current_database();
         if drop.name.0.is_empty() {
-            return Result::Err(ErrorCodes::SyntexException("Drop table name is empty"));
+            return Result::Err(ErrorCodes::SyntaxException("Drop table name is empty"));
         }
         let mut table = drop.name.0[0].value.clone();
         if drop.name.0.len() > 1 {
@@ -310,7 +310,7 @@ impl PlanParser {
         match from.len() {
             0 => self.plan_with_dummy_source(),
             1 => self.plan_table_with_joins(&from[0]),
-            _ => Result::Err(ErrorCodes::SyntexException("Cannot support JOIN clause"))
+            _ => Result::Err(ErrorCodes::SyntaxException("Cannot support JOIN clause"))
         }
     }
 
@@ -434,7 +434,7 @@ impl PlanParser {
                     last_field,
                     fractional_seconds_precision
                 ),
-                other => Result::Err(ErrorCodes::SyntexException(format!(
+                other => Result::Err(ErrorCodes::SyntaxException(format!(
                     "Unsupported value expression: {}, type: {:?}",
                     value, other
                 )))
@@ -524,7 +524,7 @@ impl PlanParser {
                     args
                 })
             }
-            other => Result::Err(ErrorCodes::SyntexException(format!(
+            other => Result::Err(ErrorCodes::SyntaxException(format!(
                 "Unsupported expression: {}, type: {:?}",
                 expr, other
             )))
@@ -647,7 +647,7 @@ impl PlanParser {
                     .sql_to_rex(&limit_expr, &input.schema())
                     .and_then(|limit_expr| match limit_expr {
                         ExpressionAction::Literal(DataValue::UInt64(Some(n))) => Ok(n as usize),
-                        _ => Err(ErrorCodes::SyntexException(
+                        _ => Err(ErrorCodes::SyntaxException(
                             "Unexpected expression for LIMIT clause"
                         ))
                     })?;

--- a/fusequery/query/src/sql/sql_common.rs
+++ b/fusequery/query/src/sql/sql_common.rs
@@ -50,28 +50,28 @@ impl SQLCommon {
         fractional_seconds_precision: &Option<u64>
     ) -> Result<ExpressionAction> {
         if leading_field.is_some() {
-            return Result::Err(ErrorCodes::SyntexException(format!(
+            return Result::Err(ErrorCodes::SyntaxException(format!(
                 "Unsupported Interval Expression with leading_field {:?}",
                 leading_field
             )));
         }
 
         if leading_precision.is_some() {
-            return Result::Err(ErrorCodes::SyntexException(format!(
+            return Result::Err(ErrorCodes::SyntaxException(format!(
                 "Unsupported Interval Expression with leading_precision {:?}",
                 leading_precision
             )));
         }
 
         if last_field.is_some() {
-            return Result::Err(ErrorCodes::SyntexException(format!(
+            return Result::Err(ErrorCodes::SyntaxException(format!(
                 "Unsupported Interval Expression with last_field {:?}",
                 last_field
             )));
         }
 
         if fractional_seconds_precision.is_some() {
-            return Result::Err(ErrorCodes::SyntexException(format!(
+            return Result::Err(ErrorCodes::SyntaxException(format!(
                 "Unsupported Interval Expression with fractional_seconds_precision {:?}",
                 fractional_seconds_precision
             )));
@@ -105,7 +105,7 @@ impl SQLCommon {
             let interval_period = match f32::from_str(interval_period_str) {
                 Ok(n) => n,
                 Err(_) => {
-                    return Result::Err(ErrorCodes::SyntexException(format!(
+                    return Result::Err(ErrorCodes::SyntaxException(format!(
                         "Unsupported Interval Expression with value {:?}",
                         value
                     )))
@@ -113,7 +113,7 @@ impl SQLCommon {
             };
 
             if interval_period > (i32::MAX as f32) {
-                return Result::Err(ErrorCodes::SyntexException(format!(
+                return Result::Err(ErrorCodes::SyntaxException(format!(
                     "Interval field value out of range: {:?}",
                     value
                 )));
@@ -130,7 +130,7 @@ impl SQLCommon {
                 "seconds" | "second" => Ok((0, 0, interval_period * MILLIS_PER_SECOND)),
                 "milliseconds" | "millisecond" => Ok((0, 0, interval_period)),
                 _ => {
-                    return Result::Err(ErrorCodes::SyntexException(format!(
+                    return Result::Err(ErrorCodes::SyntaxException(format!(
                         "Invalid input syntax for type interval: {:?}",
                         value
                     )))
@@ -158,7 +158,7 @@ impl SQLCommon {
             result_month += diff_month as i64;
 
             if result_month > (i32::MAX as i64) {
-                return Result::Err(ErrorCodes::SyntexException(format!(
+                return Result::Err(ErrorCodes::SyntaxException(format!(
                     "Interval field value out of range: {:?}",
                     value
                 )));
@@ -167,7 +167,7 @@ impl SQLCommon {
             result_days += diff_days as i64;
 
             if result_days > (i32::MAX as i64) {
-                return Result::Err(ErrorCodes::SyntexException(format!(
+                return Result::Err(ErrorCodes::SyntaxException(format!(
                     "Interval field value out of range: {:?}",
                     value
                 )));
@@ -176,7 +176,7 @@ impl SQLCommon {
             result_millis += diff_millis as i64;
 
             if result_millis > (i32::MAX as i64) {
-                return Result::Err(ErrorCodes::SyntexException(format!(
+                return Result::Err(ErrorCodes::SyntaxException(format!(
                     "Interval field value out of range: {:?}",
                     value
                 )));
@@ -190,7 +190,7 @@ impl SQLCommon {
         // It's not possible to store complex intervals
         // It's possible to do select (NOW() + INTERVAL '1 year') + INTERVAL '1 day'; as workaround
         if result_month != 0 && (result_days != 0 || result_millis != 0) {
-            return Result::Err(ErrorCodes::SyntexException(
+            return Result::Err(ErrorCodes::SyntaxException(
                 format!(
                     "DF does not support intervals that have both a Year/Month part as well as Days/Hours/Mins/Seconds: {:?}. Hint: try breaking the interval into two parts, one with Year/Month and the other with Days/Hours/Mins/Seconds - e.g. (NOW() + INTERVAL '1 year') + INTERVAL '1 day'",
                     value


### PR DESCRIPTION
## Summary

Summary about this PR

fix typo
rename `ErrorCodes::SyntexException` to `ErrorCodes::SyntaxException`

## Changelog

- Other

## Related Issues

Fixes #578

