### PR TITLE
Change arrow to crate.io instead of git sha

### DIFF
--- a/.github/workflows/performance-tests-standalone.yml
+++ b/.github/workflows/performance-tests-standalone.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           bash ./scripts/setup/dev_setup.sh
 
-      - uses: actions-rs/cargo@v1
+      - name: Build release
         run: RUST_BACKTRACE=full RUSTFLAGS="-C target-cpu=native" cargo build --bin=fuse-query --release
 
       - name: Run Performance Tests with Standalone mode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,8 +90,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrow"
-version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-rs?rev=a870b24#a870b24bd4eb76d3e0e5c718c9956a7dcdee52fd"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cdf087304d5cdd743abd621b4b1b388848d29491932dae6f676ec89ebda0ae"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -102,7 +103,7 @@ dependencies = [
  "lazy_static",
  "lexical-core",
  "multiversion",
- "num 0.3.1",
+ "num",
  "rand 0.7.3",
  "regex",
  "serde",
@@ -112,8 +113,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-rs?rev=a870b24#a870b24bd4eb76d3e0e5c718c9956a7dcdee52fd"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be523cfd3669eee90aac4223cbc6fa8c4fd4cecf3281f061e5421e3e8aa91148"
 dependencies = [
  "arrow",
  "bytes 1.0.1",
@@ -1281,7 +1283,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "msql-srv",
- "num 0.4.0",
+ "num",
  "num_cpus",
  "paste",
  "pretty_assertions",
@@ -1325,7 +1327,7 @@ dependencies = [
  "maplit",
  "metrics",
  "metrics-exporter-prometheus",
- "num 0.4.0",
+ "num",
  "num_cpus",
  "paste",
  "pretty_assertions",
@@ -2252,29 +2254,15 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
-dependencies = [
- "num-bigint 0.3.2",
- "num-complex 0.3.1",
- "num-integer",
- "num-iter",
- "num-rational 0.3.2",
- "num-traits",
-]
-
-[[package]]
-name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
  "num-bigint 0.4.0",
- "num-complex 0.4.0",
+ "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.4.0",
+ "num-rational",
  "num-traits",
 ]
 
@@ -2283,17 +2271,6 @@ name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg 1.0.1",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -2331,15 +2308,6 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
@@ -2364,18 +2332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg 1.0.1",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg 1.0.1",
- "num-bigint 0.3.2",
  "num-integer",
  "num-traits",
 ]
@@ -2507,17 +2463,18 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "4.0.0-SNAPSHOT"
-source = "git+https://github.com/apache/arrow-rs?rev=a870b24#a870b24bd4eb76d3e0e5c718c9956a7dcdee52fd"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193b8db290021fa28a6447df8f433e39b3caab20ee08b874d0a5c1c34aef68de"
 dependencies = [
  "arrow",
- "base64 0.12.3",
+ "base64 0.13.0",
  "brotli",
  "byteorder",
  "chrono",
  "flate2",
  "lz4",
- "num-bigint 0.3.2",
+ "num-bigint 0.4.0",
  "parquet-format",
  "snap",
  "thrift",
@@ -4332,18 +4289,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.7.0+zstd.1.4.9"
+version = "0.8.1+zstd.1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9428752481d8372e15b1bf779ea518a179ad6c771cca2d2c60e4fbff3cc2cd52"
+checksum = "357d6bb1bd9c6f6a55a5a15c74d01260b272f724dc60cc829b86ebd2172ac5ef"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "3.1.0+zstd.1.4.9"
+version = "4.1.0+zstd.1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa1926623ad7fe406e090555387daf73db555b948134b4d73eac5eb08fb666d"
+checksum = "d30375f78e185ca4c91930f42ea2c0162f9aa29737032501f93b79266d985ae7"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -4351,9 +4308,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.5.0+zstd.1.4.9"
+version = "1.6.0+zstd.1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6c094340240369025fc6b731b054ee2a834328fa584310ac96aa4baebdc465"
+checksum = "2141bed8922b427761470e6bbfeff255da94fa20b0bbeab0d9297fcaf71e3aa7"
 dependencies = [
  "cc",
  "libc",

--- a/common/arrow/Cargo.toml
+++ b/common/arrow/Cargo.toml
@@ -10,9 +10,9 @@ edition = "2018"
 # Workspace dependencies
 
 # Github dependencies
-arrow = { git = "https://github.com/apache/arrow-rs", rev = "a870b24"}
-arrow-flight = { git = "https://github.com/apache/arrow-rs", rev = "a870b24"}
-parquet = { git = "https://github.com/apache/arrow-rs", rev = "a870b24", features = ["arrow"]}
+arrow = { version = "4.0" }
+arrow-flight = { version = "4.0" }
+parquet = { version = "4.0", features = ["arrow"] }
 
 # Crates.io dependencies
 


### PR DESCRIPTION
## Summary

Change arrow to crate.io instead of git sha

## Changelog

- Improvement

## Related Issues

Fixes #602 

## Test Plan

Unit Tests
Stateless Tests

