### PR TITLE
Run rustfmt to get a default format

### DIFF
--- a/common/datablocks/src/data_block.rs
+++ b/common/datablocks/src/data_block.rs
@@ -19,7 +19,7 @@ use crate::pretty_format_blocks;
 #[derive(Clone)]
 pub struct DataBlock {
     schema: DataSchemaRef,
-    columns: Vec<DataArrayRef>
+    columns: Vec<DataArrayRef>,
 }
 
 impl DataBlock {
@@ -30,7 +30,7 @@ impl DataBlock {
     pub fn empty() -> Self {
         DataBlock {
             schema: Arc::new(DataSchema::empty()),
-            columns: vec![]
+            columns: vec![],
         }
     }
 

--- a/common/datablocks/src/data_block_kernel.rs
+++ b/common/datablocks/src/data_block_kernel.rs
@@ -13,7 +13,7 @@ use crate::DataBlock;
 pub struct SortColumnDescription {
     pub column_name: String,
     pub asc: bool,
-    pub nulls_first: bool
+    pub nulls_first: bool,
 }
 
 impl DataBlock {
@@ -58,7 +58,7 @@ impl DataBlock {
     pub fn sort_block(
         block: &DataBlock,
         sort_columns_descriptions: &[SortColumnDescription],
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> Result<DataBlock> {
         let order_columns = sort_columns_descriptions
             .iter()
@@ -67,8 +67,8 @@ impl DataBlock {
                     values: block.try_column_by_name(&f.column_name)?.clone(),
                     options: Some(compute::SortOptions {
                         descending: !f.asc,
-                        nulls_first: f.nulls_first
-                    })
+                        nulls_first: f.nulls_first,
+                    }),
                 })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -87,7 +87,7 @@ impl DataBlock {
         lhs: &DataBlock,
         rhs: &DataBlock,
         sort_columns_descriptions: &[SortColumnDescription],
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> Result<DataBlock> {
         if lhs.num_rows() == 0 {
             return Ok(rhs.clone());
@@ -111,7 +111,7 @@ impl DataBlock {
             .map(|f| {
                 Ok(compute::SortOptions {
                     descending: !f.asc,
-                    nulls_first: f.nulls_first
+                    nulls_first: f.nulls_first,
                 })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -121,7 +121,7 @@ impl DataBlock {
 
         let indices = match limit {
             Some(limit) => &indices[0..limit.min(indices.len())],
-            _ => &indices
+            _ => &indices,
         };
 
         let arrays = lhs
@@ -137,7 +137,7 @@ impl DataBlock {
     pub fn merge_sort_blocks(
         blocks: &[DataBlock],
         sort_columns_descriptions: &[SortColumnDescription],
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> Result<DataBlock> {
         match blocks.len() {
             0 => Result::Err(ErrorCodes::EmptyData("Can't merge empty blocks")),
@@ -146,18 +146,18 @@ impl DataBlock {
                 &blocks[0],
                 &blocks[1],
                 sort_columns_descriptions,
-                limit
+                limit,
             ),
             _ => {
                 let left = DataBlock::merge_sort_blocks(
                     &blocks[0..blocks.len() / 2],
                     sort_columns_descriptions,
-                    limit
+                    limit,
                 )?;
                 let right = DataBlock::merge_sort_blocks(
                     &blocks[blocks.len() / 2..blocks.len()],
                     sort_columns_descriptions,
-                    limit
+                    limit,
                 )?;
                 DataBlock::merge_sort_block(&left, &right, sort_columns_descriptions, limit)
             }

--- a/common/datablocks/src/data_block_kernel_test.rs
+++ b/common/datablocks/src/data_block_kernel_test.rs
@@ -15,10 +15,13 @@ fn test_data_block_kernel_take() -> anyhow::Result<()> {
         DataField::new("b", DataType::Utf8, false),
     ]);
 
-    let raw = DataBlock::create(schema.clone(), vec![
-        Arc::new(Int64Array::from(vec![1, 2, 3])),
-        Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
-    ]);
+    let raw = DataBlock::create(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
+        ],
+    );
 
     let take = DataBlock::block_take_by_indices(&raw, &[0, 2])?;
     assert_eq!(raw.schema(), take.schema());
@@ -50,18 +53,27 @@ fn test_data_block_kernel_concat() -> anyhow::Result<()> {
     ]);
 
     let blocks = vec![
-        DataBlock::create(schema.clone(), vec![
-            Arc::new(Int64Array::from(vec![1, 2, 3])),
-            Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
-        ]),
-        DataBlock::create(schema.clone(), vec![
-            Arc::new(Int64Array::from(vec![4, 5, 6])),
-            Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
-        ]),
-        DataBlock::create(schema.clone(), vec![
-            Arc::new(Int64Array::from(vec![7, 8, 9])),
-            Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
-        ]),
+        DataBlock::create(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
+            ],
+        ),
+        DataBlock::create(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![4, 5, 6])),
+                Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
+            ],
+        ),
+        DataBlock::create(
+            schema.clone(),
+            vec![
+                Arc::new(Int64Array::from(vec![7, 8, 9])),
+                Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
+            ],
+        ),
     ];
 
     let results = DataBlock::concat_blocks(&blocks)?;
@@ -100,16 +112,19 @@ fn test_data_block_sort() -> anyhow::Result<()> {
         DataField::new("b", DataType::Utf8, false),
     ]);
 
-    let raw = DataBlock::create(schema.clone(), vec![
-        Arc::new(Int64Array::from(vec![6, 4, 3, 2, 1, 7])),
-        Arc::new(StringArray::from(vec!["b1", "b2", "b3", "b4", "b5", "b6"])),
-    ]);
+    let raw = DataBlock::create(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![6, 4, 3, 2, 1, 7])),
+            Arc::new(StringArray::from(vec!["b1", "b2", "b3", "b4", "b5", "b6"])),
+        ],
+    );
 
     {
         let options = vec![SortColumnDescription {
             column_name: "a".to_owned(),
             asc: true,
-            nulls_first: false
+            nulls_first: false,
         }];
         let results = DataBlock::sort_block(&raw, &options, Some(3))?;
         assert_eq!(raw.schema(), results.schema());
@@ -130,7 +145,7 @@ fn test_data_block_sort() -> anyhow::Result<()> {
         let options = vec![SortColumnDescription {
             column_name: "a".to_owned(),
             asc: false,
-            nulls_first: false
+            nulls_first: false,
         }];
         let results = DataBlock::sort_block(&raw, &options, Some(3))?;
         assert_eq!(raw.schema(), results.schema());

--- a/common/datablocks/src/data_block_test.rs
+++ b/common/datablocks/src/data_block_test.rs
@@ -12,9 +12,10 @@ fn test_data_block() -> anyhow::Result<()> {
 
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Int64, false)]);
 
-    let block = DataBlock::create(schema.clone(), vec![Arc::new(Int64Array::from(vec![
-        1, 2, 3,
-    ]))]);
+    let block = DataBlock::create(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![1, 2, 3]))],
+    );
     assert_eq!(&schema, block.schema());
 
     assert_eq!(3, block.num_rows());

--- a/common/datavalues/src/data_array_aggregate.rs
+++ b/common/datavalues/src/data_array_aggregate.rs
@@ -27,7 +27,7 @@ impl DataArrayAggregate {
     #[inline]
     pub fn data_array_aggregate_op(
         op: DataValueAggregateOperator,
-        value: DataArrayRef
+        value: DataArrayRef,
     ) -> Result<DataValue> {
         match value.data_type() {
             DataType::Int8 => match op {
@@ -259,13 +259,13 @@ impl DataArrayAggregate {
                     "DataValue Error: Unsupported data_array_{} for data type: {:?}",
                     op,
                     value.data_type()
-                )))
+                ))),
             },
             _not_support_data_type => Result::Err(ErrorCodes::BadDataValueType(format!(
                 "DataValue Error: Unsupported data_array_{} for data type: {:?}",
                 op,
                 value.data_type()
-            )))
+            ))),
         }
     }
 }

--- a/common/datavalues/src/data_array_aggregate_test.rs
+++ b/common/datavalues/src/data_array_aggregate_test.rs
@@ -16,7 +16,7 @@ fn test_array_aggregate() {
         args: Vec<DataArrayRef>,
         expect: Vec<DataValue>,
         error: Vec<&'static str>,
-        op: DataValueAggregateOperator
+        op: DataValueAggregateOperator,
     }
 
     let tests = vec![
@@ -151,7 +151,7 @@ fn test_array_aggregate() {
             let result = DataArrayAggregate::data_array_aggregate_op(t.op.clone(), args.clone());
             match result {
                 Ok(v) => assert_eq!(v, t.expect[i]),
-                Err(e) => assert_eq!(t.error[i], e.to_string())
+                Err(e) => assert_eq!(t.error[i], e.to_string()),
             }
         }
     }

--- a/common/datavalues/src/data_array_arithmetic.rs
+++ b/common/datavalues/src/data_array_arithmetic.rs
@@ -30,7 +30,7 @@ impl DataArrayArithmetic {
     pub fn data_array_arithmetic_op(
         op: DataValueArithmeticOperator,
         left: &DataColumnarValue,
-        right: &DataColumnarValue
+        right: &DataColumnarValue,
     ) -> Result<DataArrayRef> {
         let (left_array, right_array) = match (left, right) {
             (DataColumnarValue::Array(left_array), DataColumnarValue::Array(right_array)) => {
@@ -44,14 +44,14 @@ impl DataArrayArithmetic {
             }
             (DataColumnarValue::Scalar(left_scalar), DataColumnarValue::Scalar(right_scalar)) => (
                 left_scalar.to_array_with_size(1)?,
-                right_scalar.to_array_with_size(1)?
-            )
+                right_scalar.to_array_with_size(1)?,
+            ),
         };
 
         let coercion_type = super::data_type::numerical_arithmetic_coercion(
             &op,
             &left_array.data_type(),
-            &right_array.data_type()
+            &right_array.data_type(),
         )?;
         let left_array = data_array_cast(&left_array, &coercion_type)?;
         let right_array = data_array_cast(&right_array, &coercion_type)?;

--- a/common/datavalues/src/data_array_arithmetic_test.rs
+++ b/common/datavalues/src/data_array_arithmetic_test.rs
@@ -16,7 +16,7 @@ fn test_array_arithmetic() {
         args: Vec<Vec<DataArrayRef>>,
         expect: Vec<DataArrayRef>,
         error: Vec<&'static str>,
-        op: DataValueArithmeticOperator
+        op: DataValueArithmeticOperator,
     }
 
     let tests = vec![
@@ -87,7 +87,7 @@ fn test_array_arithmetic() {
                 Arc::new(Float64Array::from(vec![5.0, 5.0, 5.0, 5.0])),
                 Arc::new(Float64Array::from(vec![5.0, 5.0, 5.0, 5.0])),
             ],
-            error: vec!["Code: 10, displayText = DataValue Error: Unsupported (Utf8) plus (Utf8)."]
+            error: vec!["Code: 10, displayText = DataValue Error: Unsupported (Utf8) plus (Utf8)."],
         },
         ArrayTest {
             name: "minus-passed",
@@ -158,7 +158,7 @@ fn test_array_arithmetic() {
             ],
             error: vec![
                 "Code: 10, displayText = DataValue Error: Unsupported (Utf8) minus (Utf8).",
-            ]
+            ],
         },
         ArrayTest {
             name: "mul-passed",
@@ -224,7 +224,7 @@ fn test_array_arithmetic() {
             ],
             error: vec![
                 "Code: 10, displayText = DataValue Error: Unsupported (Utf8) multiply (Utf8).",
-            ]
+            ],
         },
         ArrayTest {
             name: "div-passed",
@@ -290,7 +290,7 @@ fn test_array_arithmetic() {
             ],
             error: vec![
                 "Code: 10, displayText = DataValue Error: Unsupported (Utf8) divide (Utf8).",
-            ]
+            ],
         },
     ];
 
@@ -299,7 +299,7 @@ fn test_array_arithmetic() {
             let result = DataArrayArithmetic::data_array_arithmetic_op(
                 t.op.clone(),
                 &DataColumnarValue::Array(args[0].clone()),
-                &DataColumnarValue::Array(args[1].clone())
+                &DataColumnarValue::Array(args[1].clone()),
             );
             match result {
                 Ok(v) => assert_eq!(
@@ -315,7 +315,7 @@ fn test_array_arithmetic() {
                     "failed in the test: {}, case: {}",
                     t.name,
                     i
-                )
+                ),
             }
         }
     }
@@ -334,7 +334,7 @@ fn test_array_scalar_arithmetic() {
         op: DataValueArithmeticOperator,
         scalar: DataValue,
         expect: DataArrayRef,
-        error: &'static str
+        error: &'static str,
     }
 
     let tests = vec![
@@ -344,7 +344,7 @@ fn test_array_scalar_arithmetic() {
             scalar: DataValue::Int8(Some(1)),
             op: DataValueArithmeticOperator::Plus,
             expect: Arc::new(Int16Array::from(vec![5, 5, 5, 5])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "sub-passed",
@@ -352,7 +352,7 @@ fn test_array_scalar_arithmetic() {
             scalar: DataValue::Int8(Some(1)),
             op: DataValueArithmeticOperator::Minus,
             expect: Arc::new(Int16Array::from(vec![3, 3, 3, 3])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "mul-passed",
@@ -360,7 +360,7 @@ fn test_array_scalar_arithmetic() {
             scalar: DataValue::Int8(Some(1)),
             op: DataValueArithmeticOperator::Mul,
             expect: Arc::new(Int16Array::from(vec![4, 4, 4, 4])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "div-passed",
@@ -368,7 +368,7 @@ fn test_array_scalar_arithmetic() {
             scalar: DataValue::Int8(Some(2)),
             op: DataValueArithmeticOperator::Div,
             expect: Arc::new(Float64Array::from(vec![2.0, 2.0, 2.0, 2.0])),
-            error: ""
+            error: "",
         },
     ];
 
@@ -376,7 +376,7 @@ fn test_array_scalar_arithmetic() {
         let result = DataArrayArithmetic::data_array_arithmetic_op(
             t.op.clone(),
             &DataColumnarValue::Array(t.array),
-            &DataColumnarValue::Scalar(t.scalar)
+            &DataColumnarValue::Scalar(t.scalar),
         );
         match result {
             Ok(v) => assert_eq!(
@@ -385,7 +385,7 @@ fn test_array_scalar_arithmetic() {
                 "failed in the test: {}",
                 t.name
             ),
-            Err(e) => assert_eq!(t.error, e.to_string(), "failed in the test: {}", t.name)
+            Err(e) => assert_eq!(t.error, e.to_string(), "failed in the test: {}", t.name),
         }
     }
 }
@@ -403,7 +403,7 @@ fn test_scalar_array_arithmetic() {
         op: DataValueArithmeticOperator,
         scalar: DataValue,
         expect: DataArrayRef,
-        error: &'static str
+        error: &'static str,
     }
 
     let tests = vec![
@@ -413,7 +413,7 @@ fn test_scalar_array_arithmetic() {
             scalar: DataValue::Int8(Some(1)),
             op: DataValueArithmeticOperator::Plus,
             expect: Arc::new(Int16Array::from(vec![5, 5, 5, 5])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "sub-passed",
@@ -421,7 +421,7 @@ fn test_scalar_array_arithmetic() {
             scalar: DataValue::Int8(Some(1)),
             op: DataValueArithmeticOperator::Minus,
             expect: Arc::new(Int16Array::from(vec![-3, -3, -3, -3])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "mul-passed",
@@ -429,7 +429,7 @@ fn test_scalar_array_arithmetic() {
             scalar: DataValue::Int8(Some(1)),
             op: DataValueArithmeticOperator::Mul,
             expect: Arc::new(Int16Array::from(vec![4, 4, 4, 4])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "div-passed",
@@ -437,7 +437,7 @@ fn test_scalar_array_arithmetic() {
             scalar: DataValue::Int8(Some(8)),
             op: DataValueArithmeticOperator::Div,
             expect: Arc::new(Float64Array::from(vec![2.0, 2.0, 2.0, 2.0])),
-            error: ""
+            error: "",
         },
     ];
 
@@ -445,7 +445,7 @@ fn test_scalar_array_arithmetic() {
         let result = DataArrayArithmetic::data_array_arithmetic_op(
             t.op.clone(),
             &DataColumnarValue::Scalar(t.scalar),
-            &DataColumnarValue::Array(t.array)
+            &DataColumnarValue::Array(t.array),
         );
         match result {
             Ok(v) => assert_eq!(
@@ -454,7 +454,7 @@ fn test_scalar_array_arithmetic() {
                 "failed in the test: {}",
                 t.name
             ),
-            Err(e) => assert_eq!(t.error, e.to_string(), "failed in the test: {}", t.name)
+            Err(e) => assert_eq!(t.error, e.to_string(), "failed in the test: {}", t.name),
         }
     }
 }

--- a/common/datavalues/src/data_array_comparison.rs
+++ b/common/datavalues/src/data_array_comparison.rs
@@ -32,13 +32,13 @@ impl DataArrayComparison {
     pub fn data_array_comparison_op(
         op: DataValueComparisonOperator,
         left: &DataColumnarValue,
-        right: &DataColumnarValue
+        right: &DataColumnarValue,
     ) -> Result<DataArrayRef> {
         match (left, right) {
             (DataColumnarValue::Array(left_array), DataColumnarValue::Array(right_array)) => {
                 let coercion_type = super::data_type::equal_coercion(
                     &left_array.data_type(),
-                    &right_array.data_type()
+                    &right_array.data_type(),
                 )?;
                 let left_array = data_array_cast(&left_array, &coercion_type)?;
                 let right_array = data_array_cast(&right_array, &coercion_type)?;
@@ -125,7 +125,7 @@ impl DataArrayComparison {
             (DataColumnarValue::Scalar(left_scala), DataColumnarValue::Scalar(right_scalar)) => {
                 let coercion_type = super::data_type::equal_coercion(
                     &left_scala.data_type(),
-                    &right_scalar.data_type()
+                    &right_scalar.data_type(),
                 )?;
                 let left_array =
                     data_array_cast(&left_scala.to_array_with_size(1)?, &coercion_type)?;

--- a/common/datavalues/src/data_array_comparison_test.rs
+++ b/common/datavalues/src/data_array_comparison_test.rs
@@ -16,7 +16,7 @@ fn test_array_comparison() {
         args: Vec<Vec<DataArrayRef>>,
         expect: Vec<DataArrayRef>,
         error: Vec<&'static str>,
-        op: DataValueComparisonOperator
+        op: DataValueComparisonOperator,
     }
 
     let tests = vec![
@@ -47,7 +47,7 @@ fn test_array_comparison() {
                 Arc::new(BooleanArray::from(vec![false, false, true, false])),
                 Arc::new(BooleanArray::from(vec![true, true, true, true])),
             ],
-            error: vec![""]
+            error: vec![""],
         },
         ArrayTest {
             name: "lt-passed",
@@ -59,7 +59,7 @@ fn test_array_comparison() {
             expect: vec![Arc::new(BooleanArray::from(vec![
                 false, false, true, false,
             ]))],
-            error: vec![""]
+            error: vec![""],
         },
         ArrayTest {
             name: "lt-eq-passed",
@@ -69,7 +69,7 @@ fn test_array_comparison() {
             ]],
             op: DataValueComparisonOperator::LtEq,
             expect: vec![Arc::new(BooleanArray::from(vec![true, true, true, false]))],
-            error: vec![""]
+            error: vec![""],
         },
         ArrayTest {
             name: "gt-passed",
@@ -81,7 +81,7 @@ fn test_array_comparison() {
             expect: vec![Arc::new(BooleanArray::from(vec![
                 false, false, false, true,
             ]))],
-            error: vec![""]
+            error: vec![""],
         },
         ArrayTest {
             name: "gt-eq-passed",
@@ -91,7 +91,7 @@ fn test_array_comparison() {
             ]],
             op: DataValueComparisonOperator::GtEq,
             expect: vec![Arc::new(BooleanArray::from(vec![true, true, false, true]))],
-            error: vec![""]
+            error: vec![""],
         },
         ArrayTest {
             name: "not-eq-passed",
@@ -101,7 +101,7 @@ fn test_array_comparison() {
             ]],
             op: DataValueComparisonOperator::NotEq,
             expect: vec![Arc::new(BooleanArray::from(vec![false, false, true, true]))],
-            error: vec![""]
+            error: vec![""],
         },
     ];
 
@@ -110,11 +110,11 @@ fn test_array_comparison() {
             let result = DataArrayComparison::data_array_comparison_op(
                 t.op.clone(),
                 &DataColumnarValue::Array(args[0].clone()),
-                &DataColumnarValue::Array(args[1].clone())
+                &DataColumnarValue::Array(args[1].clone()),
             );
             match result {
                 Ok(v) => assert_eq!(v.as_ref(), t.expect[i].as_ref()),
-                Err(e) => assert_eq!(t.error[i], e.to_string())
+                Err(e) => assert_eq!(t.error[i], e.to_string()),
             }
         }
     }
@@ -133,7 +133,7 @@ fn test_array_scalar_comparison() {
         scalar: DataValue,
         expect: DataArrayRef,
         error: &'static str,
-        op: DataValueComparisonOperator
+        op: DataValueComparisonOperator,
     }
 
     let tests = vec![
@@ -143,7 +143,7 @@ fn test_array_scalar_comparison() {
             scalar: DataValue::Int8(Some(3)),
             op: DataValueComparisonOperator::Eq,
             expect: Arc::new(BooleanArray::from(vec![false, true, false, false])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "eq-different-type-passed",
@@ -151,7 +151,7 @@ fn test_array_scalar_comparison() {
             scalar: DataValue::Int32(Some(3)),
             op: DataValueComparisonOperator::Eq,
             expect: Arc::new(BooleanArray::from(vec![false, true, false, false])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "lt-passed",
@@ -159,7 +159,7 @@ fn test_array_scalar_comparison() {
             scalar: DataValue::Int8(Some(3)),
             op: DataValueComparisonOperator::Lt,
             expect: Arc::new(BooleanArray::from(vec![false, false, true, true])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "lt-eq-passed",
@@ -167,7 +167,7 @@ fn test_array_scalar_comparison() {
             scalar: DataValue::Int8(Some(3)),
             op: DataValueComparisonOperator::LtEq,
             expect: Arc::new(BooleanArray::from(vec![false, true, true, true])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "gt-passed",
@@ -175,7 +175,7 @@ fn test_array_scalar_comparison() {
             scalar: DataValue::Int8(Some(3)),
             op: DataValueComparisonOperator::Gt,
             expect: Arc::new(BooleanArray::from(vec![true, false, false, false])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "gt-eq-passed",
@@ -183,7 +183,7 @@ fn test_array_scalar_comparison() {
             scalar: DataValue::Int8(Some(3)),
             op: DataValueComparisonOperator::GtEq,
             expect: Arc::new(BooleanArray::from(vec![true, true, false, false])),
-            error: ""
+            error: "",
         },
     ];
 
@@ -191,11 +191,11 @@ fn test_array_scalar_comparison() {
         let result = DataArrayComparison::data_array_comparison_op(
             t.op.clone(),
             &DataColumnarValue::Array(t.array),
-            &DataColumnarValue::Scalar(t.scalar)
+            &DataColumnarValue::Scalar(t.scalar),
         );
         match result {
             Ok(v) => assert_eq!(v.as_ref(), t.expect.as_ref()),
-            Err(e) => assert_eq!(t.error, e.to_string())
+            Err(e) => assert_eq!(t.error, e.to_string()),
         }
     }
 }
@@ -213,7 +213,7 @@ fn test_scalar_array_comparison() {
         scalar: DataValue,
         expect: DataArrayRef,
         error: &'static str,
-        op: DataValueComparisonOperator
+        op: DataValueComparisonOperator,
     }
 
     let tests = vec![
@@ -223,7 +223,7 @@ fn test_scalar_array_comparison() {
             scalar: DataValue::Int8(Some(3)),
             op: DataValueComparisonOperator::Eq,
             expect: Arc::new(BooleanArray::from(vec![false, true, false, false])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "eq-different-type-passed",
@@ -231,7 +231,7 @@ fn test_scalar_array_comparison() {
             scalar: DataValue::Int32(Some(3)),
             op: DataValueComparisonOperator::Eq,
             expect: Arc::new(BooleanArray::from(vec![false, true, false, false])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "lt-passed",
@@ -239,7 +239,7 @@ fn test_scalar_array_comparison() {
             scalar: DataValue::Int8(Some(3)),
             op: DataValueComparisonOperator::Lt,
             expect: Arc::new(BooleanArray::from(vec![true, false, false, false])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "lt-eq-passed",
@@ -247,7 +247,7 @@ fn test_scalar_array_comparison() {
             scalar: DataValue::Int8(Some(3)),
             op: DataValueComparisonOperator::LtEq,
             expect: Arc::new(BooleanArray::from(vec![true, true, false, false])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "gt-passed",
@@ -255,7 +255,7 @@ fn test_scalar_array_comparison() {
             scalar: DataValue::Int8(Some(3)),
             op: DataValueComparisonOperator::Gt,
             expect: Arc::new(BooleanArray::from(vec![false, false, true, true])),
-            error: ""
+            error: "",
         },
         ArrayTest {
             name: "gt-eq-passed",
@@ -263,7 +263,7 @@ fn test_scalar_array_comparison() {
             scalar: DataValue::Int8(Some(3)),
             op: DataValueComparisonOperator::GtEq,
             expect: Arc::new(BooleanArray::from(vec![false, true, true, true])),
-            error: ""
+            error: "",
         },
     ];
 
@@ -271,11 +271,11 @@ fn test_scalar_array_comparison() {
         let result = DataArrayComparison::data_array_comparison_op(
             t.op.clone(),
             &DataColumnarValue::Scalar(t.scalar),
-            &DataColumnarValue::Array(t.array)
+            &DataColumnarValue::Array(t.array),
         );
         match result {
             Ok(v) => assert_eq!(v.as_ref(), t.expect.as_ref()),
-            Err(e) => assert_eq!(t.error, e.to_string())
+            Err(e) => assert_eq!(t.error, e.to_string()),
         }
     }
 }

--- a/common/datavalues/src/data_array_logic.rs
+++ b/common/datavalues/src/data_array_logic.rs
@@ -19,7 +19,7 @@ impl DataArrayLogic {
     pub fn data_array_logic_op(
         op: DataValueLogicOperator,
         left: &DataColumnarValue,
-        right: &DataColumnarValue
+        right: &DataColumnarValue,
     ) -> Result<DataArrayRef> {
         match (left, right) {
             (DataColumnarValue::Array(left_array), DataColumnarValue::Array(right_array)) => {
@@ -37,7 +37,7 @@ impl DataArrayLogic {
                 op,
                 left.data_type(),
                 right.data_type()
-            )))
+            ))),
         }
     }
 }

--- a/common/datavalues/src/data_array_logic_test.rs
+++ b/common/datavalues/src/data_array_logic_test.rs
@@ -16,7 +16,7 @@ fn test_array_logic() {
         args: Vec<Vec<DataArrayRef>>,
         expect: Vec<DataArrayRef>,
         error: Vec<&'static str>,
-        op: DataValueLogicOperator
+        op: DataValueLogicOperator,
     }
 
     let tests = vec![
@@ -28,7 +28,7 @@ fn test_array_logic() {
             ]],
             op: DataValueLogicOperator::And,
             expect: vec![Arc::new(BooleanArray::from(vec![true, false]))],
-            error: vec![""]
+            error: vec![""],
         },
         ArrayTest {
             name: "or-passed",
@@ -38,7 +38,7 @@ fn test_array_logic() {
             ]],
             op: DataValueLogicOperator::Or,
             expect: vec![Arc::new(BooleanArray::from(vec![true, true]))],
-            error: vec![""]
+            error: vec![""],
         },
     ];
 
@@ -47,11 +47,11 @@ fn test_array_logic() {
             let result = DataArrayLogic::data_array_logic_op(
                 t.op.clone(),
                 &DataColumnarValue::Array(args[0].clone()),
-                &DataColumnarValue::Array(args[1].clone())
+                &DataColumnarValue::Array(args[1].clone()),
             );
             match result {
                 Ok(v) => assert_eq!(v.as_ref(), t.expect[i].as_ref()),
-                Err(e) => assert_eq!(t.error[i], e.to_string())
+                Err(e) => assert_eq!(t.error[i], e.to_string()),
             }
         }
     }

--- a/common/datavalues/src/data_array_merge_sort.rs
+++ b/common/datavalues/src/data_array_merge_sort.rs
@@ -19,7 +19,7 @@ impl DataArrayMerge {
     pub fn merge_array(lhs: &ArrayRef, rhs: &ArrayRef, indices: &[bool]) -> Result<ArrayRef> {
         if lhs.data_type() != rhs.data_type() {
             return Result::Err(ErrorCodes::BadDataValueType(
-                "It is impossible to merge arrays of different data types."
+                "It is impossible to merge arrays of different data types.",
             ));
         }
 
@@ -69,7 +69,7 @@ impl DataArrayMerge {
         lhs: &[ArrayRef],
         rhs: &[ArrayRef],
         options: &[SortOptions],
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> Result<Vec<bool>> {
         if lhs.len() != rhs.len() {
             return Result::Err(ErrorCodes::BadDataArrayLength(
@@ -82,7 +82,7 @@ impl DataArrayMerge {
         };
         if lhs.is_empty() {
             return Result::Err(ErrorCodes::BadDataArrayLength(
-                "Merge requires lhs to have at least 1 entry."
+                "Merge requires lhs to have at least 1 entry.",
             ));
         };
         if lhs.len() != options.len() {
@@ -123,7 +123,7 @@ impl DataArrayMerge {
                             Ordering::Less
                         }
                     }
-                    (false, false) => Ordering::Equal
+                    (false, false) => Ordering::Equal,
                 };
                 if descending {
                     result = result.reverse();
@@ -144,7 +144,7 @@ impl DataArrayMerge {
 
         let limits = match limit {
             Some(limit) => limit.min(max_left + max_right),
-            _ => max_left + max_right
+            _ => max_left + max_right,
         };
 
         let mut result = Vec::with_capacity(limits);
@@ -153,7 +153,7 @@ impl DataArrayMerge {
                 (true, true) => break,
                 (false, true) => Ordering::Less,
                 (true, false) => Ordering::Greater,
-                (false, false) => (cmp)(left, right)
+                (false, false) => (cmp)(left, right),
             };
             let value = if order == Ordering::Less {
                 left += 1;

--- a/common/datavalues/src/data_array_merge_sort_test.rs
+++ b/common/datavalues/src/data_array_merge_sort_test.rs
@@ -36,14 +36,14 @@ fn test_indices_many() -> anyhow::Result<()> {
     let b1 = Arc::new(UInt32Array::from(vec![None, Some(2), Some(3), Some(5)]));
     let option1 = SortOptions {
         descending: false,
-        nulls_first: true
+        nulls_first: true,
     };
 
     let a2 = Arc::new(UInt32Array::from(vec![Some(2), Some(3), Some(5)]));
     let b2 = Arc::new(UInt32Array::from(vec![Some(1), Some(4), Some(6), Some(6)]));
     let option2 = SortOptions {
         descending: true,
-        nulls_first: true
+        nulls_first: true,
     };
 
     let c = DataArrayMerge::merge_indices(&[a1, a2], &[b1, b2], &[option1, option2], None)?;
@@ -72,21 +72,21 @@ fn test_merge_array() -> anyhow::Result<()> {
 
     let option1 = SortOptions {
         descending: false,
-        nulls_first: true
+        nulls_first: true,
     };
 
     let a2: DataArrayRef = Arc::new(UInt32Array::from(vec![Some(1), Some(3), Some(5)]));
     let b2: DataArrayRef = Arc::new(UInt32Array::from(vec![Some(2), Some(4), Some(6)]));
     let option2 = SortOptions {
         descending: false,
-        nulls_first: true
+        nulls_first: true,
     };
 
     let c = DataArrayMerge::merge_indices(
         &[a1.clone(), a2.clone()],
         &[b1.clone(), b2.clone()],
         &[option1, option2],
-        None
+        None,
     )?;
 
     assert_eq!(c, vec![true, false, true, false, true, false]);
@@ -116,17 +116,17 @@ fn test_merge_array2() -> anyhow::Result<()> {
     let a1: DataArrayRef = Arc::new(UInt32Array::from(
         (1..500)
             .map(|s| Some(s as u32))
-            .collect::<Vec<Option<u32>>>()
+            .collect::<Vec<Option<u32>>>(),
     ));
     let b1: DataArrayRef = Arc::new(UInt32Array::from(
         (500..1000)
             .map(|s| Some(s as u32))
-            .collect::<Vec<Option<u32>>>()
+            .collect::<Vec<Option<u32>>>(),
     ));
 
     let option1 = SortOptions {
         descending: false,
-        nulls_first: true
+        nulls_first: true,
     };
 
     let c = DataArrayMerge::merge_indices(&[a1.clone()], &[b1.clone()], &[option1], None)?;
@@ -138,7 +138,7 @@ fn test_merge_array2() -> anyhow::Result<()> {
     let expect: DataArrayRef = Arc::new(UInt32Array::from(
         (1..1000)
             .map(|s| Some(s as u32))
-            .collect::<Vec<Option<u32>>>()
+            .collect::<Vec<Option<u32>>>(),
     ));
 
     assert_eq!(*d, *expect);

--- a/common/datavalues/src/data_columnar_value.rs
+++ b/common/datavalues/src/data_columnar_value.rs
@@ -13,14 +13,14 @@ pub enum DataColumnarValue {
     // Array of values.
     Array(DataArrayRef),
     // A Single value.
-    Scalar(DataValue)
+    Scalar(DataValue),
 }
 
 impl DataColumnarValue {
     pub fn data_type(&self) -> DataType {
         let x = match self {
             DataColumnarValue::Array(v) => v.data_type().clone(),
-            DataColumnarValue::Scalar(v) => v.data_type()
+            DataColumnarValue::Scalar(v) => v.data_type(),
         };
         x
     }
@@ -29,7 +29,7 @@ impl DataColumnarValue {
     pub fn to_array(&self, size: usize) -> Result<DataArrayRef> {
         match self {
             DataColumnarValue::Array(array) => Ok(array.clone()),
-            DataColumnarValue::Scalar(scalar) => scalar.to_array_with_size(size)
+            DataColumnarValue::Scalar(scalar) => scalar.to_array_with_size(size),
         }
     }
 }

--- a/common/datavalues/src/data_type.rs
+++ b/common/datavalues/src/data_type.rs
@@ -61,15 +61,15 @@ pub fn numeric_byte_size(dt: &DataType) -> Result<usize> {
         DataType::Int32 | DataType::UInt32 | DataType::Float32 => Ok(4),
         DataType::Int64 | DataType::UInt64 | DataType::Float64 => Ok(8),
         _ => Result::Err(ErrorCodes::BadArguments(
-            "Function number_byte_size argument must be numeric types"
-        ))
+            "Function number_byte_size argument must be numeric types",
+        )),
     }
 }
 
 pub fn construct_numeric_type(
     is_signed: bool,
     is_floating: bool,
-    byte_size: usize
+    byte_size: usize,
 ) -> Result<DataType> {
     match (is_signed, is_floating, byte_size) {
         (false, false, 1) => Ok(DataType::UInt8),
@@ -97,7 +97,7 @@ pub fn construct_numeric_type(
         _ => Result::Err(ErrorCodes::BadDataValueType(format!(
             "Can't construct type from is_signed: {}, is_floating: {}, byte_size: {}",
             is_signed, is_floating, byte_size
-        )))
+        ))),
     }
 }
 
@@ -118,7 +118,7 @@ pub fn dictionary_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<D
     match (lhs_type, rhs_type) {
         (
             DataType::Dictionary(_lhs_index_type, lhs_value_type),
-            DataType::Dictionary(_rhs_index_type, rhs_value_type)
+            DataType::Dictionary(_rhs_index_type, rhs_value_type),
         ) => dictionary_value_coercion(lhs_value_type, rhs_value_type),
         (DataType::Dictionary(_index_type, value_type), _) => {
             dictionary_value_coercion(value_type, rhs_type)
@@ -129,7 +129,7 @@ pub fn dictionary_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<D
         _ => Result::Err(ErrorCodes::BadDataValueType(format!(
             "Can't construct type from {} and {}",
             lhs_type, rhs_type
-        )))
+        ))),
     }
 }
 
@@ -144,7 +144,7 @@ pub fn string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<DataT
         _ => Result::Err(ErrorCodes::BadDataValueType(format!(
             "Can't construct type from {} and {}",
             lhs_type, rhs_type
-        )))
+        ))),
     }
 }
 
@@ -170,7 +170,7 @@ pub fn numerical_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<Da
             0
         } else {
             size_of_rhs
-        }
+        },
     );
 
     let max_size_of_signed_integer = cmp::max(
@@ -183,7 +183,7 @@ pub fn numerical_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<Da
             0
         } else {
             size_of_rhs
-        }
+        },
     );
 
     let max_size_of_integer = cmp::max(
@@ -196,7 +196,7 @@ pub fn numerical_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<Da
             0
         } else {
             size_of_rhs
-        }
+        },
     );
 
     let max_size_of_float = cmp::max(
@@ -209,7 +209,7 @@ pub fn numerical_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<Da
             0
         } else {
             size_of_rhs
-        }
+        },
     );
 
     let should_double = (has_float && has_integer && max_size_of_integer >= max_size_of_float)
@@ -224,7 +224,7 @@ pub fn numerical_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<Da
             cmp::max(size_of_rhs, size_of_lhs) * 2
         } else {
             cmp::max(size_of_rhs, size_of_lhs)
-        }
+        },
     )
 }
 
@@ -232,7 +232,7 @@ pub fn numerical_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<Da
 pub fn numerical_arithmetic_coercion(
     op: &DataValueArithmeticOperator,
     lhs_type: &DataType,
-    rhs_type: &DataType
+    rhs_type: &DataType,
 ) -> Result<DataType> {
     // error on any non-numeric type
     if !is_numeric(lhs_type) || !is_numeric(rhs_type) {
@@ -255,7 +255,7 @@ pub fn numerical_arithmetic_coercion(
         DataValueArithmeticOperator::Minus => {
             construct_numeric_type(true, has_float, next_size(max_size))
         }
-        DataValueArithmeticOperator::Div => Ok(Float64)
+        DataValueArithmeticOperator::Div => Ok(Float64),
     }
 }
 

--- a/common/datavalues/src/data_value.rs
+++ b/common/datavalues/src/data_value.rs
@@ -75,7 +75,7 @@ pub enum DataValue {
 
     // Container struct.
     List(Option<Vec<DataValue>>, DataType),
-    Struct(Vec<DataValue>)
+    Struct(Vec<DataValue>),
 }
 
 pub type DataValueRef = Box<DataValue>;
@@ -189,59 +189,59 @@ impl DataValue {
             DataValue::Binary(v) => Ok(Arc::new(BinaryArray::from(vec![v.as_deref(); size]))),
             DataValue::Date32(e) => match e {
                 Some(value) => Ok(Arc::new(Date32Array::from_value(*value, size))),
-                None => Ok(new_null_array(&DataType::Date32, size))
+                None => Ok(new_null_array(&DataType::Date32, size)),
             },
             DataValue::Date64(e) => match e {
                 Some(value) => Ok(Arc::new(Date64Array::from_value(*value, size))),
-                None => Ok(new_null_array(&DataType::Date64, size))
+                None => Ok(new_null_array(&DataType::Date64, size)),
             },
             DataValue::TimestampSecond(e) => match e {
                 Some(value) => Ok(Arc::new(TimestampSecondArray::from_iter_values(
-                    repeat(*value).take(size)
+                    repeat(*value).take(size),
                 ))),
                 None => Ok(new_null_array(
                     &DataType::Timestamp(TimeUnit::Second, None),
-                    size
-                ))
+                    size,
+                )),
             },
             DataValue::TimestampMillisecond(e) => match e {
                 Some(value) => Ok(Arc::new(TimestampMillisecondArray::from_iter_values(
-                    repeat(*value).take(size)
+                    repeat(*value).take(size),
                 ))),
                 None => Ok(new_null_array(
                     &DataType::Timestamp(TimeUnit::Millisecond, None),
-                    size
-                ))
+                    size,
+                )),
             },
             DataValue::TimestampMicrosecond(e) => match e {
                 Some(value) => Ok(Arc::new(TimestampMicrosecondArray::from_value(
-                    *value, size
+                    *value, size,
                 ))),
                 None => Ok(new_null_array(
                     &DataType::Timestamp(TimeUnit::Microsecond, None),
-                    size
-                ))
+                    size,
+                )),
             },
             DataValue::TimestampNanosecond(e) => match e {
                 Some(value) => Ok(Arc::new(TimestampNanosecondArray::from_value(*value, size))),
                 None => Ok(new_null_array(
                     &DataType::Timestamp(TimeUnit::Nanosecond, None),
-                    size
-                ))
+                    size,
+                )),
             },
             DataValue::IntervalDayTime(e) => match e {
                 Some(value) => Ok(Arc::new(IntervalDayTimeArray::from_value(*value, size))),
                 None => Ok(new_null_array(
                     &DataType::Interval(IntervalUnit::DayTime),
-                    size
-                ))
+                    size,
+                )),
             },
             DataValue::IntervalYearMonth(e) => match e {
                 Some(value) => Ok(Arc::new(IntervalYearMonthArray::from_value(*value, size))),
                 None => Ok(new_null_array(
                     &DataType::Interval(IntervalUnit::YearMonth),
-                    size
-                ))
+                    size,
+                )),
             },
             DataValue::List(values, data_type) => match data_type {
                 DataType::Int8 => Ok(Arc::new(build_list!(Int8Builder, Int8, values, size))),
@@ -262,7 +262,7 @@ impl DataValue {
                 other => Result::Err(ErrorCodes::BadDataValueType(format!(
                     "Unexpected type:{} for DataValue List",
                     other
-                )))
+                ))),
             },
             DataValue::Struct(v) => {
                 let mut array = vec![];
@@ -272,9 +272,9 @@ impl DataValue {
                         DataField::new(
                             format!("item_{}", i).as_str(),
                             val_array.data_type().clone(),
-                            false
+                            false,
                         ),
-                        val_array as DataArrayRef
+                        val_array as DataArrayRef,
                     ));
                 }
                 Ok(Arc::new(StructArray::from(array)))
@@ -282,7 +282,7 @@ impl DataValue {
             other => Result::Err(ErrorCodes::BadDataValueType(format!(
                 "DataValue Error: DataValue to array cannot be {:?}",
                 other
-            )))
+            ))),
         }
     }
 }
@@ -329,7 +329,7 @@ impl TryFrom<&DataType> for DataValue {
             _ => Result::Err(ErrorCodes::BadDataValueType(format!(
                 "DataValue Error: Unsupported try_from() for data type: {:?}",
                 data_type
-            )))
+            ))),
         }
     }
 }
@@ -378,7 +378,7 @@ impl fmt::Display for DataValue {
                         .join(",")
                 )
             }
-            DataValue::Struct(v) => write!(f, "{:?}", v)
+            DataValue::Struct(v) => write!(f, "{:?}", v),
         }
     }
 }
@@ -420,7 +420,7 @@ impl fmt::Debug for DataValue {
                 write!(f, "TimestampNanosecond({})", self)
             }
             DataValue::List(_, _) => write!(f, "[{}]", self),
-            DataValue::Struct(v) => write!(f, "{:?}", v)
+            DataValue::Struct(v) => write!(f, "{:?}", v),
         }
     }
 }

--- a/common/datavalues/src/data_value_aggregate.rs
+++ b/common/datavalues/src/data_value_aggregate.rs
@@ -15,7 +15,7 @@ impl DataValueAggregate {
     pub fn data_value_aggregate_op(
         op: DataValueAggregateOperator,
         left: DataValue,
-        right: DataValue
+        right: DataValue,
     ) -> Result<DataValue> {
         match (&left, &right) {
             (DataValue::Null, _) => Result::Ok(right),

--- a/common/datavalues/src/data_value_aggregate_test.rs
+++ b/common/datavalues/src/data_value_aggregate_test.rs
@@ -14,7 +14,7 @@ fn test_data_value_arithmetic() {
         args: Vec<Vec<DataValue>>,
         expect: Vec<DataValue>,
         error: Vec<&'static str>,
-        op: DataValueAggregateOperator
+        op: DataValueAggregateOperator,
     }
 
     let tests = vec![
@@ -189,11 +189,11 @@ fn test_data_value_arithmetic() {
             let result = DataValueAggregate::data_value_aggregate_op(
                 t.op.clone(),
                 args[0].clone(),
-                args[1].clone()
+                args[1].clone(),
             );
             match result {
                 Ok(v) => assert_eq!(v, t.expect[i]),
-                Err(e) => assert_eq!(t.error[i], e.to_string())
+                Err(e) => assert_eq!(t.error[i], e.to_string()),
             }
         }
     }

--- a/common/datavalues/src/data_value_arithmetic.rs
+++ b/common/datavalues/src/data_value_arithmetic.rs
@@ -37,7 +37,7 @@ impl DataValueArithmetic {
     pub fn data_value_arithmetic_op(
         op: DataValueArithmeticOperator,
         left: DataValue,
-        right: DataValue
+        right: DataValue,
     ) -> Result<DataValue> {
         match (&left, &right) {
             (DataValue::Null, _) => Ok(right),
@@ -368,8 +368,8 @@ impl DataValueArithmetic {
                     lhs.data_type(),
                     op,
                     rhs.data_type(),
-                )))
-            }
+                ))),
+            },
         }
     }
 }

--- a/common/datavalues/src/data_value_arithmetic_test.rs
+++ b/common/datavalues/src/data_value_arithmetic_test.rs
@@ -14,7 +14,7 @@ fn test_data_value_arithmetic() {
         args: &'a Vec<Vec<DataValue>>,
         expect: Vec<DataValue>,
         error: Vec<&'static str>,
-        op: DataValueArithmeticOperator
+        op: DataValueArithmeticOperator,
     }
 
     let args = vec![
@@ -623,11 +623,11 @@ fn test_data_value_arithmetic() {
             let result = DataValueArithmetic::data_value_arithmetic_op(
                 t.op.clone(),
                 args[0].clone(),
-                args[1].clone()
+                args[1].clone(),
             );
             match result {
                 Ok(v) => assert_eq!(v, t.expect[i]),
-                Err(e) => assert_eq!(t.error[i], e.to_string())
+                Err(e) => assert_eq!(t.error[i], e.to_string()),
             }
         }
     }

--- a/common/datavalues/src/data_value_kernel.rs
+++ b/common/datavalues/src/data_value_kernel.rs
@@ -149,7 +149,7 @@ impl DataValue {
     fn dictionary_create_key_for_col<K: ArrowDictionaryKeyType>(
         col: &ArrayRef,
         row: usize,
-        vec: &mut Vec<u8>
+        vec: &mut Vec<u8>,
     ) -> Result<()> {
         let dict_col = col.as_any().downcast_ref::<DictionaryArray<K>>().unwrap();
 
@@ -182,7 +182,7 @@ impl DataValue {
             other => Result::Err(ErrorCodes::BadDataValueType(format!(
                 "Unexpected type:{} for DataValue List",
                 other
-            )))
+            ))),
         }
     }
 
@@ -295,7 +295,7 @@ impl DataValue {
             other => Result::Err(ErrorCodes::BadDataValueType(format!(
                 "DataValue Error: Can't create a scalar of array of type \"{:?}\"",
                 other
-            )))
+            ))),
         }
     }
 
@@ -308,7 +308,7 @@ impl DataValue {
                     Ok(DataValue::Int64(Some(n)))
                 }
             }
-            Err(_) => Ok(DataValue::Float64(Some(literal.parse::<f64>()?)))
+            Err(_) => Ok(DataValue::Float64(Some(literal.parse::<f64>()?))),
         }
     }
 }

--- a/common/datavalues/src/data_value_kernel_test.rs
+++ b/common/datavalues/src/data_value_kernel_test.rs
@@ -15,7 +15,7 @@ fn test_data_value_kernel_concat_row_key() -> anyhow::Result<()> {
         name: &'static str,
         args: Vec<DataArrayRef>,
         expect: Vec<&'static str>,
-        error: Vec<&'static str>
+        error: Vec<&'static str>,
     }
 
     let tests = vec![ArrayTest {

--- a/common/datavalues/src/data_value_operator.rs
+++ b/common/datavalues/src/data_value_operator.rs
@@ -8,7 +8,7 @@ pub enum DataValueAggregateOperator {
     Max,
     Sum,
     Avg,
-    Count
+    Count,
 }
 
 impl std::fmt::Display for DataValueAggregateOperator {
@@ -18,7 +18,7 @@ impl std::fmt::Display for DataValueAggregateOperator {
             DataValueAggregateOperator::Max => "max",
             DataValueAggregateOperator::Sum => "sum",
             DataValueAggregateOperator::Avg => "avg",
-            DataValueAggregateOperator::Count => "count"
+            DataValueAggregateOperator::Count => "count",
         };
         write!(f, "{}", display)
     }
@@ -31,7 +31,7 @@ pub enum DataValueComparisonOperator {
     LtEq,
     Gt,
     GtEq,
-    NotEq
+    NotEq,
 }
 
 impl std::fmt::Display for DataValueComparisonOperator {
@@ -56,7 +56,7 @@ pub enum DataValueArithmeticOperator {
     Minus,
     Mul,
     Div,
-    Modulo
+    Modulo,
 }
 
 impl std::fmt::Display for DataValueArithmeticOperator {
@@ -66,7 +66,7 @@ impl std::fmt::Display for DataValueArithmeticOperator {
             DataValueArithmeticOperator::Minus => "minus",
             DataValueArithmeticOperator::Mul => "multiply",
             DataValueArithmeticOperator::Div => "divide",
-            DataValueArithmeticOperator::Modulo => "modulo"
+            DataValueArithmeticOperator::Modulo => "modulo",
         };
         write!(f, "{}", display)
     }
@@ -75,14 +75,14 @@ impl std::fmt::Display for DataValueArithmeticOperator {
 #[derive(Clone)]
 pub enum DataValueLogicOperator {
     And,
-    Or
+    Or,
 }
 
 impl std::fmt::Display for DataValueLogicOperator {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let display = match &self {
             DataValueLogicOperator::And => "and",
-            DataValueLogicOperator::Or => "or"
+            DataValueLogicOperator::Or => "or",
         };
         write!(f, "{}", display)
     }

--- a/common/datavalues/src/macros.rs
+++ b/common/datavalues/src/macros.rs
@@ -23,7 +23,7 @@ macro_rules! compute_op {
         let ll = downcast_array!($LEFT, $DT)?;
         let rr = downcast_array!($RIGHT, $DT)?;
         Ok(Arc::new(
-            common_arrow::arrow::compute::$OP(&ll, &rr).map_err(ErrorCodes::from)?
+            common_arrow::arrow::compute::$OP(&ll, &rr).map_err(ErrorCodes::from)?,
         ))
     }};
 }
@@ -35,7 +35,7 @@ macro_rules! compute_utf8_op {
         let rr = downcast_array!($RIGHT, $DT)?;
         Ok(Arc::new(
             (paste::expr! {common_arrow::arrow::compute::[<$OP _utf8>]}(&ll, &rr))
-                .map_err(ErrorCodes::from)?
+                .map_err(ErrorCodes::from)?,
         ))
     }};
 }
@@ -46,7 +46,7 @@ macro_rules! compute_self_defined_op {
         let ll = downcast_array!($LEFT, $DT)?;
         let rr = downcast_array!($RIGHT, $DT)?;
         Ok(Arc::new(
-            common_arrow::arrow::compute::math_op(&ll, &rr, $OP).map_err(ErrorCodes::from)?
+            common_arrow::arrow::compute::math_op(&ll, &rr, $OP).map_err(ErrorCodes::from)?,
         ))
     }};
 }
@@ -71,7 +71,7 @@ macro_rules! arrow_primitive_array_op {
                 "Unsupported arithmetic_compute::{} for data type: {:?}",
                 stringify!($OP),
                 ($LEFT).data_type(),
-            )))
+            ))),
         }
     };
 }
@@ -95,7 +95,7 @@ macro_rules! arrow_primitive_array_self_defined_op {
             _ => Result::Err(ErrorCodes::BadDataValueType(format!(
                 "Unsupported arithmetic_compute::math_op for data type: {:?}",
                 ($LEFT).data_type(),
-            )))
+            ))),
         }
     };
 }
@@ -120,7 +120,7 @@ macro_rules! arrow_array_op {
                 "Unsupported arithmetic_compute::{} for data type: {:?}",
                 stringify!($OP),
                 ($LEFT).data_type(),
-            )))
+            ))),
         }
     };
 }
@@ -134,9 +134,9 @@ macro_rules! compute_op_scalar {
         Ok(Arc::new(
             (paste::expr! {common_arrow::arrow::compute::[<$OP _scalar>]}(
                 &ll,
-                $RIGHT.try_into().map_err(ErrorCodes::from)?
+                $RIGHT.try_into().map_err(ErrorCodes::from)?,
             ))
-            .map_err(ErrorCodes::from)?
+            .map_err(ErrorCodes::from)?,
         ))
     }};
 }
@@ -149,9 +149,9 @@ macro_rules! compute_utf8_op_scalar {
             Ok(Arc::new(
                 (paste::expr! {common_arrow::arrow::compute::[<$OP _utf8_scalar>]}(
                     &ll,
-                    &string_value
+                    &string_value,
                 ))
-                .map_err(ErrorCodes::from)?
+                .map_err(ErrorCodes::from)?,
             ))
         } else {
             Result::Err(ErrorCodes::BadDataValueType(format!(
@@ -181,7 +181,7 @@ macro_rules! arrow_array_op_scalar {
             other => Result::Err(ErrorCodes::BadDataValueType(format!(
                 "DataValue Error: Unsupported data type {:?}",
                 other
-            )))
+            ))),
         };
         Ok(result?)
     }};
@@ -218,7 +218,7 @@ macro_rules! typed_data_value_add {
             (None, None) => None,
             (Some(a), None) => Some(a.clone() as $TYPE),
             (None, Some(b)) => Some(b.clone() as $TYPE),
-            (Some(a), Some(b)) => Some((*a as $TYPE) + (*b as $TYPE))
+            (Some(a), Some(b)) => Some((*a as $TYPE) + (*b as $TYPE)),
         }))
     }};
 }
@@ -230,7 +230,7 @@ macro_rules! typed_data_value_sub {
             (None, None) => None,
             (Some(a), None) => Some(a.clone() as $TYPE),
             (None, Some(b)) => Some(b.clone() as $TYPE),
-            (Some(a), Some(b)) => Some((*a as $TYPE) - (*b as $TYPE))
+            (Some(a), Some(b)) => Some((*a as $TYPE) - (*b as $TYPE)),
         }))
     }};
 }
@@ -242,7 +242,7 @@ macro_rules! typed_data_value_mul {
             (None, None) => None,
             (Some(a), None) => Some(a.clone() as $TYPE),
             (None, Some(b)) => Some(b.clone() as $TYPE),
-            (Some(a), Some(b)) => Some((*a as $TYPE) * (*b as $TYPE))
+            (Some(a), Some(b)) => Some((*a as $TYPE) * (*b as $TYPE)),
         }))
     }};
 }
@@ -254,7 +254,7 @@ macro_rules! typed_data_value_div {
             (None, None) => None,
             (Some(a), None) => Some(a.clone() as f64),
             (None, Some(b)) => Some(b.clone() as f64),
-            (Some(a), Some(b)) => Some((*a as f64) / (*b as f64))
+            (Some(a), Some(b)) => Some((*a as f64) / (*b as f64)),
         }))
     }};
 }
@@ -266,7 +266,7 @@ macro_rules! typed_data_value_modulo {
             (None, None) => None,
             (Some(a), None) => Some(a.clone() as $TYPE),
             (None, Some(b)) => Some(b.clone() as $TYPE),
-            (Some(a), Some(b)) => Some((*a as $TYPE) % (*b as $TYPE))
+            (Some(a), Some(b)) => Some((*a as $TYPE) % (*b as $TYPE)),
         }))
     }};
 }
@@ -277,7 +277,7 @@ macro_rules! typed_data_value_min_max {
             (None, None) => None,
             (Some(a), None) => Some(a.clone()),
             (None, Some(b)) => Some(b.clone()),
-            (Some(a), Some(b)) => Some((*a).$OP(*b))
+            (Some(a), Some(b)) => Some((*a).$OP(*b)),
         }))
     }};
 }
@@ -289,7 +289,7 @@ macro_rules! typed_data_value_min_max_string {
             (None, None) => None,
             (Some(a), None) => Some(a.clone()),
             (None, Some(b)) => Some(b.clone()),
-            (Some(a), Some(b)) => Some((a).$OP(b).clone())
+            (Some(a), Some(b)) => Some((a).$OP(b).clone()),
         }))
     }};
 }
@@ -298,7 +298,7 @@ macro_rules! format_data_value_with_option {
     ($F:expr, $EXPR:expr) => {{
         match $EXPR {
             Some(e) => write!($F, "{}", e),
-            None => write!($F, "NULL")
+            None => write!($F, "NULL"),
         }
     }};
 }
@@ -309,7 +309,7 @@ macro_rules! array_boolean_op {
         let ll = downcast_array!($LEFT, $DT)?;
         let rr = downcast_array!($RIGHT, $DT)?;
         Ok(Arc::new(
-            common_arrow::arrow::compute::$OP(&ll, &rr).map_err(ErrorCodes::from)?
+            common_arrow::arrow::compute::$OP(&ll, &rr).map_err(ErrorCodes::from)?,
         ))
     }};
 }
@@ -320,7 +320,7 @@ macro_rules! typed_cast_from_array_to_data_value {
         let array = downcast_array!($array, $ARRAYTYPE)?;
         Result::Ok(DataValue::$SCALAR(match array.is_null($index) {
             true => None,
-            false => Some(array.value($index).into())
+            false => Some(array.value($index).into()),
         }))
     }};
 }
@@ -337,7 +337,7 @@ macro_rules! typed_cast_from_data_value_to_std {
                         "DataValue Error:  Cannot convert {:?} to {}",
                         value,
                         std::any::type_name::<Self>()
-                    ))
+                    )),
                 }
             }
         }
@@ -351,7 +351,7 @@ macro_rules! build_list {
             None => {
                 return Ok(common_arrow::arrow::array::new_null_array(
                     &DataType::List(Box::new(DataField::new("item", DataType::$SCALAR_TY, true))),
-                    $SIZE
+                    $SIZE,
                 ))
             }
             Some(values) => {
@@ -368,7 +368,7 @@ macro_rules! build_list {
                             }
                             _ => {
                                 return Result::Err(ErrorCodes::BadDataValueType(
-                                    "Incompatible DataValue for list"
+                                    "Incompatible DataValue for list",
                                 ))
                             }
                         };
@@ -395,7 +395,7 @@ macro_rules! try_build_array {
                 }
                 _ => {
                     return Result::Err(ErrorCodes::BadDataValueType(
-                        "Incompatible DataValue for list"
+                        "Incompatible DataValue for list",
                     ))
                 }
             };

--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -16,7 +16,7 @@ pub struct ErrorCodes {
     code: u16,
     display_text: String,
     cause: Option<Box<dyn std::error::Error + Sync + Send>>,
-    backtrace: Option<Backtrace>
+    backtrace: Option<Backtrace>,
 }
 
 impl ErrorCodes {
@@ -34,7 +34,7 @@ impl ErrorCodes {
     pub fn backtrace(&self) -> String {
         return match self.backtrace.as_ref() {
             None => "".to_string(), // no backtrace
-            Some(backtrace) => format!("{:?}", backtrace)
+            Some(backtrace) => format!("{:?}", backtrace),
         };
     }
 }
@@ -130,13 +130,13 @@ impl Display for ErrorCodes {
 
 #[derive(Error)]
 enum OtherErrors {
-    AnyHow { error: anyhow::Error }
+    AnyHow { error: anyhow::Error },
 }
 
 impl Display for OtherErrors {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            OtherErrors::AnyHow { error } => write!(f, "{}", error)
+            OtherErrors::AnyHow { error } => write!(f, "{}", error),
         }
     }
 }
@@ -144,7 +144,7 @@ impl Display for OtherErrors {
 impl Debug for OtherErrors {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            OtherErrors::AnyHow { error } => write!(f, "{:?}", error)
+            OtherErrors::AnyHow { error } => write!(f, "{:?}", error),
         }
     }
 }
@@ -155,7 +155,7 @@ impl From<anyhow::Error> for ErrorCodes {
             code: 1002,
             display_text: String::from(""),
             cause: Some(Box::new(OtherErrors::AnyHow { error })),
-            backtrace: None
+            backtrace: None,
         }
     }
 }
@@ -195,7 +195,7 @@ impl ErrorCodes {
             code: 1002,
             display_text: format!("{}", error),
             cause: None,
-            backtrace: Some(Backtrace::new())
+            backtrace: Some(Backtrace::new()),
         }
     }
 }

--- a/common/flights/build.rs
+++ b/common/flights/build.rs
@@ -16,7 +16,7 @@ fn build_proto() {
     let proto_dir = Path::new(&manifest_dir).join("proto");
     let protos = [
         &Path::new(&proto_dir).join(Path::new("queryflight.proto")),
-        &Path::new(&proto_dir).join(Path::new("storeflight.proto"))
+        &Path::new(&proto_dir).join(Path::new("storeflight.proto")),
     ];
 
     for proto in protos.iter() {

--- a/common/flights/src/common.rs
+++ b/common/flights/src/common.rs
@@ -8,7 +8,7 @@ use tonic::Status;
 pub fn flight_result_to_str(r: &arrow_flight::Result) -> String {
     match std::str::from_utf8(&r.body) {
         Ok(v) => v.to_string(),
-        Err(_e) => format!("{:?}", r.body)
+        Err(_e) => format!("{:?}", r.body),
     }
 }
 

--- a/common/flights/src/flight_token.rs
+++ b/common/flights/src/flight_token.rs
@@ -7,12 +7,12 @@ use jwt_simple::prelude::*;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct FlightClaim {
-    pub username: String
+    pub username: String,
 }
 
 #[derive(Clone)]
 pub struct FlightToken {
-    key: HS256Key
+    key: HS256Key,
 }
 
 impl FlightToken {

--- a/common/flights/src/query_client.rs
+++ b/common/flights/src/query_client.rs
@@ -33,7 +33,7 @@ use crate::query_do_get::QueryDoGet;
 pub struct QueryClient {
     // In seconds.
     timeout_second: u64,
-    client: FlightServiceClient<tonic::transport::channel::Channel>
+    client: FlightServiceClient<tonic::transport::channel::Channel>,
 }
 
 impl QueryClient {
@@ -41,7 +41,7 @@ impl QueryClient {
         let client = FlightServiceClient::connect(format!("http://{}", addr)).await?;
         Ok(Self {
             timeout_second: 60,
-            client
+            client,
         })
     }
 
@@ -53,11 +53,11 @@ impl QueryClient {
     pub async fn execute_remote_plan_action(
         &mut self,
         job_id: String,
-        plan: &PlanNode
+        plan: &PlanNode,
     ) -> Result<SendableDataBlockStream> {
         let action = QueryDoGet::ExecutePlan(ExecutePlanAction {
             job_id: job_id.clone(),
-            plan: plan.clone()
+            plan: plan.clone(),
         });
         self.do_get(&action).await
     }
@@ -82,7 +82,7 @@ impl QueryClient {
                 let block_stream = stream.map(move |flight_data| {
                     fn fetch_impl(
                         data: Result<FlightData, Status>,
-                        schema: &SchemaRef
+                        schema: &SchemaRef,
                     ) -> anyhow::Result<RecordBatch> {
                         let batch = flight_data_to_arrow_batch(&data?, schema.clone(), &[])?;
                         Ok(batch)
@@ -97,7 +97,7 @@ impl QueryClient {
             None => bail!(
                 "Can not receive data from flight server, action:{:?}",
                 action
-            )
+            ),
         }
     }
 
@@ -114,7 +114,7 @@ impl QueryClient {
                     action
                 )
             }
-            Some(resp) => Ok(resp.body)
+            Some(resp) => Ok(resp.body),
         }
     }
 }

--- a/common/flights/src/query_do_action.rs
+++ b/common/flights/src/query_do_action.rs
@@ -15,13 +15,13 @@ use crate::protobuf::FlightQueryRequest;
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct FetchPartitionAction {
     pub uuid: String,
-    pub nums: u32
+    pub nums: u32,
 }
 
 // Action wrapper for do_action.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub enum QueryDoAction {
-    FetchPartition(FetchPartitionAction)
+    FetchPartition(FetchPartitionAction),
 }
 
 /// Try convert tonic::Request<Action> to DoActionAction.
@@ -50,13 +50,13 @@ impl TryInto<Request<Action>> for &QueryDoAction {
 
     fn try_into(self) -> Result<Request<Action>, Self::Error> {
         let flight_request = FlightQueryRequest {
-            body: serde_json::to_string(&self)?
+            body: serde_json::to_string(&self)?,
         };
         let mut buf = vec![];
         flight_request.encode(&mut buf)?;
         let request = tonic::Request::new(Action {
             r#type: "".to_string(),
-            body: buf
+            body: buf,
         });
         Ok(request)
     }

--- a/common/flights/src/query_do_get.rs
+++ b/common/flights/src/query_do_get.rs
@@ -16,13 +16,13 @@ use crate::protobuf::FlightQueryRequest;
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ExecutePlanAction {
     pub job_id: String,
-    pub plan: PlanNode
+    pub plan: PlanNode,
 }
 
 // Action wrapper for do_get.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub enum QueryDoGet {
-    ExecutePlan(ExecutePlanAction)
+    ExecutePlan(ExecutePlanAction),
 }
 
 /// Try convert tonic::Request<Ticket> to DoGetAction.
@@ -51,7 +51,7 @@ impl TryInto<Request<Ticket>> for &QueryDoGet {
 
     fn try_into(self) -> Result<Request<Ticket>, Self::Error> {
         let flight_request = FlightQueryRequest {
-            body: serde_json::to_string(&self)?
+            body: serde_json::to_string(&self)?,
         };
 
         let mut buf = vec![];

--- a/common/flights/src/store_client.rs
+++ b/common/flights/src/store_client.rs
@@ -39,7 +39,7 @@ use crate::GetTableActionResult;
 pub struct StoreClient {
     token: Vec<u8>,
     timeout_second: u64,
-    client: FlightServiceClient<tonic::transport::channel::Channel>
+    client: FlightServiceClient<tonic::transport::channel::Channel>,
 }
 
 impl StoreClient {
@@ -48,7 +48,7 @@ impl StoreClient {
         let mut rx = Self {
             token: vec![],
             timeout_second: 60,
-            client
+            client,
         };
         rx.handshake(username, password).await?;
         Ok(rx)
@@ -61,7 +61,7 @@ impl StoreClient {
     /// Create database call.
     pub async fn create_database(
         &mut self,
-        plan: CreateDatabasePlan
+        plan: CreateDatabasePlan,
     ) -> anyhow::Result<CreateDatabaseActionResult> {
         let action = StoreDoAction::CreateDatabase(CreateDatabaseAction { plan });
         let rst = self.do_action(&action).await?;
@@ -75,7 +75,7 @@ impl StoreClient {
     /// Drop database call.
     pub async fn drop_database(
         &mut self,
-        plan: DropDatabasePlan
+        plan: DropDatabasePlan,
     ) -> anyhow::Result<DropDatabaseActionResult> {
         let action = StoreDoAction::DropDatabase(DropDatabaseAction { plan });
         let rst = self.do_action(&action).await?;
@@ -89,7 +89,7 @@ impl StoreClient {
     /// Create table call.
     pub async fn create_table(
         &mut self,
-        plan: CreateTablePlan
+        plan: CreateTablePlan,
     ) -> anyhow::Result<CreateTableActionResult> {
         let action = StoreDoAction::CreateTable(CreateTableAction { plan });
         let rst = self.do_action(&action).await?;
@@ -103,7 +103,7 @@ impl StoreClient {
     /// Drop table call.
     pub async fn drop_table(
         &mut self,
-        plan: DropTablePlan
+        plan: DropTablePlan,
     ) -> anyhow::Result<DropTableActionResult> {
         let action = StoreDoAction::DropTable(DropTableAction { plan });
         let rst = self.do_action(&action).await?;
@@ -118,7 +118,7 @@ impl StoreClient {
     pub async fn get_table(
         &mut self,
         db: String,
-        table: String
+        table: String,
     ) -> anyhow::Result<GetTableActionResult> {
         let action = StoreDoAction::GetTable(GetTableAction { db, table });
         let rst = self.do_action(&action).await?;
@@ -133,7 +133,7 @@ impl StoreClient {
     async fn handshake(&mut self, username: &str, password: &str) -> anyhow::Result<()> {
         let auth = BasicAuth {
             username: username.to_string(),
-            password: password.to_string()
+            password: password.to_string(),
         };
         let mut payload = vec![];
         auth.encode(&mut payload)?;
@@ -164,7 +164,7 @@ impl StoreClient {
         let metadata = req.metadata_mut();
         metadata.insert_bin(
             "auth-token-bin",
-            MetadataValue::from_bytes(&self.token.clone())
+            MetadataValue::from_bytes(&self.token.clone()),
         );
 
         let mut stream = self

--- a/common/flights/src/store_do_action.rs
+++ b/common/flights/src/store_do_action.rs
@@ -21,39 +21,39 @@ use crate::protobuf::FlightStoreRequest;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ReadPlanAction {
-    pub scan: ScanPlan
+    pub scan: ScanPlan,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct ReadPlanActionResult {}
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct CreateDatabaseAction {
-    pub plan: CreateDatabasePlan
+    pub plan: CreateDatabasePlan,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct CreateDatabaseActionResult {
-    pub database_id: i64
+    pub database_id: i64,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct DropDatabaseAction {
-    pub plan: DropDatabasePlan
+    pub plan: DropDatabasePlan,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct DropDatabaseActionResult {}
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct CreateTableAction {
-    pub plan: CreateTablePlan
+    pub plan: CreateTablePlan,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct CreateTableActionResult {
-    pub table_id: i64
+    pub table_id: i64,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct DropTableAction {
-    pub plan: DropTablePlan
+    pub plan: DropTablePlan,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct DropTableActionResult {}
@@ -61,14 +61,14 @@ pub struct DropTableActionResult {}
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetTableAction {
     pub db: String,
-    pub table: String
+    pub table: String,
 }
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetTableActionResult {
     pub table_id: i64,
     pub db: String,
     pub name: String,
-    pub schema: DataSchemaRef
+    pub schema: DataSchemaRef,
 }
 
 // Action wrapper for do_action.
@@ -79,7 +79,7 @@ pub enum StoreDoAction {
     DropDatabase(DropDatabaseAction),
     CreateTable(CreateTableAction),
     DropTable(DropTableAction),
-    GetTable(GetTableAction)
+    GetTable(GetTableAction),
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -89,7 +89,7 @@ pub enum StoreDoActionResult {
     DropDatabase(DropDatabaseActionResult),
     CreateTable(CreateTableActionResult),
     DropTable(DropTableActionResult),
-    GetTable(GetTableActionResult)
+    GetTable(GetTableActionResult),
 }
 
 /// Try convert tonic::Request<Action> to DoActionAction.
@@ -118,13 +118,13 @@ impl TryInto<Request<Action>> for &StoreDoAction {
 
     fn try_into(self) -> Result<Request<Action>, Self::Error> {
         let flight_request = FlightStoreRequest {
-            body: serde_json::to_string(&self)?
+            body: serde_json::to_string(&self)?,
         };
         let mut buf = vec![];
         flight_request.encode(&mut buf)?;
         let request = tonic::Request::new(Action {
             r#type: "".to_string(),
-            body: buf
+            body: buf,
         });
         Ok(request)
     }

--- a/common/flights/src/store_do_get.rs
+++ b/common/flights/src/store_do_get.rs
@@ -12,20 +12,20 @@ use common_planners::PlanNode;
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ReadAction {
     pub partition: Partitions,
-    pub push_down: PlanNode
+    pub push_down: PlanNode,
 }
 
 /// Pull a file. This is used to replicate data between store servers, which is only used internally.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct PullAction {
-    pub key: String
+    pub key: String,
 }
 
 // Action wrapper for do_get.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub enum StoreDoGet {
     Read(ReadAction),
-    Pull(PullAction)
+    Pull(PullAction),
 }
 
 /// Try convert tonic::Request<Ticket> to StoreDoGet.

--- a/common/functions/src/aggregators/aggregator_avg.rs
+++ b/common/functions/src/aggregators/aggregator_avg.rs
@@ -22,25 +22,25 @@ pub struct AggregatorAvgFunction {
     display_name: String,
     depth: usize,
     arg: Box<dyn IFunction>,
-    state: DataValue
+    state: DataValue,
 }
 
 impl AggregatorAvgFunction {
     pub fn try_create(
         display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         match args.len() {
             1 => Ok(Box::new(AggregatorAvgFunction {
                 display_name: display_name.to_string(),
                 depth: 0,
                 arg: args[0].clone(),
-                state: DataValue::Struct(vec![DataValue::Null, DataValue::UInt64(Some(0))])
+                state: DataValue::Struct(vec![DataValue::Null, DataValue::UInt64(Some(0))]),
             })),
             _ => Result::Err(ErrorCodes::BadArguments(format!(
                 "Function Error: Aggregator function {} args require single argument",
                 display_name
-            )))
+            ))),
         }
     }
 }
@@ -72,13 +72,13 @@ impl IFunction for AggregatorAvgFunction {
                 values[0].clone(),
                 DataArrayAggregate::data_array_aggregate_op(
                     DataValueAggregateOperator::Sum,
-                    val.to_array(1)?
-                )?
+                    val.to_array(1)?,
+                )?,
             )?;
             let count = DataValueArithmetic::data_value_arithmetic_op(
                 DataValueArithmeticOperator::Plus,
                 values[1].clone(),
-                DataValue::UInt64(Some(rows as u64))
+                DataValue::UInt64(Some(rows as u64)),
             )?;
 
             self.state = DataValue::Struct(vec![sum, count]);
@@ -98,12 +98,12 @@ impl IFunction for AggregatorAvgFunction {
             let sum = DataValueArithmetic::data_value_arithmetic_op(
                 DataValueArithmeticOperator::Plus,
                 new_states[0].clone(),
-                old_states[0].clone()
+                old_states[0].clone(),
             )?;
             let count = DataValueArithmetic::data_value_arithmetic_op(
                 DataValueArithmeticOperator::Plus,
                 new_states[1].clone(),
-                old_states[1].clone()
+                old_states[1].clone(),
             )?;
             self.state = DataValue::Struct(vec![sum, count]);
         }
@@ -115,7 +115,7 @@ impl IFunction for AggregatorAvgFunction {
             DataValueArithmetic::data_value_arithmetic_op(
                 DataValueArithmeticOperator::Div,
                 states[0].clone(),
-                states[1].clone()
+                states[1].clone(),
             )?
         } else {
             self.state.clone()

--- a/common/functions/src/aggregators/aggregator_count.rs
+++ b/common/functions/src/aggregators/aggregator_count.rs
@@ -20,13 +20,13 @@ pub struct AggregatorCountFunction {
     display_name: String,
     depth: usize,
     arg: Box<dyn IFunction>,
-    state: DataValue
+    state: DataValue,
 }
 
 impl AggregatorCountFunction {
     pub fn try_create(
         display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         let arg = if args.is_empty() {
             LiteralFunction::try_create(DataValue::UInt64(Some(1)))?
@@ -37,7 +37,7 @@ impl AggregatorCountFunction {
             display_name: display_name.to_string(),
             depth: 0,
             arg,
-            state: DataValue::Null
+            state: DataValue::Null,
         }))
     }
 }
@@ -64,7 +64,7 @@ impl IFunction for AggregatorCountFunction {
         self.state = DataValueArithmetic::data_value_arithmetic_op(
             DataValueArithmeticOperator::Plus,
             self.state.clone(),
-            DataValue::UInt64(Some(rows as u64))
+            DataValue::UInt64(Some(rows as u64)),
         )?;
         Ok(())
     }
@@ -78,7 +78,7 @@ impl IFunction for AggregatorCountFunction {
         self.state = DataValueArithmetic::data_value_arithmetic_op(
             DataValueArithmeticOperator::Plus,
             self.state.clone(),
-            val
+            val,
         )?;
         Ok(())
     }

--- a/common/functions/src/aggregators/aggregator_max.rs
+++ b/common/functions/src/aggregators/aggregator_max.rs
@@ -21,25 +21,25 @@ pub struct AggregatorMaxFunction {
     display_name: String,
     depth: usize,
     arg: Box<dyn IFunction>,
-    state: DataValue
+    state: DataValue,
 }
 
 impl AggregatorMaxFunction {
     pub fn try_create(
         display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         match args.len() {
             1 => Ok(Box::new(AggregatorMaxFunction {
                 display_name: display_name.to_string(),
                 depth: 0,
                 arg: args[0].clone(),
-                state: DataValue::Null
+                state: DataValue::Null,
             })),
             _ => Result::Err(ErrorCodes::BadArguments(format!(
                 "Function Error: Aggregator function {} args require single argument",
                 display_name
-            )))
+            ))),
         }
     }
 }
@@ -69,8 +69,8 @@ impl IFunction for AggregatorMaxFunction {
             self.state.clone(),
             DataArrayAggregate::data_array_aggregate_op(
                 DataValueAggregateOperator::Max,
-                val.to_array(rows)?
-            )?
+                val.to_array(rows)?,
+            )?,
         )?;
         Ok(())
     }
@@ -84,7 +84,7 @@ impl IFunction for AggregatorMaxFunction {
         self.state = DataValueAggregate::data_value_aggregate_op(
             DataValueAggregateOperator::Max,
             self.state.clone(),
-            val
+            val,
         )?;
         Ok(())
     }

--- a/common/functions/src/aggregators/aggregator_min.rs
+++ b/common/functions/src/aggregators/aggregator_min.rs
@@ -21,25 +21,25 @@ pub struct AggregatorMinFunction {
     display_name: String,
     depth: usize,
     arg: Box<dyn IFunction>,
-    state: DataValue
+    state: DataValue,
 }
 
 impl AggregatorMinFunction {
     pub fn try_create(
         display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         match args.len() {
             1 => Ok(Box::new(AggregatorMinFunction {
                 display_name: display_name.to_string(),
                 depth: 0,
                 arg: args[0].clone(),
-                state: DataValue::Null
+                state: DataValue::Null,
             })),
             _ => Result::Err(ErrorCodes::BadArguments(format!(
                 "Function Error: Aggregator function {} args require single argument",
                 display_name
-            )))
+            ))),
         }
     }
 }
@@ -69,8 +69,8 @@ impl IFunction for AggregatorMinFunction {
             self.state.clone(),
             DataArrayAggregate::data_array_aggregate_op(
                 DataValueAggregateOperator::Min,
-                val.to_array(rows)?
-            )?
+                val.to_array(rows)?,
+            )?,
         )?;
         Ok(())
     }
@@ -84,7 +84,7 @@ impl IFunction for AggregatorMinFunction {
         self.state = DataValueAggregate::data_value_aggregate_op(
             DataValueAggregateOperator::Min,
             self.state.clone(),
-            val
+            val,
         )?;
         Ok(())
     }

--- a/common/functions/src/aggregators/aggregator_sum.rs
+++ b/common/functions/src/aggregators/aggregator_sum.rs
@@ -22,25 +22,25 @@ pub struct AggregatorSumFunction {
     display_name: String,
     depth: usize,
     arg: Box<dyn IFunction>,
-    state: DataValue
+    state: DataValue,
 }
 
 impl AggregatorSumFunction {
     pub fn try_create(
         display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         match args.len() {
             1 => Ok(Box::new(AggregatorSumFunction {
                 display_name: display_name.to_string(),
                 depth: 0,
                 arg: args[0].clone(),
-                state: DataValue::Null
+                state: DataValue::Null,
             })),
             _ => Result::Err(ErrorCodes::BadArguments(format!(
                 "Function Error: Aggregator function {} args require single argument",
                 display_name
-            )))
+            ))),
         }
     }
 }
@@ -71,8 +71,8 @@ impl IFunction for AggregatorSumFunction {
             self.state.clone(),
             DataArrayAggregate::data_array_aggregate_op(
                 DataValueAggregateOperator::Sum,
-                val.to_array(rows)?
-            )?
+                val.to_array(rows)?,
+            )?,
         )?;
 
         Ok(())
@@ -87,7 +87,7 @@ impl IFunction for AggregatorSumFunction {
         self.state = DataValueArithmetic::data_value_arithmetic_op(
             DataValueArithmeticOperator::Plus,
             self.state.clone(),
-            val
+            val,
         )?;
         Ok(())
     }

--- a/common/functions/src/aggregators/aggregator_test.rs
+++ b/common/functions/src/aggregators/aggregator_test.rs
@@ -26,17 +26,20 @@ fn test_aggregator_function() -> Result<()> {
         block: DataBlock,
         expect: DataValue,
         error: &'static str,
-        func: Box<dyn IFunction>
+        func: Box<dyn IFunction>,
     }
 
     let schema = DataSchemaRefExt::create(vec![
         DataField::new("a", DataType::Int64, false),
         DataField::new("b", DataType::Int64, false),
     ]);
-    let block = DataBlock::create(schema.clone(), vec![
-        Arc::new(Int64Array::from(vec![4, 3, 2, 1])),
-        Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
-    ]);
+    let block = DataBlock::create(
+        schema.clone(),
+        vec![
+            Arc::new(Int64Array::from(vec![4, 3, 2, 1])),
+            Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
+        ],
+    );
 
     let field_a = ColumnFunction::try_create("a")?;
     let field_b = ColumnFunction::try_create("b")?;
@@ -48,12 +51,13 @@ fn test_aggregator_function() -> Result<()> {
             args: vec![field_a.clone(), field_b.clone()],
             display: "count(a)",
             nullable: false,
-            func: AggregatorCountFunction::try_create("count", &[ColumnFunction::try_create(
-                "a"
-            )?])?,
+            func: AggregatorCountFunction::try_create(
+                "count",
+                &[ColumnFunction::try_create("a")?],
+            )?,
             block: block.clone(),
             expect: DataValue::UInt64(Some(4)),
-            error: ""
+            error: "",
         },
         Test {
             name: "max-passed",
@@ -64,7 +68,7 @@ fn test_aggregator_function() -> Result<()> {
             func: AggregatorMaxFunction::try_create("max", &[ColumnFunction::try_create("a")?])?,
             block: block.clone(),
             expect: DataValue::Int64(Some(4)),
-            error: ""
+            error: "",
         },
         Test {
             name: "min-passed",
@@ -75,7 +79,7 @@ fn test_aggregator_function() -> Result<()> {
             func: AggregatorMinFunction::try_create("min", &[ColumnFunction::try_create("a")?])?,
             block: block.clone(),
             expect: DataValue::Int64(Some(1)),
-            error: ""
+            error: "",
         },
         Test {
             name: "avg-passed",
@@ -86,7 +90,7 @@ fn test_aggregator_function() -> Result<()> {
             func: AggregatorAvgFunction::try_create("avg", &[ColumnFunction::try_create("a")?])?,
             block: block.clone(),
             expect: DataValue::Float64(Some(2.5)),
-            error: ""
+            error: "",
         },
         Test {
             name: "sum-passed",
@@ -97,7 +101,7 @@ fn test_aggregator_function() -> Result<()> {
             func: AggregatorSumFunction::try_create("sum", &[ColumnFunction::try_create("a")?])?,
             block: block.clone(),
             expect: DataValue::Int64(Some(10)),
-            error: ""
+            error: "",
         },
         Test {
             name: "1+1+sum(a)-merge-passed",
@@ -105,16 +109,25 @@ fn test_aggregator_function() -> Result<()> {
             args: vec![field_a.clone(), field_b.clone()],
             display: "plus(1, plus(1, sum(a)))",
             nullable: false,
-            func: ArithmeticPlusFunction::try_create_func("+", &[
-                LiteralFunction::try_create(DataValue::Int64(Some(1)))?,
-                ArithmeticPlusFunction::try_create_func("+", &[
+            func: ArithmeticPlusFunction::try_create_func(
+                "+",
+                &[
                     LiteralFunction::try_create(DataValue::Int64(Some(1)))?,
-                    AggregatorSumFunction::try_create("sum", &[ColumnFunction::try_create("a")?])?
-                ])?
-            ])?,
+                    ArithmeticPlusFunction::try_create_func(
+                        "+",
+                        &[
+                            LiteralFunction::try_create(DataValue::Int64(Some(1)))?,
+                            AggregatorSumFunction::try_create(
+                                "sum",
+                                &[ColumnFunction::try_create("a")?],
+                            )?,
+                        ],
+                    )?,
+                ],
+            )?,
             block: block.clone(),
             expect: DataValue::Int64(Some(72)),
-            error: ""
+            error: "",
         },
         Test {
             name: "sum(a)/count(a)-merge-passed",
@@ -122,13 +135,19 @@ fn test_aggregator_function() -> Result<()> {
             args: vec![field_a.clone(), field_b.clone()],
             display: "divide(sum(a), count(a))",
             nullable: false,
-            func: ArithmeticDivFunction::try_create_func("/", &[
-                AggregatorSumFunction::try_create("sum", &[ColumnFunction::try_create("a")?])?,
-                AggregatorCountFunction::try_create("count", &[ColumnFunction::try_create("a")?])?
-            ])?,
+            func: ArithmeticDivFunction::try_create_func(
+                "/",
+                &[
+                    AggregatorSumFunction::try_create("sum", &[ColumnFunction::try_create("a")?])?,
+                    AggregatorCountFunction::try_create(
+                        "count",
+                        &[ColumnFunction::try_create("a")?],
+                    )?,
+                ],
+            )?,
             block: block.clone(),
             expect: DataValue::Float64(Some(2.5)),
-            error: ""
+            error: "",
         },
         Test {
             name: "(sum(a+1)+2)-merge-passed",
@@ -136,18 +155,25 @@ fn test_aggregator_function() -> Result<()> {
             args: vec![field_a.clone(), field_b.clone()],
             display: "plus(sum(plus(a, 1)), 2)",
             nullable: false,
-            func: ArithmeticPlusFunction::try_create_func("+", &[
-                AggregatorSumFunction::try_create("sum", &[
-                    ArithmeticPlusFunction::try_create_func("+", &[
-                        ColumnFunction::try_create("a")?,
-                        LiteralFunction::try_create(DataValue::Int8(Some(1)))?
-                    ])?
-                ])?,
-                LiteralFunction::try_create(DataValue::Int8(Some(2)))?
-            ])?,
+            func: ArithmeticPlusFunction::try_create_func(
+                "+",
+                &[
+                    AggregatorSumFunction::try_create(
+                        "sum",
+                        &[ArithmeticPlusFunction::try_create_func(
+                            "+",
+                            &[
+                                ColumnFunction::try_create("a")?,
+                                LiteralFunction::try_create(DataValue::Int8(Some(1)))?,
+                            ],
+                        )?],
+                    )?,
+                    LiteralFunction::try_create(DataValue::Int8(Some(2)))?,
+                ],
+            )?,
             block,
             expect: DataValue::Int64(Some(100)),
-            error: ""
+            error: "",
         },
     ];
 

--- a/common/functions/src/arithmetics/arithmetic.rs
+++ b/common/functions/src/arithmetics/arithmetic.rs
@@ -28,7 +28,7 @@ pub struct ArithmeticFunction {
     depth: usize,
     op: DataValueArithmeticOperator,
     left: Box<dyn IFunction>,
-    right: Box<dyn IFunction>
+    right: Box<dyn IFunction>,
 }
 
 impl ArithmeticFunction {
@@ -49,19 +49,19 @@ impl ArithmeticFunction {
 
     pub fn try_create_func(
         op: DataValueArithmeticOperator,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         match args.len() {
             2 => Ok(Box::new(ArithmeticFunction {
                 depth: 0,
                 op,
                 left: args[0].clone(),
-                right: args[1].clone()
+                right: args[1].clone(),
             })),
             _ => Result::Err(ErrorCodes::BadArguments(format!(
                 "Function Error: Arithmetic function {} args length must be 2",
                 op
-            )))
+            ))),
         }
     }
 }
@@ -75,7 +75,7 @@ impl IFunction for ArithmeticFunction {
         common_datavalues::numerical_arithmetic_coercion(
             &self.op,
             &self.left.return_type(input_schema)?,
-            &self.right.return_type(input_schema)?
+            &self.right.return_type(input_schema)?,
         )
     }
 
@@ -93,7 +93,7 @@ impl IFunction for ArithmeticFunction {
                 let data_value = DataValue::try_from_array(&result, 0)?;
                 Ok(DataColumnarValue::Scalar(data_value))
             }
-            _ => Ok(DataColumnarValue::Array(result))
+            _ => Ok(DataColumnarValue::Array(result)),
         }
     }
 
@@ -111,7 +111,7 @@ impl IFunction for ArithmeticFunction {
     fn accumulate_result(&self) -> Result<Vec<DataValue>> {
         Ok([
             &self.left.accumulate_result()?[..],
-            &self.right.accumulate_result()?[..]
+            &self.right.accumulate_result()?[..],
         ]
         .concat())
     }
@@ -125,7 +125,7 @@ impl IFunction for ArithmeticFunction {
         DataValueArithmetic::data_value_arithmetic_op(
             self.op.clone(),
             self.left.merge_result()?,
-            self.right.merge_result()?
+            self.right.merge_result()?,
         )
     }
 

--- a/common/functions/src/arithmetics/arithmetic_div.rs
+++ b/common/functions/src/arithmetics/arithmetic_div.rs
@@ -13,7 +13,7 @@ pub struct ArithmeticDivFunction;
 impl ArithmeticDivFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Div, args)
     }

--- a/common/functions/src/arithmetics/arithmetic_minus.rs
+++ b/common/functions/src/arithmetics/arithmetic_minus.rs
@@ -13,7 +13,7 @@ pub struct ArithmeticMinusFunction;
 impl ArithmeticMinusFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Minus, args)
     }

--- a/common/functions/src/arithmetics/arithmetic_modulo.rs
+++ b/common/functions/src/arithmetics/arithmetic_modulo.rs
@@ -13,7 +13,7 @@ pub struct ArithmeticModuloFunction;
 impl ArithmeticModuloFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Modulo, args)
     }

--- a/common/functions/src/arithmetics/arithmetic_mul.rs
+++ b/common/functions/src/arithmetics/arithmetic_mul.rs
@@ -13,7 +13,7 @@ pub struct ArithmeticMulFunction;
 impl ArithmeticMulFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Mul, args)
     }

--- a/common/functions/src/arithmetics/arithmetic_plus.rs
+++ b/common/functions/src/arithmetics/arithmetic_plus.rs
@@ -13,7 +13,7 @@ pub struct ArithmeticPlusFunction;
 impl ArithmeticPlusFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus, args)
     }

--- a/common/functions/src/arithmetics/arithmetic_test.rs
+++ b/common/functions/src/arithmetics/arithmetic_test.rs
@@ -23,7 +23,7 @@ fn test_arithmetic_function() -> Result<()> {
         block: DataBlock,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>
+        func: Box<dyn IFunction>,
     }
 
     let schema = DataSchemaRefExt::create(vec![
@@ -42,84 +42,102 @@ fn test_arithmetic_function() -> Result<()> {
             display: "plus(a, b)",
             nullable: false,
             func: ArithmeticPlusFunction::try_create_func("", &[field_a.clone(), field_b.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2, 1])),
-                Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
-                Arc::new(Int16Array::from(vec![1, 2, 3, 4])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2, 1])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
+                    Arc::new(Int16Array::from(vec![1, 2, 3, 4])),
+                ],
+            ),
             expect: Arc::new(Int64Array::from(vec![5, 5, 5, 5])),
-            error: ""
+            error: "",
         },
         Test {
             name: "add-diff-passed",
             display: "plus(c, a)",
             nullable: false,
             func: ArithmeticPlusFunction::try_create_func("", &[field_c.clone(), field_a.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2, 1])),
-                Arc::new(Int16Array::from(vec![1, 2, 3, 4])),
-                Arc::new(Int16Array::from(vec![1, 2, 3, 4])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2, 1])),
+                    Arc::new(Int16Array::from(vec![1, 2, 3, 4])),
+                    Arc::new(Int16Array::from(vec![1, 2, 3, 4])),
+                ],
+            ),
             expect: Arc::new(Int64Array::from(vec![5, 5, 5, 5])),
-            error: ""
+            error: "",
         },
         Test {
             name: "sub-int64-passed",
             display: "minus(a, b)",
             nullable: false,
-            func: ArithmeticMinusFunction::try_create_func("", &[
-                field_a.clone(),
-                field_b.clone()
-            ])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2])),
-                Arc::new(Int64Array::from(vec![1, 2, 3])),
-                Arc::new(Int16Array::from(vec![1, 2, 3])),
-            ]),
+            func: ArithmeticMinusFunction::try_create_func(
+                "",
+                &[field_a.clone(), field_b.clone()],
+            )?,
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3])),
+                    Arc::new(Int16Array::from(vec![1, 2, 3])),
+                ],
+            ),
             expect: Arc::new(Int64Array::from(vec![3, 1, -1])),
-            error: ""
+            error: "",
         },
         Test {
             name: "mul-int64-passed",
             display: "multiply(a, b)",
             nullable: false,
             func: ArithmeticMulFunction::try_create_func("", &[field_a.clone(), field_b.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2])),
-                Arc::new(Int64Array::from(vec![1, 2, 3])),
-                Arc::new(Int16Array::from(vec![1, 2, 3])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3])),
+                    Arc::new(Int16Array::from(vec![1, 2, 3])),
+                ],
+            ),
             expect: Arc::new(Int64Array::from(vec![4, 6, 6])),
-            error: ""
+            error: "",
         },
         Test {
             name: "div-int64-passed",
             display: "divide(a, b)",
             nullable: false,
             func: ArithmeticDivFunction::try_create_func("", &[field_a.clone(), field_b.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2])),
-                Arc::new(Int64Array::from(vec![1, 2, 3])),
-                Arc::new(Int16Array::from(vec![1, 2, 3])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3])),
+                    Arc::new(Int16Array::from(vec![1, 2, 3])),
+                ],
+            ),
             expect: Arc::new(Float64Array::from(vec![4.0, 1.5, 0.6666666666666666])),
-            error: ""
+            error: "",
         },
         Test {
             name: "mod-int64-passed",
             display: "modulo(a, b)",
             nullable: false,
-            func: ArithmeticModuloFunction::try_create_func("", &[
-                field_a.clone(),
-                field_b.clone()
-            ])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2])),
-                Arc::new(Int64Array::from(vec![1, 2, 3])),
-                Arc::new(Int16Array::from(vec![1, 2, 3])),
-            ]),
+            func: ArithmeticModuloFunction::try_create_func(
+                "",
+                &[field_a.clone(), field_b.clone()],
+            )?,
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3])),
+                    Arc::new(Int16Array::from(vec![1, 2, 3])),
+                ],
+            ),
             expect: Arc::new(Int64Array::from(vec![0, 1, 2])),
-            error: ""
+            error: "",
         },
     ];
 

--- a/common/functions/src/comparisons/comparison.rs
+++ b/common/functions/src/comparisons/comparison.rs
@@ -29,7 +29,7 @@ pub struct ComparisonFunction {
     op: DataValueComparisonOperator,
     left: Box<dyn IFunction>,
     right: Box<dyn IFunction>,
-    saved: Option<DataColumnarValue>
+    saved: Option<DataColumnarValue>,
 }
 
 impl ComparisonFunction {
@@ -48,7 +48,7 @@ impl ComparisonFunction {
 
     pub fn try_create_func(
         op: DataValueComparisonOperator,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         match args.len() {
             2 => Ok(Box::new(ComparisonFunction {
@@ -56,12 +56,12 @@ impl ComparisonFunction {
                 op,
                 left: args[0].clone(),
                 right: args[1].clone(),
-                saved: None
+                saved: None,
             })),
             _ => Result::Err(ErrorCodes::BadArguments(format!(
                 "Function Error: Comparison function {} args length must be 2",
                 op
-            )))
+            ))),
         }
     }
 }
@@ -89,7 +89,7 @@ impl IFunction for ComparisonFunction {
                 let data_value = DataValue::try_from_array(&result, 0)?;
                 Ok(DataColumnarValue::Scalar(data_value))
             }
-            _ => Ok(DataColumnarValue::Array(result))
+            _ => Ok(DataColumnarValue::Array(result)),
         }
     }
 

--- a/common/functions/src/comparisons/comparison_eq.rs
+++ b/common/functions/src/comparisons/comparison_eq.rs
@@ -13,7 +13,7 @@ pub struct ComparisonEqFunction;
 impl ComparisonEqFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::Eq, args)
     }

--- a/common/functions/src/comparisons/comparison_gt.rs
+++ b/common/functions/src/comparisons/comparison_gt.rs
@@ -13,7 +13,7 @@ pub struct ComparisonGtFunction;
 impl ComparisonGtFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::Gt, args)
     }

--- a/common/functions/src/comparisons/comparison_gt_eq.rs
+++ b/common/functions/src/comparisons/comparison_gt_eq.rs
@@ -13,7 +13,7 @@ pub struct ComparisonGtEqFunction;
 impl ComparisonGtEqFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::GtEq, args)
     }

--- a/common/functions/src/comparisons/comparison_lt.rs
+++ b/common/functions/src/comparisons/comparison_lt.rs
@@ -13,7 +13,7 @@ pub struct ComparisonLtFunction;
 impl ComparisonLtFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::Lt, args)
     }

--- a/common/functions/src/comparisons/comparison_lt_eq.rs
+++ b/common/functions/src/comparisons/comparison_lt_eq.rs
@@ -13,7 +13,7 @@ pub struct ComparisonLtEqFunction;
 impl ComparisonLtEqFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::LtEq, args)
     }

--- a/common/functions/src/comparisons/comparison_not_eq.rs
+++ b/common/functions/src/comparisons/comparison_not_eq.rs
@@ -13,7 +13,7 @@ pub struct ComparisonNotEqFunction;
 impl ComparisonNotEqFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::NotEq, args)
     }

--- a/common/functions/src/comparisons/comparison_test.rs
+++ b/common/functions/src/comparisons/comparison_test.rs
@@ -23,7 +23,7 @@ fn test_comparison_function() -> Result<()> {
         block: DataBlock,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>
+        func: Box<dyn IFunction>,
     }
 
     let schema = DataSchemaRefExt::create(vec![
@@ -40,75 +40,93 @@ fn test_comparison_function() -> Result<()> {
             display: "a = b",
             nullable: false,
             func: ComparisonEqFunction::try_create_func("", &[field_a.clone(), field_b.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
-                Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
+                ],
+            ),
             expect: Arc::new(BooleanArray::from(vec![false, false, false, true])),
-            error: ""
+            error: "",
         },
         Test {
             name: "gt-passed",
             display: "a > b",
             nullable: false,
             func: ComparisonGtFunction::try_create_func("", &[field_a.clone(), field_b.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
-                Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
+                ],
+            ),
             expect: Arc::new(BooleanArray::from(vec![true, true, false, false])),
-            error: ""
+            error: "",
         },
         Test {
             name: "gt-eq-passed",
             display: "a >= b",
             nullable: false,
             func: ComparisonGtEqFunction::try_create_func("", &[field_a.clone(), field_b.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
-                Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
+                ],
+            ),
             expect: Arc::new(BooleanArray::from(vec![true, true, false, true])),
-            error: ""
+            error: "",
         },
         Test {
             name: "lt-passed",
             display: "a < b",
             nullable: false,
             func: ComparisonLtFunction::try_create_func("", &[field_a.clone(), field_b.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
-                Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
+                ],
+            ),
             expect: Arc::new(BooleanArray::from(vec![false, false, true, false])),
-            error: ""
+            error: "",
         },
         Test {
             name: "lt-eq-passed",
             display: "a <= b",
             nullable: false,
             func: ComparisonLtEqFunction::try_create_func("", &[field_a.clone(), field_b.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
-                Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
+                ],
+            ),
             expect: Arc::new(BooleanArray::from(vec![false, false, true, true])),
-            error: ""
+            error: "",
         },
         Test {
             name: "not-eq-passed",
             display: "a != b",
             nullable: false,
-            func: ComparisonNotEqFunction::try_create_func("", &[
-                field_a.clone(),
-                field_b.clone()
-            ])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
-                Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
-            ]),
+            func: ComparisonNotEqFunction::try_create_func(
+                "",
+                &[field_a.clone(), field_b.clone()],
+            )?,
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(Int64Array::from(vec![4, 3, 2, 4])),
+                    Arc::new(Int64Array::from(vec![1, 2, 3, 4])),
+                ],
+            ),
             expect: Arc::new(BooleanArray::from(vec![true, true, true, false])),
-            error: ""
+            error: "",
         },
     ];
 

--- a/common/functions/src/expressions/cast.rs
+++ b/common/functions/src/expressions/cast.rs
@@ -23,7 +23,7 @@ pub struct CastFunction {
     /// The expression to cast
     expr: Box<dyn IFunction>,
     /// The data type to cast to
-    cast_type: DataType
+    cast_type: DataType,
 }
 
 impl CastFunction {
@@ -52,15 +52,15 @@ impl IFunction for CastFunction {
                 compute::kernels::cast::cast_with_options(
                     &v,
                     &self.cast_type,
-                    &DEFAULT_DATAFUSE_CAST_OPTIONS
-                )?
+                    &DEFAULT_DATAFUSE_CAST_OPTIONS,
+                )?,
             )),
             DataColumnarValue::Scalar(v) => {
                 let scalar_array = v.to_array()?;
                 let cast_array = compute::kernels::cast::cast_with_options(
                     &scalar_array,
                     &self.cast_type,
-                    &DEFAULT_DATAFUSE_CAST_OPTIONS
+                    &DEFAULT_DATAFUSE_CAST_OPTIONS,
                 )?;
                 let cast_scalar = DataValue::try_from_array(&cast_array, 0)?;
                 Ok(DataColumnarValue::Scalar(cast_scalar))

--- a/common/functions/src/expressions/cast_test.rs
+++ b/common/functions/src/expressions/cast_test.rs
@@ -22,7 +22,7 @@ fn test_cast_function() -> Result<()> {
         block: DataBlock,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>
+        func: Box<dyn IFunction>,
     }
 
     let field_a = ColumnFunction::try_create("a").unwrap();
@@ -34,11 +34,11 @@ fn test_cast_function() -> Result<()> {
             nullable: false,
             block: DataBlock::create(
                 DataSchemaRefExt::create(vec![DataField::new("a", DataType::Int64, false)]),
-                vec![Arc::new(Int64Array::from(vec![4, 3, 2, 4]))]
+                vec![Arc::new(Int64Array::from(vec![4, 3, 2, 4]))],
             ),
             func: CastFunction::create(field_a.clone(), DataType::Int8),
             expect: Arc::new(Int8Array::from(vec![4, 3, 2, 4])),
-            error: ""
+            error: "",
         },
         Test {
             name: "cast-string-to-date32-passed",
@@ -46,11 +46,11 @@ fn test_cast_function() -> Result<()> {
             nullable: false,
             block: DataBlock::create(
                 DataSchemaRefExt::create(vec![DataField::new("a", DataType::Utf8, false)]),
-                vec![Arc::new(StringArray::from(vec!["20210305", "20211024"]))]
+                vec![Arc::new(StringArray::from(vec!["20210305", "20211024"]))],
             ),
             func: CastFunction::create(field_a.clone(), DataType::Int32),
             expect: Arc::new(Int32Array::from(vec![20210305, 20211024])),
-            error: ""
+            error: "",
         },
     ];
 

--- a/common/functions/src/function_alias.rs
+++ b/common/functions/src/function_alias.rs
@@ -17,7 +17,7 @@ use crate::IFunction;
 pub struct AliasFunction {
     depth: usize,
     alias: String,
-    func: Box<dyn IFunction>
+    func: Box<dyn IFunction>,
 }
 
 impl AliasFunction {
@@ -25,7 +25,7 @@ impl AliasFunction {
         Ok(Box::new(AliasFunction {
             depth: 0,
             alias,
-            func
+            func,
         }))
     }
 }

--- a/common/functions/src/function_column.rs
+++ b/common/functions/src/function_column.rs
@@ -17,14 +17,14 @@ use crate::IFunction;
 #[derive(Clone, Debug)]
 pub struct ColumnFunction {
     value: String,
-    saved: Option<DataValue>
+    saved: Option<DataValue>,
 }
 
 impl ColumnFunction {
     pub fn try_create(value: &str) -> Result<Box<dyn IFunction>> {
         Ok(Box::new(ColumnFunction {
             value: value.to_string(),
-            saved: None
+            saved: None,
         }))
     }
 }

--- a/common/functions/src/function_column_test.rs
+++ b/common/functions/src/function_column_test.rs
@@ -13,9 +13,10 @@ fn test_column_function() -> anyhow::Result<()> {
     use crate::*;
 
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Boolean, false)]);
-    let block = DataBlock::create(schema.clone(), vec![Arc::new(BooleanArray::from(vec![
-        true, true, true, false,
-    ]))]);
+    let block = DataBlock::create(
+        schema.clone(),
+        vec![Arc::new(BooleanArray::from(vec![true, true, true, false]))],
+    );
 
     // Ok.
     {

--- a/common/functions/src/function_literal.rs
+++ b/common/functions/src/function_literal.rs
@@ -15,7 +15,7 @@ use crate::IFunction;
 
 #[derive(Clone, Debug)]
 pub struct LiteralFunction {
-    value: DataValue
+    value: DataValue,
 }
 
 impl LiteralFunction {

--- a/common/functions/src/logics/logic.rs
+++ b/common/functions/src/logics/logic.rs
@@ -24,7 +24,7 @@ pub struct LogicFunction {
     op: DataValueLogicOperator,
     left: Box<dyn IFunction>,
     right: Box<dyn IFunction>,
-    saved: Option<DataColumnarValue>
+    saved: Option<DataColumnarValue>,
 }
 
 impl LogicFunction {
@@ -37,7 +37,7 @@ impl LogicFunction {
 
     pub fn try_create_func(
         op: DataValueLogicOperator,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         match args.len() {
             2 => Result::Ok(Box::new(LogicFunction {
@@ -45,12 +45,12 @@ impl LogicFunction {
                 op,
                 left: args[0].clone(),
                 right: args[1].clone(),
-                saved: None
+                saved: None,
             })),
             _ => Result::Err(ErrorCodes::BadArguments(format!(
                 "Function Error: Logic function {} args length must be 2",
                 op
-            )))
+            ))),
         }
     }
 }
@@ -73,8 +73,8 @@ impl IFunction for LogicFunction {
             DataArrayLogic::data_array_logic_op(
                 self.op.clone(),
                 &self.left.eval(block)?,
-                &self.right.eval(block)?
-            )?
+                &self.right.eval(block)?,
+            )?,
         ))
     }
 

--- a/common/functions/src/logics/logic_and.rs
+++ b/common/functions/src/logics/logic_and.rs
@@ -13,7 +13,7 @@ pub struct LogicAndFunction;
 impl LogicAndFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         LogicFunction::try_create_func(DataValueLogicOperator::And, args)
     }

--- a/common/functions/src/logics/logic_or.rs
+++ b/common/functions/src/logics/logic_or.rs
@@ -13,7 +13,7 @@ pub struct LogicOrFunction;
 impl LogicOrFunction {
     pub fn try_create_func(
         _display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         LogicFunction::try_create_func(DataValueLogicOperator::Or, args)
     }

--- a/common/functions/src/logics/logic_test.rs
+++ b/common/functions/src/logics/logic_test.rs
@@ -22,7 +22,7 @@ fn test_logic_function() -> anyhow::Result<()> {
         block: DataBlock,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>
+        func: Box<dyn IFunction>,
     }
 
     let schema = DataSchemaRefExt::create(vec![
@@ -40,12 +40,15 @@ fn test_logic_function() -> anyhow::Result<()> {
             display: "a and b",
             nullable: false,
             func: LogicAndFunction::try_create_func("", &[field_a.clone(), field_b.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(BooleanArray::from(vec![true, true, true, false])),
-                Arc::new(BooleanArray::from(vec![true, false, true, true])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(BooleanArray::from(vec![true, true, true, false])),
+                    Arc::new(BooleanArray::from(vec![true, false, true, true])),
+                ],
+            ),
             expect: Arc::new(BooleanArray::from(vec![true, false, true, false])),
-            error: ""
+            error: "",
         },
         Test {
             name: "or-passed",
@@ -53,12 +56,15 @@ fn test_logic_function() -> anyhow::Result<()> {
             display: "a or b",
             nullable: false,
             func: LogicOrFunction::try_create_func("", &[field_a.clone(), field_b.clone()])?,
-            block: DataBlock::create(schema.clone(), vec![
-                Arc::new(BooleanArray::from(vec![true, true, true, false])),
-                Arc::new(BooleanArray::from(vec![true, false, true, true])),
-            ]),
+            block: DataBlock::create(
+                schema.clone(),
+                vec![
+                    Arc::new(BooleanArray::from(vec![true, true, true, false])),
+                    Arc::new(BooleanArray::from(vec![true, false, true, true])),
+                ],
+            ),
             expect: Arc::new(BooleanArray::from(vec![true, true, true, true])),
-            error: ""
+            error: "",
         },
     ];
 

--- a/common/functions/src/strings/substring.rs
+++ b/common/functions/src/strings/substring.rs
@@ -23,24 +23,24 @@ pub struct SubstringFunction {
     expr: Box<dyn IFunction>,
     /// Substring params
     from: Box<dyn IFunction>,
-    len: Box<dyn IFunction>
+    len: Box<dyn IFunction>,
 }
 
 impl SubstringFunction {
     pub fn try_create(
         display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         match args.len() {
             3 => Ok(Box::new(SubstringFunction {
                 display_name: display_name.to_string(),
                 expr: args[0].clone(),
                 from: args[1].clone(),
-                len: args[2].clone()
+                len: args[2].clone(),
             })),
             _ => Result::Err(ErrorCodes::BadArguments(
-                "Function Error: Substring function args length must be 3"
-            ))
+                "Function Error: Substring function args length must be 3",
+            )),
         }
     }
 }
@@ -82,14 +82,14 @@ impl IFunction for SubstringFunction {
 
         match value {
             DataColumnarValue::Array(v) => Ok(DataColumnarValue::Array(
-                compute::kernels::substring::substring(v.deref(), from_scalar, &len_scalar)?
+                compute::kernels::substring::substring(v.deref(), from_scalar, &len_scalar)?,
             )),
             DataColumnarValue::Scalar(v) => {
                 let scalar_array = v.to_array()?;
                 let substring_array = compute::kernels::substring::substring(
                     scalar_array.deref(),
                     from_scalar,
-                    &len_scalar
+                    &len_scalar,
                 )?;
                 let substring_scalar = DataValue::try_from_array(&substring_array, 0)?;
                 Ok(DataColumnarValue::Scalar(substring_scalar))

--- a/common/functions/src/strings/substring_test.rs
+++ b/common/functions/src/strings/substring_test.rs
@@ -25,7 +25,7 @@ fn test_substring_function() -> Result<()> {
         block: DataBlock,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>
+        func: Box<dyn IFunction>,
     }
 
     let field_a = ColumnFunction::try_create("a").unwrap();
@@ -37,15 +37,18 @@ fn test_substring_function() -> Result<()> {
             nullable: false,
             block: DataBlock::create(
                 DataSchemaRefExt::create(vec![DataField::new("a", DataType::Utf8, false)]),
-                vec![Arc::new(StringArray::from(vec!["abcde"]))]
+                vec![Arc::new(StringArray::from(vec!["abcde"]))],
             ),
-            func: SubstringFunction::try_create("substring", &[
-                field_a.clone(),
-                LiteralFunction::try_create(DataValue::Int64(Some(2)))?,
-                LiteralFunction::try_create(DataValue::UInt64(Some(3)))?
-            ])?,
+            func: SubstringFunction::try_create(
+                "substring",
+                &[
+                    field_a.clone(),
+                    LiteralFunction::try_create(DataValue::Int64(Some(2)))?,
+                    LiteralFunction::try_create(DataValue::UInt64(Some(3)))?,
+                ],
+            )?,
             expect: Arc::new(StringArray::from(vec!["bcd"])),
-            error: ""
+            error: "",
         },
         Test {
             name: "substring-abcde-passed",
@@ -53,15 +56,18 @@ fn test_substring_function() -> Result<()> {
             nullable: false,
             block: DataBlock::create(
                 DataSchemaRefExt::create(vec![DataField::new("a", DataType::Utf8, false)]),
-                vec![Arc::new(StringArray::from(vec!["abcde"]))]
+                vec![Arc::new(StringArray::from(vec!["abcde"]))],
             ),
-            func: SubstringFunction::try_create("substring", &[
-                field_a.clone(),
-                LiteralFunction::try_create(DataValue::Int64(Some(1)))?,
-                LiteralFunction::try_create(DataValue::UInt64(Some(3)))?
-            ])?,
+            func: SubstringFunction::try_create(
+                "substring",
+                &[
+                    field_a.clone(),
+                    LiteralFunction::try_create(DataValue::Int64(Some(1)))?,
+                    LiteralFunction::try_create(DataValue::UInt64(Some(3)))?,
+                ],
+            )?,
             expect: Arc::new(StringArray::from(vec!["abc"])),
-            error: ""
+            error: "",
         },
         Test {
             name: "substring-abcde-passed",
@@ -69,15 +75,18 @@ fn test_substring_function() -> Result<()> {
             nullable: false,
             block: DataBlock::create(
                 DataSchemaRefExt::create(vec![DataField::new("a", DataType::Utf8, false)]),
-                vec![Arc::new(StringArray::from(vec!["abcde"]))]
+                vec![Arc::new(StringArray::from(vec!["abcde"]))],
             ),
-            func: SubstringFunction::try_create("substring", &[
-                field_a.clone(),
-                LiteralFunction::try_create(DataValue::Int64(Some(2)))?,
-                LiteralFunction::try_create(DataValue::UInt64(None))?
-            ])?,
+            func: SubstringFunction::try_create(
+                "substring",
+                &[
+                    field_a.clone(),
+                    LiteralFunction::try_create(DataValue::Int64(Some(2)))?,
+                    LiteralFunction::try_create(DataValue::UInt64(None))?,
+                ],
+            )?,
             expect: Arc::new(StringArray::from(vec!["bcde"])),
-            error: ""
+            error: "",
         },
     ];
 

--- a/common/functions/src/udfs/database.rs
+++ b/common/functions/src/udfs/database.rs
@@ -16,23 +16,23 @@ use crate::IFunction;
 #[derive(Clone)]
 pub struct DatabaseFunction {
     display_name: String,
-    arg: Box<dyn IFunction>
+    arg: Box<dyn IFunction>,
 }
 
 impl DatabaseFunction {
     pub fn try_create(
         display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         match args.len() {
             1 => Ok(Box::new(Self {
                 display_name: display_name.to_string(),
-                arg: args[0].clone()
+                arg: args[0].clone(),
             })),
             _ => Result::Err(ErrorCodes::BadArguments(format!(
                 "The argument size of function {} must be one",
                 display_name
-            )))
+            ))),
         }
     }
 }

--- a/common/functions/src/udfs/database_test.rs
+++ b/common/functions/src/udfs/database_test.rs
@@ -21,7 +21,7 @@ fn test_database_function() -> anyhow::Result<()> {
         block: DataBlock,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>
+        func: Box<dyn IFunction>,
     }
 
     let database = LiteralFunction::try_create(DataValue::Utf8(Some("default".to_string())))?;
@@ -33,7 +33,7 @@ fn test_database_function() -> anyhow::Result<()> {
         func: DatabaseFunction::try_create("database", &[database.clone()])?,
         block: DataBlock::empty(),
         expect: Arc::new(StringArray::from(vec!["default"])),
-        error: ""
+        error: "",
     }];
 
     for t in tests {

--- a/common/functions/src/udfs/to_type_name.rs
+++ b/common/functions/src/udfs/to_type_name.rs
@@ -17,23 +17,23 @@ use crate::IFunction;
 #[derive(Clone)]
 pub struct ToTypeNameFunction {
     display_name: String,
-    arg: Box<dyn IFunction>
+    arg: Box<dyn IFunction>,
 }
 
 impl ToTypeNameFunction {
     pub fn try_create(
         display_name: &str,
-        args: &[Box<dyn IFunction>]
+        args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         match args.len() {
             1 => Ok(Box::new(ToTypeNameFunction {
                 display_name: display_name.to_string(),
-                arg: args[0].clone()
+                arg: args[0].clone(),
             })),
             _ => Result::Err(ErrorCodes::BadArguments(format!(
                 "The argument size of function {} must be one",
                 display_name
-            )))
+            ))),
         }
     }
 }

--- a/common/functions/src/udfs/to_type_name_test.rs
+++ b/common/functions/src/udfs/to_type_name_test.rs
@@ -21,7 +21,7 @@ fn test_to_type_name_function() -> anyhow::Result<()> {
         block: DataBlock,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>
+        func: Box<dyn IFunction>,
     }
 
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Boolean, false)]);
@@ -33,13 +33,14 @@ fn test_to_type_name_function() -> anyhow::Result<()> {
         display: "toTypeName(a)",
         nullable: false,
         func: ToTypeNameFunction::try_create("toTypeName", &[field_a.clone()])?,
-        block: DataBlock::create(schema.clone(), vec![Arc::new(BooleanArray::from(vec![
-            true, true, true, false,
-        ]))]),
+        block: DataBlock::create(
+            schema.clone(),
+            vec![Arc::new(BooleanArray::from(vec![true, true, true, false]))],
+        ),
         expect: Arc::new(StringArray::from(vec![
             "Boolean", "Boolean", "Boolean", "Boolean",
         ])),
-        error: ""
+        error: "",
     }];
 
     for t in tests {

--- a/common/functions/src/udfs/udf_example.rs
+++ b/common/functions/src/udfs/udf_example.rs
@@ -15,16 +15,16 @@ use crate::IFunction;
 
 #[derive(Clone)]
 pub struct UdfExampleFunction {
-    display_name: String
+    display_name: String,
 }
 
 impl UdfExampleFunction {
     pub fn try_create(
         display_name: &str,
-        _args: &[Box<dyn IFunction>]
+        _args: &[Box<dyn IFunction>],
     ) -> Result<Box<dyn IFunction>> {
         Ok(Box::new(UdfExampleFunction {
-            display_name: display_name.to_string()
+            display_name: display_name.to_string(),
         }))
     }
 }

--- a/common/functions/src/udfs/udf_example_test.rs
+++ b/common/functions/src/udfs/udf_example_test.rs
@@ -21,7 +21,7 @@ fn test_udf_example_function() -> anyhow::Result<()> {
         block: DataBlock,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>
+        func: Box<dyn IFunction>,
     }
 
     let schema = DataSchemaRefExt::create(vec![
@@ -37,12 +37,15 @@ fn test_udf_example_function() -> anyhow::Result<()> {
         display: "example()",
         nullable: false,
         func: UdfExampleFunction::try_create("example", &[field_a.clone(), field_b.clone()])?,
-        block: DataBlock::create(schema.clone(), vec![
-            Arc::new(BooleanArray::from(vec![true, true, true, false])),
-            Arc::new(BooleanArray::from(vec![true, false, true, true])),
-        ]),
+        block: DataBlock::create(
+            schema.clone(),
+            vec![
+                Arc::new(BooleanArray::from(vec![true, true, true, false])),
+                Arc::new(BooleanArray::from(vec![true, false, true, true])),
+            ],
+        ),
         expect: Arc::new(BooleanArray::from(vec![true, true, true, true])),
-        error: ""
+        error: "",
     }];
 
     for t in tests {

--- a/common/planners/src/plan_aggregator_final.rs
+++ b/common/planners/src/plan_aggregator_final.rs
@@ -14,7 +14,7 @@ pub struct AggregatorFinalPlan {
     pub aggr_expr: Vec<ExpressionAction>,
     pub group_expr: Vec<ExpressionAction>,
     pub schema: DataSchemaRef,
-    pub input: Arc<PlanNode>
+    pub input: Arc<PlanNode>,
 }
 
 impl AggregatorFinalPlan {

--- a/common/planners/src/plan_aggregator_partial.rs
+++ b/common/planners/src/plan_aggregator_partial.rs
@@ -13,7 +13,7 @@ use crate::PlanNode;
 pub struct AggregatorPartialPlan {
     pub group_expr: Vec<ExpressionAction>,
     pub aggr_expr: Vec<ExpressionAction>,
-    pub input: Arc<PlanNode>
+    pub input: Arc<PlanNode>,
 }
 
 impl AggregatorPartialPlan {

--- a/common/planners/src/plan_aggregator_test.rs
+++ b/common/planners/src/plan_aggregator_test.rs
@@ -20,7 +20,7 @@ mod tests {
             .build()?;
         let explain = PlanNode::Explain(ExplainPlan {
             typ: ExplainType::Syntax,
-            input: Arc::new(plan)
+            input: Arc::new(plan),
         });
         let expect = "\
         Projection: sumx:UInt64\
@@ -44,7 +44,7 @@ mod tests {
             name: &'static str,
             plan: Result<PlanBuilder, ErrorCodes>,
             expect_error: bool,
-            expect: &'static str
+            expect: &'static str,
         }
 
         let source = Test::create().generate_source_plan_for_test(10000)?;

--- a/common/planners/src/plan_builder_test.rs
+++ b/common/planners/src/plan_builder_test.rs
@@ -12,7 +12,7 @@ fn test_plan_builds() -> anyhow::Result<()> {
     struct TestCase {
         name: &'static str,
         plan: Result<PlanNode>,
-        expect: &'static str
+        expect: &'static str,
     }
 
     let source = Test::create().generate_source_plan_for_test(10000)?;

--- a/common/planners/src/plan_database_create.rs
+++ b/common/planners/src/plan_database_create.rs
@@ -12,14 +12,14 @@ use common_datavalues::DataSchemaRef;
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum DatabaseEngineType {
     Local,
-    Remote
+    Remote,
 }
 
 impl ToString for DatabaseEngineType {
     fn to_string(&self) -> String {
         match self {
             DatabaseEngineType::Local => "Local".into(),
-            DatabaseEngineType::Remote => "Remote".into()
+            DatabaseEngineType::Remote => "Remote".into(),
         }
     }
 }
@@ -31,7 +31,7 @@ pub struct CreateDatabasePlan {
     pub if_not_exists: bool,
     pub db: String,
     pub engine: DatabaseEngineType,
-    pub options: DatabaseOptions
+    pub options: DatabaseOptions,
 }
 
 impl CreateDatabasePlan {

--- a/common/planners/src/plan_database_drop.rs
+++ b/common/planners/src/plan_database_drop.rs
@@ -10,7 +10,7 @@ use common_datavalues::DataSchemaRef;
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct DropDatabasePlan {
     pub if_exists: bool,
-    pub db: String
+    pub db: String,
 }
 
 impl DropDatabasePlan {

--- a/common/planners/src/plan_display_test.rs
+++ b/common/planners/src/plan_display_test.rs
@@ -28,7 +28,7 @@ fn test_plan_display_indent() -> anyhow::Result<()> {
         table: "bar".into(),
         schema,
         engine: TableEngineType::JsonEachRaw,
-        options
+        options,
     });
 
     assert_eq!(

--- a/common/planners/src/plan_empty.rs
+++ b/common/planners/src/plan_empty.rs
@@ -7,13 +7,13 @@ use common_datavalues::DataSchemaRef;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct EmptyPlan {
-    pub schema: DataSchemaRef
+    pub schema: DataSchemaRef,
 }
 
 impl EmptyPlan {
     pub fn create() -> Self {
         EmptyPlan {
-            schema: DataSchemaRef::new(DataSchema::empty())
+            schema: DataSchemaRef::new(DataSchema::empty()),
         }
     }
 }

--- a/common/planners/src/plan_explain.rs
+++ b/common/planners/src/plan_explain.rs
@@ -12,13 +12,13 @@ use crate::PlanNode;
 pub enum ExplainType {
     Syntax,
     Graph,
-    Pipeline
+    Pipeline,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct ExplainPlan {
     pub typ: ExplainType,
-    pub input: Arc<PlanNode>
+    pub input: Arc<PlanNode>,
 }
 
 impl ExplainPlan {

--- a/common/planners/src/plan_explain_test.rs
+++ b/common/planners/src/plan_explain_test.rs
@@ -18,7 +18,7 @@ fn test_explain_plan() -> anyhow::Result<()> {
         .build()?;
     let explain = PlanNode::Explain(ExplainPlan {
         typ: ExplainType::Syntax,
-        input: Arc::new(plan)
+        input: Arc::new(plan),
     });
     let expect ="\
     Having: ((number + 1) = 4)\

--- a/common/planners/src/plan_expression.rs
+++ b/common/planners/src/plan_expression.rs
@@ -14,7 +14,7 @@ pub struct ExpressionPlan {
     pub exprs: Vec<ExpressionAction>,
     pub schema: DataSchemaRef,
     pub input: Arc<PlanNode>,
-    pub desc: String
+    pub desc: String,
 }
 
 impl ExpressionPlan {

--- a/common/planners/src/plan_expression_action.rs
+++ b/common/planners/src/plan_expression_action.rs
@@ -28,12 +28,12 @@ pub enum ExpressionAction {
     BinaryExpression {
         left: Box<ExpressionAction>,
         op: String,
-        right: Box<ExpressionAction>
+        right: Box<ExpressionAction>,
     },
     /// Functions with a set of arguments.
     Function {
         op: String,
-        args: Vec<ExpressionAction>
+        args: Vec<ExpressionAction>,
     },
 
     /// A sort expression, that can be used to sort values.
@@ -43,7 +43,7 @@ pub enum ExpressionAction {
         /// The direction of the sort
         asc: bool,
         /// Whether to put Nulls before all other data values
-        nulls_first: bool
+        nulls_first: bool,
     },
     /// All fields(*) in a schema.
     Wildcard,
@@ -53,8 +53,8 @@ pub enum ExpressionAction {
         /// The expression being cast
         expr: Box<ExpressionAction>,
         /// The `DataType` the expression will yield
-        data_type: DataType
-    }
+        data_type: DataType,
+    },
 }
 
 impl ExpressionAction {
@@ -89,8 +89,8 @@ impl ExpressionAction {
             ExpressionAction::Wildcard => ColumnFunction::try_create("*"),
             ExpressionAction::Cast { expr, data_type } => Ok(CastFunction::create(
                 expr.to_function_with_depth(depth)?,
-                data_type.clone()
-            ))
+                data_type.clone(),
+            )),
         }
     }
 

--- a/common/planners/src/plan_expression_action_function.rs
+++ b/common/planners/src/plan_expression_action_function.rs
@@ -9,7 +9,7 @@ fn binary_expr(l: ExpressionAction, op: &str, r: ExpressionAction) -> Expression
     ExpressionAction::BinaryExpression {
         left: Box::new(l),
         op: op.to_string(),
-        right: Box::new(r)
+        right: Box::new(r),
     }
 }
 
@@ -27,7 +27,7 @@ pub fn modular(left: ExpressionAction, right: ExpressionAction) -> ExpressionAct
 pub fn sum(other: ExpressionAction) -> ExpressionAction {
     ExpressionAction::Function {
         op: "sum".to_string(),
-        args: vec![other]
+        args: vec![other],
     }
 }
 
@@ -35,7 +35,7 @@ pub fn sum(other: ExpressionAction) -> ExpressionAction {
 pub fn avg(other: ExpressionAction) -> ExpressionAction {
     ExpressionAction::Function {
         op: "avg".to_string(),
-        args: vec![other]
+        args: vec![other],
     }
 }
 

--- a/common/planners/src/plan_expression_action_sort.rs
+++ b/common/planners/src/plan_expression_action_sort.rs
@@ -9,6 +9,6 @@ pub fn sort(name: &str, asc: bool, nulls_first: bool) -> ExpressionAction {
     ExpressionAction::Sort {
         expr: Box::new(col(name)),
         asc,
-        nulls_first
+        nulls_first,
     }
 }

--- a/common/planners/src/plan_expression_action_test.rs
+++ b/common/planners/src/plan_expression_action_test.rs
@@ -19,12 +19,12 @@ fn test_expression_action_plan() -> anyhow::Result<()> {
                 .and(col("number").lt(lit(4)))
                 .and(col("number").lt_eq(lit(4)))
                 .and(col("number").gt(lit(4)))
-                .and(col("number").gt_eq(lit(4)))
+                .and(col("number").gt_eq(lit(4))),
         )?
         .build()?;
     let explain = PlanNode::Explain(ExplainPlan {
         typ: ExplainType::Syntax,
-        input: Arc::new(plan)
+        input: Arc::new(plan),
     });
     let expect ="Filter: (((((((number + 1) = 4) and (number != 4)) and (number < 4)) and (number <= 4)) and (number > 4)) and (number >= 4))\
     \n  ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 10000, read_bytes: 80000]";

--- a/common/planners/src/plan_expression_test.rs
+++ b/common/planners/src/plan_expression_test.rs
@@ -15,7 +15,7 @@ fn test_expression_plan() -> anyhow::Result<()> {
         exprs: vec![col("a")],
         schema: DataSchemaRefExt::create(vec![DataField::new("a", DataType::Utf8, false)]),
         input: Arc::from(PlanBuilder::empty().build()?),
-        desc: "".to_string()
+        desc: "".to_string(),
     });
     let _ = expression.schema();
     let expect = "Expression: a:Utf8 ()";

--- a/common/planners/src/plan_filter.rs
+++ b/common/planners/src/plan_filter.rs
@@ -14,7 +14,7 @@ pub struct FilterPlan {
     /// The predicate expression, which must have Boolean type.
     pub predicate: ExpressionAction,
     /// The incoming logical plan
-    pub input: Arc<PlanNode>
+    pub input: Arc<PlanNode>,
 }
 
 impl FilterPlan {

--- a/common/planners/src/plan_having.rs
+++ b/common/planners/src/plan_having.rs
@@ -14,7 +14,7 @@ pub struct HavingPlan {
     /// The predicate expression, which must have Boolean type.
     pub predicate: ExpressionAction,
     /// The incoming logical plan
-    pub input: Arc<PlanNode>
+    pub input: Arc<PlanNode>,
 }
 
 impl HavingPlan {

--- a/common/planners/src/plan_limit.rs
+++ b/common/planners/src/plan_limit.rs
@@ -13,7 +13,7 @@ pub struct LimitPlan {
     /// The limit
     pub n: usize,
     /// The logical plan
-    pub input: Arc<PlanNode>
+    pub input: Arc<PlanNode>,
 }
 
 impl LimitPlan {

--- a/common/planners/src/plan_limit_test.rs
+++ b/common/planners/src/plan_limit_test.rs
@@ -12,7 +12,7 @@ fn test_limit_plan() -> anyhow::Result<()> {
 
     let limit = PlanNode::Limit(LimitPlan {
         n: 33,
-        input: Arc::from(PlanBuilder::empty().build()?)
+        input: Arc::from(PlanBuilder::empty().build()?),
     });
     let expect = "Limit: 33";
     let actual = format!("{:?}", limit);

--- a/common/planners/src/plan_node.rs
+++ b/common/planners/src/plan_node.rs
@@ -48,7 +48,7 @@ pub enum PlanNode {
     CreateTable(CreateTablePlan),
     DropTable(DropTablePlan),
     UseDatabase(UseDatabasePlan),
-    SetVariable(SettingPlan)
+    SetVariable(SettingPlan),
 }
 
 impl PlanNode {
@@ -74,7 +74,7 @@ impl PlanNode {
             PlanNode::DropTable(v) => v.schema(),
             PlanNode::SetVariable(v) => v.schema(),
             PlanNode::Sort(v) => v.schema(),
-            PlanNode::UseDatabase(v) => v.schema()
+            PlanNode::UseDatabase(v) => v.schema(),
         }
     }
 
@@ -99,7 +99,7 @@ impl PlanNode {
             PlanNode::DropTable(_) => "DropTablePlan",
             PlanNode::SetVariable(_) => "SetVariablePlan",
             PlanNode::Sort(_) => "SortPlan",
-            PlanNode::UseDatabase(_) => "UseDatabasePlan"
+            PlanNode::UseDatabase(_) => "UseDatabasePlan",
         }
     }
 
@@ -117,7 +117,7 @@ impl PlanNode {
             PlanNode::Select(v) => vec![v.input.clone()],
             PlanNode::Sort(v) => vec![v.input.clone()],
 
-            _ => vec![]
+            _ => vec![],
         }
     }
 

--- a/common/planners/src/plan_partition.rs
+++ b/common/planners/src/plan_partition.rs
@@ -7,5 +7,5 @@ pub type Partitions = Vec<Partition>;
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct Partition {
     pub name: String,
-    pub version: u64
+    pub version: u64,
 }

--- a/common/planners/src/plan_projection.rs
+++ b/common/planners/src/plan_projection.rs
@@ -18,7 +18,7 @@ pub struct ProjectionPlan {
     /// The schema description of the output
     pub schema: DataSchemaRef,
     /// The incoming logical plan
-    pub input: Arc<PlanNode>
+    pub input: Arc<PlanNode>,
 }
 
 impl ProjectionPlan {

--- a/common/planners/src/plan_projection_test.rs
+++ b/common/planners/src/plan_projection_test.rs
@@ -14,7 +14,7 @@ fn test_projection_plan() -> anyhow::Result<()> {
     let projection = PlanNode::Projection(ProjectionPlan {
         expr: vec![col("a")],
         schema: DataSchemaRefExt::create(vec![DataField::new("a", DataType::Utf8, false)]),
-        input: Arc::from(PlanBuilder::empty().build()?)
+        input: Arc::from(PlanBuilder::empty().build()?),
     });
     let _ = projection.schema();
     let expect = "Projection: a:Utf8";

--- a/common/planners/src/plan_read_datasource.rs
+++ b/common/planners/src/plan_read_datasource.rs
@@ -17,7 +17,7 @@ pub struct ReadDataSourcePlan {
     pub schema: DataSchemaRef,
     pub partitions: Partitions,
     pub statistics: Statistics,
-    pub description: String
+    pub description: String,
 }
 
 impl ReadDataSourcePlan {
@@ -28,7 +28,7 @@ impl ReadDataSourcePlan {
             schema: Arc::from(DataSchema::empty()),
             partitions: vec![],
             statistics: Statistics::default(),
-            description: "".to_string()
+            description: "".to_string(),
         }
     }
 

--- a/common/planners/src/plan_rewriter.rs
+++ b/common/planners/src/plan_rewriter.rs
@@ -75,18 +75,18 @@ pub trait PlanRewriter<'plan> {
             PlanNode::Having(plan) => self.rewrite_having(plan),
             PlanNode::Expression(plan) => self.rewrite_expression(plan),
             PlanNode::DropTable(plan) => self.rewrite_drop_table(plan),
-            PlanNode::DropDatabase(plan) => self.rewrite_drop_database(plan)
+            PlanNode::DropDatabase(plan) => self.rewrite_drop_database(plan),
         }
     }
 
     fn rewrite_aggregate_partial(
         &mut self,
-        plan: &'plan AggregatorPartialPlan
+        plan: &'plan AggregatorPartialPlan,
     ) -> Result<PlanNode> {
         Ok(PlanNode::AggregatorPartial(AggregatorPartialPlan {
             aggr_expr: plan.aggr_expr.clone(),
             group_expr: plan.group_expr.clone(),
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
@@ -95,7 +95,7 @@ pub trait PlanRewriter<'plan> {
             schema: plan.schema.clone(),
             aggr_expr: plan.aggr_expr.clone(),
             group_expr: plan.group_expr.clone(),
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
@@ -108,7 +108,7 @@ pub trait PlanRewriter<'plan> {
             uuid: plan.uuid.clone(),
             id: plan.id,
             state: plan.state.clone(),
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
@@ -116,7 +116,7 @@ pub trait PlanRewriter<'plan> {
         Ok(PlanNode::Projection(ProjectionPlan {
             schema: plan.schema.clone(),
             expr: plan.expr.clone(),
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
@@ -125,35 +125,35 @@ pub trait PlanRewriter<'plan> {
             schema: plan.schema.clone(),
             desc: plan.desc.clone(),
             exprs: plan.exprs.clone(),
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
     fn rewrite_filter(&mut self, plan: &'plan FilterPlan) -> Result<PlanNode> {
         Ok(PlanNode::Filter(FilterPlan {
             predicate: plan.predicate.clone(),
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
     fn rewrite_having(&mut self, plan: &'plan HavingPlan) -> Result<PlanNode> {
         Ok(PlanNode::Having(HavingPlan {
             predicate: plan.predicate.clone(),
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
     fn rewrite_sort(&mut self, plan: &'plan SortPlan) -> Result<PlanNode> {
         Ok(PlanNode::Sort(SortPlan {
             order_by: plan.order_by.clone(),
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
     fn rewrite_limit(&mut self, plan: &'plan LimitPlan) -> Result<PlanNode> {
         Ok(PlanNode::Limit(LimitPlan {
             n: plan.n,
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
@@ -167,14 +167,14 @@ pub trait PlanRewriter<'plan> {
 
     fn rewrite_select(&mut self, plan: &'plan SelectPlan) -> Result<PlanNode> {
         Ok(PlanNode::Select(SelectPlan {
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
     fn rewrite_explain(&mut self, plan: &'plan ExplainPlan) -> Result<PlanNode> {
         Ok(PlanNode::Explain(ExplainPlan {
             typ: plan.typ,
-            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?)
+            input: Arc::new(self.rewrite_plan_node(plan.input.as_ref())?),
         }))
     }
 
@@ -209,7 +209,7 @@ struct QueryAliasData {
     aliases: HashMap<String, ExpressionAction>,
     inside_aliases: HashSet<String>,
     // deepest alias current step in
-    current_alias: String
+    current_alias: String,
 }
 
 impl RewriteHelper {
@@ -225,7 +225,7 @@ impl RewriteHelper {
         let mut data = QueryAliasData {
             aliases: mp,
             inside_aliases: HashSet::new(),
-            current_alias: "".into()
+            current_alias: "".into(),
         };
 
         exprs
@@ -236,7 +236,7 @@ impl RewriteHelper {
 
     fn alias_exprs_to_map(
         exprs: &[ExpressionAction],
-        mp: &mut HashMap<String, ExpressionAction>
+        mp: &mut HashMap<String, ExpressionAction>,
     ) -> Result<()> {
         for expr in exprs.iter() {
             if let ExpressionAction::Alias(alias, alias_expr) = expr {
@@ -259,7 +259,7 @@ impl RewriteHelper {
 
     fn expr_rewrite_alias(
         expr: &ExpressionAction,
-        data: &mut QueryAliasData
+        data: &mut QueryAliasData,
     ) -> Result<ExpressionAction> {
         match expr {
             ExpressionAction::Column(field) => {
@@ -298,7 +298,7 @@ impl RewriteHelper {
                 Ok(ExpressionAction::BinaryExpression {
                     left: Box::new(left_new),
                     op: op.clone(),
-                    right: Box::new(right_new)
+                    right: Box::new(right_new),
                 })
             }
 
@@ -311,9 +311,9 @@ impl RewriteHelper {
                 match new_args {
                     Ok(v) => Ok(ExpressionAction::Function {
                         op: op.clone(),
-                        args: v
+                        args: v,
                     }),
-                    Err(v) => Err(v)
+                    Err(v) => Err(v),
                 }
             }
 
@@ -338,12 +338,12 @@ impl RewriteHelper {
                 let new_expr = RewriteHelper::expr_rewrite_alias(expr, data)?;
                 Ok(ExpressionAction::Cast {
                     expr: Box::new(new_expr),
-                    data_type: data_type.clone()
+                    data_type: data_type.clone(),
                 })
             }
             ExpressionAction::Wildcard
             | ExpressionAction::Literal(_)
-            | ExpressionAction::Sort { .. } => Ok(expr.clone())
+            | ExpressionAction::Sort { .. } => Ok(expr.clone()),
         }
     }
 
@@ -353,7 +353,7 @@ impl RewriteHelper {
     /// SELECT a as b ... where a>1
     pub fn rewrite_alias_expr(
         projection_map: &HashMap<String, ExpressionAction>,
-        expr: &ExpressionAction
+        expr: &ExpressionAction,
     ) -> Result<ExpressionAction> {
         let expressions = Self::expression_plan_children(expr)?;
 
@@ -373,7 +373,7 @@ impl RewriteHelper {
     /// replaces expressions columns by its name on the projection.
     pub fn rewrite_alias_exprs(
         projection_map: &HashMap<String, ExpressionAction>,
-        exprs: &[ExpressionAction]
+        exprs: &[ExpressionAction],
     ) -> Result<Vec<ExpressionAction>> {
         exprs
             .iter()
@@ -400,7 +400,7 @@ impl RewriteHelper {
             ExpressionAction::Function { args, .. } => args.clone(),
             ExpressionAction::Wildcard => vec![],
             ExpressionAction::Sort { expr, .. } => vec![expr.as_ref().clone()],
-            ExpressionAction::Cast { expr, .. } => vec![expr.as_ref().clone()]
+            ExpressionAction::Cast { expr, .. } => vec![expr.as_ref().clone()],
         })
     }
 
@@ -426,21 +426,21 @@ impl RewriteHelper {
             }
             ExpressionAction::Wildcard => vec![],
             ExpressionAction::Sort { expr, .. } => Self::expression_plan_columns(expr)?,
-            ExpressionAction::Cast { expr, .. } => Self::expression_plan_columns(expr)?
+            ExpressionAction::Cast { expr, .. } => Self::expression_plan_columns(expr)?,
         })
     }
 
     /// Collect all unique projection fields to a map.
     fn projections_to_map(
         plan: &PlanNode,
-        map: &mut HashMap<String, ExpressionAction>
+        map: &mut HashMap<String, ExpressionAction>,
     ) -> Result<()> {
         match plan {
             PlanNode::Projection(v) => {
                 v.schema.fields().iter().enumerate().for_each(|(i, field)| {
                     let expr = match &v.expr[i] {
                         ExpressionAction::Alias(_alias, plan) => plan.as_ref().clone(),
-                        other => other.clone()
+                        other => other.clone(),
                     };
                     map.insert(field.name().clone(), expr);
                 })
@@ -470,7 +470,7 @@ impl RewriteHelper {
 
     fn rebuild_from_exprs(
         expr: &ExpressionAction,
-        expressions: &[ExpressionAction]
+        expressions: &[ExpressionAction],
     ) -> ExpressionAction {
         match expr {
             ExpressionAction::Alias(alias, _) => {
@@ -481,13 +481,13 @@ impl RewriteHelper {
             ExpressionAction::BinaryExpression { op, .. } => ExpressionAction::BinaryExpression {
                 left: Box::new(expressions[0].clone()),
                 op: op.clone(),
-                right: Box::new(expressions[1].clone())
+                right: Box::new(expressions[1].clone()),
             },
             ExpressionAction::Function { op, .. } => ExpressionAction::Function {
                 op: op.clone(),
-                args: expressions.to_vec()
+                args: expressions.to_vec(),
             },
-            other => other.clone()
+            other => other.clone(),
         }
     }
 
@@ -498,7 +498,7 @@ impl RewriteHelper {
     pub fn check_aggr_in_group_expr(
         aggr: &ExpressionAction,
         group_by_names: &HashSet<String>,
-        input_schema: &DataSchemaRef
+        input_schema: &DataSchemaRef,
     ) -> Result<bool> {
         match aggr {
             ExpressionAction::Alias(alias, plan) => {
@@ -528,7 +528,7 @@ impl RewriteHelper {
 
     pub fn exprs_to_fields(
         exprs: &[ExpressionAction],
-        input_schema: &DataSchemaRef
+        input_schema: &DataSchemaRef,
     ) -> Result<Vec<DataField>> {
         exprs
             .iter()

--- a/common/planners/src/plan_rewriter_test.rs
+++ b/common/planners/src/plan_rewriter_test.rs
@@ -15,7 +15,7 @@ fn test_rewrite_projection_alias_plan() -> anyhow::Result<()> {
         name: &'static str,
         exprs: Vec<ExpressionAction>,
         expect_str: &'static str,
-        error_msg: &'static str
+        error_msg: &'static str,
     }
 
     let tests = vec![
@@ -155,7 +155,7 @@ fn test_rewrite_projection_alias_plan() -> anyhow::Result<()> {
         let result = RewriteHelper::rewrite_projection_aliases(&t.exprs);
         match &result {
             Ok(v) => assert_eq!(t.expect_str, format!("{:?}", v), "in test_case {}", t.name),
-            Err(e) => assert_eq!(t.error_msg, e.to_string(), "in test_case {}", t.name)
+            Err(e) => assert_eq!(t.error_msg, e.to_string(), "in test_case {}", t.name),
         }
     }
 
@@ -181,12 +181,12 @@ fn test_rewrite_expressions_plan() -> anyhow::Result<()> {
 
     let exprs = vec![ExpressionAction::Function {
         op: "multiply".to_string(),
-        args: vec![col("x"), col("y")]
+        args: vec![col("x"), col("y")],
     }];
 
     let expect_plan = ExpressionAction::Function {
         op: "multiply".to_string(),
-        args: vec![col("number"), col("number")]
+        args: vec![col("number"), col("number")],
     };
     let actual_plan = RewriteHelper::rewrite_alias_exprs(&actual, &exprs)?;
     assert_eq!(expect_plan, actual_plan[0]);

--- a/common/planners/src/plan_scan.rs
+++ b/common/planners/src/plan_scan.rs
@@ -23,7 +23,7 @@ pub struct ScanPlan {
     /// Optional filter expression plan
     pub filters: Vec<ExpressionAction>,
     /// Optional limit to skip read
-    pub limit: Option<usize>
+    pub limit: Option<usize>,
 }
 
 impl ScanPlan {
@@ -39,7 +39,7 @@ impl ScanPlan {
             projection: None,
             projected_schema: Arc::new(DataSchema::empty()),
             filters: vec![],
-            limit: None
+            limit: None,
         }
     }
 }

--- a/common/planners/src/plan_scan_test.rs
+++ b/common/planners/src/plan_scan_test.rs
@@ -17,10 +17,10 @@ fn test_scan_plan() -> anyhow::Result<()> {
         projected_schema: DataSchemaRefExt::create(vec![DataField::new(
             "a",
             DataType::Utf8,
-            false
+            false,
         )]),
         filters: vec![],
-        limit: None
+        limit: None,
     });
     let _ = scan.schema();
     let expect = "";

--- a/common/planners/src/plan_select.rs
+++ b/common/planners/src/plan_select.rs
@@ -10,7 +10,7 @@ use crate::PlanNode;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct SelectPlan {
-    pub input: Arc<PlanNode>
+    pub input: Arc<PlanNode>,
 }
 
 impl SelectPlan {

--- a/common/planners/src/plan_select_test.rs
+++ b/common/planners/src/plan_select_test.rs
@@ -14,7 +14,7 @@ fn test_select_wildcard_plan() -> anyhow::Result<()> {
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Utf8, false)]);
     let plan = PlanBuilder::create(schema).project(&[col("a")])?.build()?;
     let select = PlanNode::Select(SelectPlan {
-        input: Arc::new(plan)
+        input: Arc::new(plan),
     });
     let expect = "Projection: a:Utf8";
 

--- a/common/planners/src/plan_setting.rs
+++ b/common/planners/src/plan_setting.rs
@@ -10,12 +10,12 @@ use common_datavalues::DataSchemaRef;
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct VarValue {
     pub variable: String,
-    pub value: String
+    pub value: String,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
 pub struct SettingPlan {
-    pub vars: Vec<VarValue>
+    pub vars: Vec<VarValue>,
 }
 
 impl SettingPlan {

--- a/common/planners/src/plan_sort.rs
+++ b/common/planners/src/plan_sort.rs
@@ -14,7 +14,7 @@ pub struct SortPlan {
     /// The expression to sort on
     pub order_by: Vec<ExpressionAction>,
     /// The logical plan
-    pub input: Arc<PlanNode>
+    pub input: Arc<PlanNode>,
 }
 
 impl SortPlan {

--- a/common/planners/src/plan_stage.rs
+++ b/common/planners/src/plan_stage.rs
@@ -14,7 +14,7 @@ pub enum StageState {
     Through,
     SortMerge,
     GroupByMerge,
-    AggregatorMerge
+    AggregatorMerge,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone)]
@@ -22,7 +22,7 @@ pub struct StagePlan {
     pub uuid: String,
     pub id: usize,
     pub state: StageState,
-    pub input: Arc<PlanNode>
+    pub input: Arc<PlanNode>,
 }
 
 impl StagePlan {

--- a/common/planners/src/plan_stage_test.rs
+++ b/common/planners/src/plan_stage_test.rs
@@ -19,7 +19,7 @@ fn test_stage_plan() -> anyhow::Result<()> {
         .build()?;
     let explain = PlanNode::Explain(ExplainPlan {
         typ: ExplainType::Syntax,
-        input: Arc::new(plan)
+        input: Arc::new(plan),
     });
     let expect = "\
     Projection: sumx:UInt64\

--- a/common/planners/src/plan_statistics.rs
+++ b/common/planners/src/plan_statistics.rs
@@ -7,14 +7,14 @@ pub struct Statistics {
     /// Total rows of the query read.
     pub read_rows: usize,
     /// Total bytes of the query read.
-    pub read_bytes: usize
+    pub read_bytes: usize,
 }
 
 impl Statistics {
     pub fn default() -> Self {
         Statistics {
             read_rows: 0,
-            read_bytes: 0
+            read_bytes: 0,
         }
     }
 

--- a/common/planners/src/plan_table_create.rs
+++ b/common/planners/src/plan_table_create.rs
@@ -16,7 +16,7 @@ pub enum TableEngineType {
     /// Comma separated values
     Csv,
     /// Null ENGINE
-    Null
+    Null,
 }
 
 impl ToString for TableEngineType {
@@ -25,7 +25,7 @@ impl ToString for TableEngineType {
             TableEngineType::JsonEachRaw => "JSON".into(),
             TableEngineType::Parquet => "Parquet".into(),
             TableEngineType::Csv => "CSV".into(),
-            TableEngineType::Null => "Null".into()
+            TableEngineType::Null => "Null".into(),
         }
     }
 }
@@ -42,7 +42,7 @@ pub struct CreateTablePlan {
     pub schema: DataSchemaRef,
     /// The file type of physical file
     pub engine: TableEngineType,
-    pub options: TableOptions
+    pub options: TableOptions,
 }
 
 impl CreateTablePlan {

--- a/common/planners/src/plan_table_drop.rs
+++ b/common/planners/src/plan_table_drop.rs
@@ -12,7 +12,7 @@ pub struct DropTablePlan {
     pub if_exists: bool,
     pub db: String,
     /// The table name
-    pub table: String
+    pub table: String,
 }
 
 impl DropTablePlan {

--- a/common/planners/src/plan_use_database.rs
+++ b/common/planners/src/plan_use_database.rs
@@ -9,7 +9,7 @@ use common_datavalues::DataSchemaRef;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct UseDatabasePlan {
-    pub db: String
+    pub db: String,
 }
 
 impl UseDatabasePlan {

--- a/common/planners/src/plan_visitor.rs
+++ b/common/planners/src/plan_visitor.rs
@@ -87,7 +87,7 @@ pub trait PlanVisitor<'plan> {
             PlanNode::SetVariable(plan) => self.visit_set_variable(plan),
             PlanNode::Stage(plan) => self.visit_stage(plan),
             PlanNode::Having(plan) => self.visit_having(plan),
-            PlanNode::Expression(plan) => self.visit_expression(plan)
+            PlanNode::Expression(plan) => self.visit_expression(plan),
         }
     }
 

--- a/common/planners/src/plan_walker.rs
+++ b/common/planners/src/plan_walker.rs
@@ -10,12 +10,12 @@ use crate::PlanVisitor;
 #[derive(PartialEq)]
 enum WalkOrder {
     PreOrder,
-    PostOrder
+    PostOrder,
 }
 
 struct PreOrderWalker<'a, E> {
     callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>,
-    state: Result<(), E>
+    state: Result<(), E>,
 }
 
 impl<'plan, 'a, E> PlanVisitor<'plan> for PreOrderWalker<'a, E> {
@@ -41,7 +41,7 @@ impl<'a, E> PreOrderWalker<'a, E> {
     fn new(callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>) -> PreOrderWalker<E> {
         PreOrderWalker {
             callback,
-            state: Ok(())
+            state: Ok(()),
         }
     }
 
@@ -52,7 +52,7 @@ impl<'a, E> PreOrderWalker<'a, E> {
 
 struct PostOrderWalker<'a, E> {
     callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>,
-    state: Result<bool, E>
+    state: Result<bool, E>,
 }
 
 impl<'plan, 'a, E> PlanVisitor<'plan> for PostOrderWalker<'a, E> {
@@ -73,7 +73,7 @@ impl<'a, E> PostOrderWalker<'a, E> {
     fn new(callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>) -> PostOrderWalker<E> {
         PostOrderWalker {
             callback,
-            state: Ok(true)
+            state: Ok(true),
         }
     }
 
@@ -86,7 +86,7 @@ impl PlanNode {
     fn walk_base<'a, E>(
         order: WalkOrder,
         node: &PlanNode,
-        callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>
+        callback: &'a mut dyn FnMut(&PlanNode) -> Result<bool, E>,
     ) -> Result<(), E> {
         match order {
             WalkOrder::PreOrder => {
@@ -111,7 +111,7 @@ impl PlanNode {
     /// A Preorder walk of this graph is A B C
     pub fn walk_preorder<E>(
         &self,
-        mut visitor: impl FnMut(&PlanNode) -> Result<bool, E>
+        mut visitor: impl FnMut(&PlanNode) -> Result<bool, E>,
     ) -> Result<(), E> {
         Self::walk_base(WalkOrder::PreOrder, self, &mut visitor)
     }
@@ -125,7 +125,7 @@ impl PlanNode {
     /// A Postorder walk of this graph is C B A
     pub fn walk_postorder<E>(
         &self,
-        mut visitor: impl FnMut(&PlanNode) -> Result<bool, E>
+        mut visitor: impl FnMut(&PlanNode) -> Result<bool, E>,
     ) -> Result<(), E> {
         Self::walk_base(WalkOrder::PostOrder, self, &mut visitor)
     }

--- a/common/planners/src/test.rs
+++ b/common/planners/src/test.rs
@@ -26,7 +26,7 @@ impl Test {
 
         let statistics = Statistics {
             read_rows: total,
-            read_bytes: total * 8
+            read_bytes: total * 8,
         };
 
         Ok(PlanNode::ReadSource(ReadDataSourcePlan {
@@ -38,7 +38,7 @@ impl Test {
             description: format!(
                 "(Read from system.numbers_mt table, Read Rows:{}, Read Bytes:{})",
                 statistics.read_rows, statistics.read_bytes
-            )
+            ),
         }))
     }
 
@@ -50,7 +50,7 @@ impl Test {
         if part_size == 0 {
             partitions.push(Partition {
                 name: format!("{}-{}-{}", total, 0, total,),
-                version: 0
+                version: 0,
             })
         } else {
             for part in 0..workers {
@@ -61,7 +61,7 @@ impl Test {
                 }
                 partitions.push(Partition {
                     name: format!("{}-{}-{}", total, part_begin, part_end,),
-                    version: 0
+                    version: 0,
                 })
             }
         }

--- a/common/progress/src/progress.rs
+++ b/common/progress/src/progress.rs
@@ -12,14 +12,14 @@ pub type ProgressCallback = Box<dyn FnMut(&ProgressValues) + Send + Sync + 'stat
 pub struct ProgressValues {
     pub read_rows: usize,
     pub read_bytes: usize,
-    pub total_rows_to_read: usize
+    pub total_rows_to_read: usize,
 }
 
 #[derive(Debug)]
 pub struct Progress {
     read_rows: AtomicUsize,
     read_bytes: AtomicUsize,
-    total_rows_to_read: AtomicUsize
+    total_rows_to_read: AtomicUsize,
 }
 
 impl Progress {
@@ -27,7 +27,7 @@ impl Progress {
         Self {
             read_rows: AtomicUsize::new(0),
             read_bytes: AtomicUsize::new(0),
-            total_rows_to_read: AtomicUsize::new(0)
+            total_rows_to_read: AtomicUsize::new(0),
         }
     }
 
@@ -47,7 +47,7 @@ impl Progress {
         ProgressValues {
             read_rows,
             read_bytes,
-            total_rows_to_read
+            total_rows_to_read,
         }
     }
 
@@ -64,7 +64,7 @@ impl Progress {
         ProgressValues {
             read_rows,
             read_bytes,
-            total_rows_to_read
+            total_rows_to_read,
         }
     }
 

--- a/common/progress/src/progress_test.rs
+++ b/common/progress/src/progress_test.rs
@@ -10,7 +10,7 @@ fn test_progress() -> anyhow::Result<()> {
     let values = ProgressValues {
         read_rows: 2,
         read_bytes: 10,
-        total_rows_to_read: 10
+        total_rows_to_read: 10,
     };
 
     progress.incr(&values);

--- a/common/runtime/src/runtime.rs
+++ b/common/runtime/src/runtime.rs
@@ -18,7 +18,7 @@ pub struct Runtime {
     // Handle to runtime.
     handle: Handle,
     // Use to receive a drop signal when dropper is dropped.
-    _dropper: Dropper
+    _dropper: Dropper,
 }
 
 impl Runtime {
@@ -48,8 +48,8 @@ impl Runtime {
         Ok(Runtime {
             handle,
             _dropper: Dropper {
-                close: Some(send_stop)
-            }
+                close: Some(send_stop),
+            },
         })
     }
 
@@ -73,7 +73,7 @@ impl Runtime {
     pub fn spawn<T>(&self, task: T) -> JoinHandle<T::Output>
     where
         T: Future + Send + 'static,
-        T::Output: Send + 'static
+        T::Output: Send + 'static,
     {
         self.handle.spawn(task)
     }
@@ -81,7 +81,7 @@ impl Runtime {
 
 /// Dropping the dropper will cause runtime to shutdown.
 pub struct Dropper {
-    close: Option<oneshot::Sender<()>>
+    close: Option<oneshot::Sender<()>>,
 }
 
 impl Drop for Dropper {

--- a/common/streams/src/stream_datablock.rs
+++ b/common/streams/src/stream_datablock.rs
@@ -13,20 +13,20 @@ pub struct DataBlockStream {
     current: usize,
     schema: DataSchemaRef,
     data: Vec<DataBlock>,
-    projects: Option<Vec<usize>>
+    projects: Option<Vec<usize>>,
 }
 
 impl DataBlockStream {
     pub fn create(
         schema: DataSchemaRef,
         projects: Option<Vec<usize>>,
-        data: Vec<DataBlock>
+        data: Vec<DataBlock>,
     ) -> Self {
         DataBlockStream {
             current: 0,
             schema,
             data,
-            projects
+            projects,
         }
     }
 }
@@ -36,7 +36,7 @@ impl futures::Stream for DataBlockStream {
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
-        _: &mut Context<'_>
+        _: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         Poll::Ready(if self.current < self.data.len() {
             self.current += 1;
@@ -45,9 +45,9 @@ impl futures::Stream for DataBlockStream {
             Some(Ok(match &self.projects {
                 Some(v) => DataBlock::create(
                     self.schema.clone(),
-                    v.iter().map(|x| block.column(*x).clone()).collect()
+                    v.iter().map(|x| block.column(*x).clone()).collect(),
                 ),
-                None => block.clone()
+                None => block.clone(),
             }))
         } else {
             None

--- a/common/streams/src/stream_datablock_test.rs
+++ b/common/streams/src/stream_datablock_test.rs
@@ -12,10 +12,10 @@ async fn test_datablock_stream() {
 
     use crate::*;
 
-    let mut s1 = DataBlockStream::create(Arc::new(DataSchema::empty()), None, vec![
-        DataBlock::empty(),
-        DataBlock::empty(),
-        DataBlock::empty(),
-    ]);
+    let mut s1 = DataBlockStream::create(
+        Arc::new(DataSchema::empty()),
+        None,
+        vec![DataBlock::empty(), DataBlock::empty(), DataBlock::empty()],
+    );
     while let Some(_) = s1.next().await {}
 }

--- a/common/streams/src/stream_limit.rs
+++ b/common/streams/src/stream_limit.rs
@@ -16,7 +16,7 @@ use crate::SendableDataBlockStream;
 pub struct LimitStream {
     input: SendableDataBlockStream,
     limit: usize,
-    current: usize
+    current: usize,
 }
 
 impl LimitStream {
@@ -24,7 +24,7 @@ impl LimitStream {
         Ok(LimitStream {
             input,
             limit,
-            current: 0
+            current: 0,
         })
     }
 
@@ -45,7 +45,7 @@ impl LimitStream {
             }
             Ok(Some(DataBlock::create(
                 block.schema().clone(),
-                limited_columns
+                limited_columns,
             )))
         }
     }
@@ -56,11 +56,11 @@ impl Stream for LimitStream {
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
-        ctx: &mut Context<'_>
+        ctx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         self.input.poll_next_unpin(ctx).map(|x| match x {
             Some(Ok(ref v)) => self.limit(v).transpose(),
-            other => other
+            other => other,
         })
     }
 }

--- a/common/streams/src/stream_parquet.rs
+++ b/common/streams/src/stream_parquet.rs
@@ -11,7 +11,7 @@ use crossbeam::channel::Receiver;
 use futures::Stream;
 
 pub struct ParquetStream {
-    response_rx: Receiver<Option<Result<DataBlock>>>
+    response_rx: Receiver<Option<Result<DataBlock>>>,
 }
 
 impl ParquetStream {
@@ -27,7 +27,7 @@ impl Stream for ParquetStream {
         match self.response_rx.recv() {
             Ok(block) => Poll::Ready(block),
             // RecvError means receiver has exited and closed the channel
-            Err(_) => Poll::Ready(None)
+            Err(_) => Poll::Ready(None),
         }
     }
 }

--- a/common/streams/src/stream_progress.rs
+++ b/common/streams/src/stream_progress.rs
@@ -33,7 +33,7 @@ impl Stream for ProgressStream {
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,
-        ctx: &mut Context<'_>
+        ctx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let this = self.project();
 
@@ -44,17 +44,17 @@ impl Stream for ProgressStream {
                         let progress_values = ProgressValues {
                             read_rows: block.num_rows(),
                             read_bytes: block.memory_size(),
-                            total_rows_to_read: 0
+                            total_rows_to_read: 0,
                         };
 
                         (this.callback)(&progress_values);
                         Poll::Ready(Some(Ok(block)))
                     }
-                    Err(e) => Poll::Ready(Some(Err(e)))
+                    Err(e) => Poll::Ready(Some(Err(e))),
                 },
-                None => Poll::Ready(None)
+                None => Poll::Ready(None),
             },
-            Poll::Pending => Poll::Pending
+            Poll::Pending => Poll::Pending,
         }
     }
 }

--- a/common/streams/src/stream_progress_test.rs
+++ b/common/streams/src/stream_progress_test.rs
@@ -15,15 +15,16 @@ async fn test_progress_stream() -> anyhow::Result<()> {
 
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Int64, false)]);
 
-    let block = DataBlock::create(schema.clone(), vec![Arc::new(Int64Array::from(vec![
-        1, 2, 3,
-    ]))]);
+    let block = DataBlock::create(
+        schema.clone(),
+        vec![Arc::new(Int64Array::from(vec![1, 2, 3]))],
+    );
 
-    let input = DataBlockStream::create(Arc::new(DataSchema::empty()), None, vec![
-        block.clone(),
-        block.clone(),
-        block,
-    ]);
+    let input = DataBlockStream::create(
+        Arc::new(DataSchema::empty()),
+        None,
+        vec![block.clone(), block.clone(), block],
+    );
 
     let mut all_rows = 0;
     let progress = Box::new(move |value: &ProgressValues| {

--- a/common/streams/src/stream_sort.rs
+++ b/common/streams/src/stream_sort.rs
@@ -16,19 +16,19 @@ use crate::SendableDataBlockStream;
 pub struct SortStream {
     input: SendableDataBlockStream,
     sort_columns_descriptions: Vec<SortColumnDescription>,
-    limit: Option<usize>
+    limit: Option<usize>,
 }
 
 impl SortStream {
     pub fn try_create(
         input: SendableDataBlockStream,
         sort_columns_descriptions: Vec<SortColumnDescription>,
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> Result<Self> {
         Ok(SortStream {
             input,
             sort_columns_descriptions,
-            limit
+            limit,
         })
     }
 }
@@ -38,15 +38,15 @@ impl Stream for SortStream {
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
-        ctx: &mut Context<'_>
+        ctx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         self.input.poll_next_unpin(ctx).map(|x| match x {
             Some(Ok(v)) => Some(DataBlock::sort_block(
                 &v,
                 &self.sort_columns_descriptions,
-                self.limit
+                self.limit,
             )),
-            other => other
+            other => other,
         })
     }
 }

--- a/fusequery/benchmarks/nyctaxi/src/bin/nyctaxi.rs
+++ b/fusequery/benchmarks/nyctaxi/src/bin/nyctaxi.rs
@@ -33,7 +33,7 @@ struct Opt {
 
     /// Path to data files
     #[structopt(parse(from_os_str), required = true, short = "p", long = "path")]
-    path: PathBuf
+    path: PathBuf,
 }
 
 // cargo run --release --bin nyctaxi --path /xx/xx.csv
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         table: "nyctaxi".to_string(),
         schema: nyctaxi_schema(),
         engine: TableEngineType::Csv,
-        options
+        options,
     };
     database.create_table(create_table_plan).await?;
 

--- a/fusequery/query/build.rs
+++ b/fusequery/query/build.rs
@@ -32,7 +32,7 @@ fn commit_authors() {
     );
     let authors = match r {
         Ok((_, output, _)) => output,
-        Err(e) => e.to_string()
+        Err(e) => e.to_string(),
     };
     println!("cargo:rustc-env=COMMIT_AUTHORS={}", authors);
 }

--- a/fusequery/query/src/api/http/router.rs
+++ b/fusequery/query/src/api/http/router.rs
@@ -10,7 +10,7 @@ use crate::configs::Config;
 
 pub struct Router {
     cfg: Config,
-    cluster: ClusterRef
+    cluster: ClusterRef,
 }
 
 impl Router {
@@ -19,7 +19,7 @@ impl Router {
     }
 
     pub fn router(
-        &self
+        &self,
     ) -> Result<impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone> {
         let v1 = super::v1::hello::hello_handler(self.cfg.clone())
             .or(super::v1::config::config_handler(self.cfg.clone()))

--- a/fusequery/query/src/api/http/v1/cluster.rs
+++ b/fusequery/query/src/api/http/v1/cluster.rs
@@ -13,11 +13,11 @@ pub struct ClusterNodeRequest {
     // Larger value means higher
     // priority
     pub priority: u8,
-    pub address: String
+    pub address: String,
 }
 
 pub fn cluster_handler(
-    cluster: ClusterRef
+    cluster: ClusterRef,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     cluster_list_node(cluster.clone())
         .or(cluster_add_node(cluster.clone()))
@@ -26,7 +26,7 @@ pub fn cluster_handler(
 
 /// GET /v1/cluster/list
 fn cluster_list_node(
-    cluster: ClusterRef
+    cluster: ClusterRef,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("v1" / "cluster" / "list")
         .and(warp::get())
@@ -35,7 +35,7 @@ fn cluster_list_node(
 }
 
 fn cluster_add_node(
-    cluster: ClusterRef
+    cluster: ClusterRef,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("v1" / "cluster" / "add")
         .and(warp::post())
@@ -45,7 +45,7 @@ fn cluster_add_node(
 }
 
 fn cluster_remove_node(
-    cluster: ClusterRef
+    cluster: ClusterRef,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("v1" / "cluster" / "remove")
         .and(warp::post())
@@ -55,7 +55,7 @@ fn cluster_remove_node(
 }
 
 fn with_cluster(
-    cluster: ClusterRef
+    cluster: ClusterRef,
 ) -> impl Filter<Extract = (ClusterRef,), Error = std::convert::Infallible> + Clone {
     warp::any().map(move || cluster.clone())
 }
@@ -74,7 +74,7 @@ mod handlers {
     use crate::clusters::Node;
 
     pub async fn list_node(
-        cluster: ClusterRef
+        cluster: ClusterRef,
     ) -> Result<impl warp::Reply, std::convert::Infallible> {
         // TODO(BohuTANG): error handler
         let nodes = cluster.get_nodes().unwrap();
@@ -83,7 +83,7 @@ mod handlers {
 
     pub async fn add_node(
         req: ClusterNodeRequest,
-        cluster: ClusterRef
+        cluster: ClusterRef,
     ) -> Result<impl warp::Reply, std::convert::Infallible> {
         info!("Cluster add node: {:?}", req);
         // TODO(BohuTANG): error handler
@@ -92,7 +92,7 @@ mod handlers {
                 name: req.name,
                 priority: req.priority,
                 address: req.address,
-                local: false
+                local: false,
             })
             .unwrap();
         Ok(warp::http::StatusCode::OK)
@@ -100,7 +100,7 @@ mod handlers {
 
     pub async fn remove_node(
         req: ClusterNodeRequest,
-        cluster: ClusterRef
+        cluster: ClusterRef,
     ) -> Result<impl warp::Reply, std::convert::Infallible> {
         info!("Cluster remove node: {:?}", req);
         // TODO(BohuTANG): error handler

--- a/fusequery/query/src/api/http/v1/cluster_test.rs
+++ b/fusequery/query/src/api/http/v1/cluster_test.rs
@@ -24,7 +24,7 @@ async fn test_cluster() -> Result<()> {
             .json(&ClusterNodeRequest {
                 name: "9090".to_string(),
                 priority: 8,
-                address: "127.0.0.1:9090".to_string()
+                address: "127.0.0.1:9090".to_string(),
             })
             .reply(&filter);
         assert_eq!(200, res.await.status());
@@ -36,7 +36,7 @@ async fn test_cluster() -> Result<()> {
             .json(&ClusterNodeRequest {
                 name: "9091".to_string(),
                 priority: 4,
-                address: "127.0.0.1:9091".to_string()
+                address: "127.0.0.1:9091".to_string(),
             })
             .reply(&filter);
         assert_eq!(200, res.await.status());
@@ -51,7 +51,7 @@ async fn test_cluster() -> Result<()> {
             .json(&ClusterNodeRequest {
                 name: "9091".to_string(),
                 priority: 4,
-                address: "127.0.0.1:9091".to_string()
+                address: "127.0.0.1:9091".to_string(),
             })
             .reply(&filter);
         assert_eq!(200, res.await.status());

--- a/fusequery/query/src/api/http/v1/config.rs
+++ b/fusequery/query/src/api/http/v1/config.rs
@@ -7,7 +7,7 @@ use warp::Filter;
 use crate::configs::Config;
 
 pub fn config_handler(
-    cfg: Config
+    cfg: Config,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("v1" / "configs").map(move || format!("{:?}", cfg))
 }

--- a/fusequery/query/src/api/http/v1/hello.rs
+++ b/fusequery/query/src/api/http/v1/hello.rs
@@ -7,7 +7,7 @@ use warp::Filter;
 use crate::configs::Config;
 
 pub fn hello_handler(
-    cfg: Config
+    cfg: Config,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("v1" / "hello").map(move || format!("{:?}", cfg))
 }

--- a/fusequery/query/src/api/http_service.rs
+++ b/fusequery/query/src/api/http_service.rs
@@ -10,7 +10,7 @@ use crate::configs::Config;
 
 pub struct HttpService {
     cfg: Config,
-    cluster: ClusterRef
+    cluster: ClusterRef,
 }
 
 impl HttpService {

--- a/fusequery/query/src/api/rpc/flight_service.rs
+++ b/fusequery/query/src/api/rpc/flight_service.rs
@@ -49,7 +49,7 @@ pub type FlightStream<T> =
 pub struct FlightService {
     conf: Config,
     cluster: ClusterRef,
-    session_manager: SessionManagerRef
+    session_manager: SessionManagerRef,
 }
 
 impl FlightService {
@@ -57,7 +57,7 @@ impl FlightService {
         Self {
             conf,
             cluster,
-            session_manager
+            session_manager,
         }
     }
 
@@ -71,7 +71,7 @@ impl Flight for FlightService {
     type HandshakeStream = FlightStream<HandshakeResponse>;
     async fn handshake(
         &self,
-        _request: Request<Streaming<HandshakeRequest>>
+        _request: Request<Streaming<HandshakeRequest>>,
     ) -> Result<Response<Self::HandshakeStream>, Status> {
         unimplemented!()
     }
@@ -79,21 +79,21 @@ impl Flight for FlightService {
     type ListFlightsStream = FlightStream<FlightInfo>;
     async fn list_flights(
         &self,
-        _request: Request<Criteria>
+        _request: Request<Criteria>,
     ) -> Result<Response<Self::ListFlightsStream>, Status> {
         unimplemented!()
     }
 
     async fn get_flight_info(
         &self,
-        _request: Request<FlightDescriptor>
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
         unimplemented!()
     }
 
     async fn get_schema(
         &self,
-        _request: Request<FlightDescriptor>
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<SchemaResult>, Status> {
         unimplemented!()
     }
@@ -101,7 +101,7 @@ impl Flight for FlightService {
     type DoGetStream = FlightStream<FlightData>;
     async fn do_get(
         &self,
-        request: Request<Ticket>
+        request: Request<Ticket>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
         let action: QueryDoGet = request.try_into()?;
         match action {
@@ -149,7 +149,7 @@ impl Flight for FlightService {
                             let schema_flight_data =
                                 arrow_flight::utils::flight_data_from_arrow_schema(
                                     block.schema(),
-                                    &options
+                                    &options,
                                 );
                             sender.send(Ok(schema_flight_data)).await.ok();
                             has_send = true;
@@ -178,7 +178,7 @@ impl Flight for FlightService {
                         let empty_schema = DataSchemaRefExt::create(vec![]);
                         let schema_flight_data = arrow_flight::utils::flight_data_from_arrow_schema(
                             &empty_schema,
-                            &options
+                            &options,
                         );
                         sender.send(Ok(schema_flight_data)).await.ok();
                     }
@@ -203,7 +203,7 @@ impl Flight for FlightService {
     type DoPutStream = FlightStream<PutResult>;
     async fn do_put(
         &self,
-        _request: Request<Streaming<FlightData>>
+        _request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoPutStream>, Status> {
         unimplemented!()
     }
@@ -211,7 +211,7 @@ impl Flight for FlightService {
     type DoExchangeStream = FlightStream<FlightData>;
     async fn do_exchange(
         &self,
-        _request: Request<Streaming<FlightData>>
+        _request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoExchangeStream>, Status> {
         unimplemented!()
     }
@@ -219,7 +219,7 @@ impl Flight for FlightService {
     type DoActionStream = FlightStream<arrow_flight::Result>;
     async fn do_action(
         &self,
-        request: Request<Action>
+        request: Request<Action>,
     ) -> Result<Response<Self::DoActionStream>, Status> {
         let action: QueryDoAction = request.try_into()?;
         match action {
@@ -236,7 +236,7 @@ impl Flight for FlightService {
                 let stream = {
                     let result = arrow_flight::Result {
                         body: serde_json::to_vec(&parts)
-                            .map_err(|e| Status::internal(e.to_string()))?
+                            .map_err(|e| Status::internal(e.to_string()))?,
                     };
 
                     let flights: Vec<Result<arrow_flight::Result, Status>> = vec![Ok(result)];
@@ -250,7 +250,7 @@ impl Flight for FlightService {
     type ListActionsStream = FlightStream<ActionType>;
     async fn list_actions(
         &self,
-        _request: Request<Empty>
+        _request: Request<Empty>,
     ) -> Result<Response<Self::ListActionsStream>, Status> {
         unimplemented!()
     }
@@ -258,7 +258,7 @@ impl Flight for FlightService {
 
 async fn send_response(
     tx: &FlightDataSender,
-    data: Result<FlightData, Status>
+    data: Result<FlightData, Status>,
 ) -> Result<(), Status> {
     tx.send(data)
         .await

--- a/fusequery/query/src/api/rpc/flight_service_test.rs
+++ b/fusequery/query/src/api/rpc/flight_service_test.rs
@@ -15,7 +15,7 @@ async fn test_flight_execute() -> anyhow::Result<()> {
     let ctx = crate::tests::try_create_context()?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
     let plan = PlanBuilder::from(&PlanNode::ReadSource(
-        test_source.number_read_source_plan_for_test(5)?
+        test_source.number_read_source_plan_for_test(5)?,
     ))
     .build()?;
 
@@ -57,7 +57,7 @@ async fn test_flight_empty_source() -> anyhow::Result<()> {
     let ctx = crate::tests::try_create_context()?;
     let test_source = crate::tests::NumberTestData::create(ctx.clone());
     let plan = PlanBuilder::from(&PlanNode::ReadSource(
-        test_source.number_read_source_plan_for_test(0)?
+        test_source.number_read_source_plan_for_test(0)?,
     ))
     .build()?;
 

--- a/fusequery/query/src/api/rpc/macros.rs
+++ b/fusequery/query/src/api/rpc/macros.rs
@@ -14,7 +14,7 @@ macro_rules! match_async_result {
                 $SENDER.send(Err(tonic::Status::internal(msg))).await.ok();
                 return;
             }
-            Ok(v) => v
+            Ok(v) => v,
         }
     }};
 }

--- a/fusequery/query/src/api/rpc_service.rs
+++ b/fusequery/query/src/api/rpc_service.rs
@@ -14,7 +14,7 @@ use crate::sessions::SessionManagerRef;
 pub struct RpcService {
     conf: Config,
     cluster: ClusterRef,
-    session_manager: SessionManagerRef
+    session_manager: SessionManagerRef,
 }
 
 impl RpcService {
@@ -22,7 +22,7 @@ impl RpcService {
         Self {
             conf,
             cluster,
-            session_manager
+            session_manager,
         }
     }
 
@@ -36,7 +36,7 @@ impl RpcService {
         let flight_srv = FlightService::create(
             self.conf.clone(),
             self.cluster.clone(),
-            self.session_manager.clone()
+            self.session_manager.clone(),
         );
 
         Server::builder()

--- a/fusequery/query/src/bin/fuse-query.rs
+++ b/fusequery/query/src/bin/fuse-query.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or(conf.log_level.to_lowercase().as_str())
+        env_logger::Env::default().default_filter_or(conf.log_level.to_lowercase().as_str()),
     )
     .init();
 

--- a/fusequery/query/src/clusters/cluster.rs
+++ b/fusequery/query/src/clusters/cluster.rs
@@ -15,21 +15,21 @@ pub type ClusterRef = Arc<Cluster>;
 
 pub struct Cluster {
     cfg: Config,
-    nodes: Mutex<HashMap<String, Node>>
+    nodes: Mutex<HashMap<String, Node>>,
 }
 
 impl Cluster {
     pub fn create(cfg: Config) -> ClusterRef {
         Arc::new(Cluster {
             cfg,
-            nodes: Mutex::new(HashMap::new())
+            nodes: Mutex::new(HashMap::new()),
         })
     }
 
     pub fn empty() -> ClusterRef {
         Arc::new(Cluster {
             cfg: Config::default(),
-            nodes: Mutex::new(HashMap::new())
+            nodes: Mutex::new(HashMap::new()),
         })
     }
 
@@ -46,7 +46,7 @@ impl Cluster {
             // The value of "priority" must be in [0,10].
             priority: n.priority,
             address: n.address.clone(),
-            local: false
+            local: false,
         };
         if node.address == self.cfg.flight_api_address {
             node.local = true;

--- a/fusequery/query/src/clusters/cluster_test.rs
+++ b/fusequery/query/src/clusters/cluster_test.rs
@@ -17,7 +17,7 @@ fn test_cluster() -> Result<()> {
         name: "node1".to_string(),
         priority: 5,
         address: "127.0.0.1:9001".to_string(),
-        local: false
+        local: false,
     };
     cluster.add_node(&node1)?;
 
@@ -25,7 +25,7 @@ fn test_cluster() -> Result<()> {
         name: "node2".to_string(),
         priority: 5,
         address: "127.0.0.1:9002".to_string(),
-        local: false
+        local: false,
     };
     cluster.add_node(&node2)?;
 

--- a/fusequery/query/src/clusters/node.rs
+++ b/fusequery/query/src/clusters/node.rs
@@ -9,7 +9,7 @@ pub struct Node {
     // larger value means higher priority
     pub priority: u8,
     pub address: String,
-    pub local: bool
+    pub local: bool,
 }
 
 impl Node {

--- a/fusequery/query/src/configs/config.rs
+++ b/fusequery/query/src/configs/config.rs
@@ -88,7 +88,7 @@ pub struct Config {
     pub store_api_password: String,
 
     #[structopt(long, short = "c", env = "CONFIG_FILE", default_value = "")]
-    pub config_file: String
+    pub config_file: String,
 }
 
 impl Config {
@@ -110,7 +110,7 @@ impl Config {
             store_api_address: "127.0.0.1:9191".to_string(),
             store_api_username: "root".to_string(),
             store_api_password: "root".to_string(),
-            config_file: "".to_string()
+            config_file: "".to_string(),
         }
     }
 
@@ -146,7 +146,7 @@ impl Config {
 
         match (build_semver, git_sha, rustc_semver, timestamp) {
             (Some(v1), Some(v2), Some(v3), Some(v4)) => format!("{}-{}({}-{})", v1, v2, v3, v4),
-            _ => String::new()
+            _ => String::new(),
         }
     }
 }

--- a/fusequery/query/src/configs/config_test.rs
+++ b/fusequery/query/src/configs/config_test.rs
@@ -26,7 +26,7 @@ fn test_config() -> common_exception::Result<()> {
             store_api_address: "127.0.0.1:9191".to_string(),
             store_api_username: "root".to_string(),
             store_api_password: "root".to_string(),
-            config_file: "".to_string()
+            config_file: "".to_string(),
         };
         let actual = Config::default();
         assert_eq!(actual, expect);

--- a/fusequery/query/src/datasources/common.rs
+++ b/fusequery/query/src/datasources/common.rs
@@ -20,7 +20,7 @@ impl Common {
         if part_size == 0 {
             partitions.push(Partition {
                 name: format!("{}-{}-{}", total, start, total,),
-                version: 0
+                version: 0,
             })
         } else {
             for part in 0..workers {
@@ -34,7 +34,7 @@ impl Common {
                 }
                 partitions.push(Partition {
                     name: format!("{}-{}-{}", total, part_begin, part_end,),
-                    version: 0
+                    version: 0,
                 })
             }
         }
@@ -51,7 +51,7 @@ impl Common {
         while match reader.read_until(sep, &mut line) {
             Ok(n) if n > 0 => true,
             Err(e) => return Err(e),
-            _ => false
+            _ => false,
         } {
             if *line.last().unwrap() == sep {
                 count += 1;

--- a/fusequery/query/src/datasources/datasource.rs
+++ b/fusequery/query/src/datasources/datasource.rs
@@ -39,7 +39,7 @@ pub struct DataSource {
     conf: Config,
     databases: RwLock<HashMap<String, Arc<dyn IDatabase>>>,
     table_functions: RwLock<HashMap<String, Arc<dyn ITableFunction>>>,
-    store_client: RwLock<Option<StoreClient>>
+    store_client: RwLock<Option<StoreClient>>,
 }
 
 impl DataSource {
@@ -48,7 +48,7 @@ impl DataSource {
             conf: Config::default(),
             databases: Default::default(),
             table_functions: Default::default(),
-            store_client: RwLock::new(None)
+            store_client: RwLock::new(None),
         };
 
         datasource.register_system_database()?;

--- a/fusequery/query/src/datasources/local/csv_table.rs
+++ b/fusequery/query/src/datasources/local/csv_table.rs
@@ -25,7 +25,7 @@ pub struct CsvTable {
     name: String,
     schema: DataSchemaRef,
     file: String,
-    has_header: bool
+    has_header: bool,
 }
 
 impl CsvTable {
@@ -33,16 +33,16 @@ impl CsvTable {
         db: String,
         name: String,
         schema: DataSchemaRef,
-        options: TableOptions
+        options: TableOptions,
     ) -> Result<Box<dyn ITable>> {
         let has_header = options.get("has_header").is_some();
         let file = match options.get("location") {
             None => {
                 return Result::Err(ErrorCodes::BadOption(
-                    "CSV Engine must contains file location options"
+                    "CSV Engine must contains file location options",
                 ));
             }
-            Some(v) => v.trim_matches(|s| s == '\'' || s == '"').to_string()
+            Some(v) => v.trim_matches(|s| s == '\'' || s == '"').to_string(),
         };
 
         Ok(Box::new(Self {
@@ -50,7 +50,7 @@ impl CsvTable {
             name,
             schema,
             file,
-            has_header
+            has_header,
         }))
     }
 }
@@ -83,7 +83,7 @@ impl ITable for CsvTable {
         let lines_count = Common::count_lines(
             File::open(file.clone())
                 .with_context(|| format!("Cannot find file:{}", file))
-                .map_err(ErrorCodes::from)?
+                .map_err(ErrorCodes::from)?,
         )
         .map_err(|e| ErrorCodes::CannotReadFile(e.to_string()))?;
 
@@ -94,10 +94,10 @@ impl ITable for CsvTable {
             partitions: Common::generate_parts(
                 start_line as u64,
                 ctx.get_max_threads()?,
-                lines_count as u64
+                lines_count as u64,
             ),
             statistics: Statistics::default(),
-            description: format!("(Read from CSV Engine table  {}.{})", self.db, self.name)
+            description: format!("(Read from CSV Engine table  {}.{})", self.db, self.name),
         })
     }
 
@@ -105,7 +105,7 @@ impl ITable for CsvTable {
         Ok(Box::pin(CsvTableStream::try_create(
             ctx,
             self.schema.clone(),
-            self.file.clone()
+            self.file.clone(),
         )?))
     }
 }

--- a/fusequery/query/src/datasources/local/csv_table_stream.rs
+++ b/fusequery/query/src/datasources/local/csv_table_stream.rs
@@ -19,14 +19,14 @@ use crate::sessions::FuseQueryContextRef;
 pub struct CsvTableStream {
     ctx: FuseQueryContextRef,
     file: String,
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl CsvTableStream {
     pub fn try_create(
         ctx: FuseQueryContextRef,
         schema: DataSchemaRef,
-        file: String
+        file: String,
     ) -> Result<Self> {
         Ok(CsvTableStream { ctx, file, schema })
     }
@@ -54,7 +54,7 @@ impl CsvTableStream {
             None,
             block_size,
             bounds,
-            None
+            None,
         );
 
         reader
@@ -74,7 +74,7 @@ impl Stream for CsvTableStream {
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,
-        _: &mut std::task::Context<'_>
+        _: &mut std::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let block = self.try_get_one_block()?;
         Poll::Ready(block.map(Ok))

--- a/fusequery/query/src/datasources/local/csv_table_test.rs
+++ b/fusequery/query/src/datasources/local/csv_table_test.rs
@@ -17,7 +17,7 @@ async fn test_csv_table() -> anyhow::Result<()> {
         env::current_dir()?
             .join("../../tests/data/sample.csv")
             .display()
-            .to_string()
+            .to_string(),
     )]
     .iter()
     .cloned()
@@ -28,7 +28,7 @@ async fn test_csv_table() -> anyhow::Result<()> {
         "default".into(),
         "test_csv".into(),
         DataSchemaRefExt::create(vec![DataField::new("column1", DataType::UInt64, false)]).into(),
-        options
+        options,
     )?;
 
     let scan_plan = &ScanPlan {
@@ -39,10 +39,10 @@ async fn test_csv_table() -> anyhow::Result<()> {
         projected_schema: DataSchemaRefExt::create(vec![DataField::new(
             "column1",
             DataType::UInt64,
-            false
+            false,
         )]),
         filters: vec![],
-        limit: None
+        limit: None,
     };
     let source_plan = table.read_plan(ctx.clone(), &scan_plan)?;
     ctx.try_set_partitions(source_plan.partitions)?;
@@ -85,7 +85,7 @@ async fn test_csv_table_parse_error() -> anyhow::Result<()> {
         env::current_dir()?
             .join("../../tests/data/sample.csv")
             .display()
-            .to_string()
+            .to_string(),
     )]
     .iter()
     .cloned()
@@ -102,7 +102,7 @@ async fn test_csv_table_parse_error() -> anyhow::Result<()> {
             DataField::new("column4", DataType::UInt64, false),
         ])
         .into(),
-        options
+        options,
     )?;
     let scan_plan = &ScanPlan {
         schema_name: "".to_string(),
@@ -112,10 +112,10 @@ async fn test_csv_table_parse_error() -> anyhow::Result<()> {
         projected_schema: DataSchemaRefExt::create(vec![DataField::new(
             "column2",
             DataType::UInt64,
-            false
+            false,
         )]),
         filters: vec![],
-        limit: None
+        limit: None,
     };
     let source_plan = table.read_plan(ctx.clone(), &scan_plan)?;
     ctx.try_set_partitions(source_plan.partitions)?;

--- a/fusequery/query/src/datasources/local/local_database.rs
+++ b/fusequery/query/src/datasources/local/local_database.rs
@@ -20,13 +20,13 @@ use crate::datasources::ITable;
 use crate::datasources::ITableFunction;
 
 pub struct LocalDatabase {
-    tables: RwLock<HashMap<String, Arc<dyn ITable>>>
+    tables: RwLock<HashMap<String, Arc<dyn ITable>>>,
 }
 
 impl LocalDatabase {
     pub fn create() -> Self {
         LocalDatabase {
-            tables: RwLock::new(HashMap::default())
+            tables: RwLock::new(HashMap::default()),
         }
     }
 }

--- a/fusequery/query/src/datasources/local/null_table.rs
+++ b/fusequery/query/src/datasources/local/null_table.rs
@@ -21,7 +21,7 @@ use crate::sessions::FuseQueryContextRef;
 pub struct NullTable {
     db: String,
     name: String,
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl NullTable {
@@ -29,7 +29,7 @@ impl NullTable {
         db: String,
         name: String,
         schema: DataSchemaRef,
-        _options: TableOptions
+        _options: TableOptions,
     ) -> Result<Box<dyn ITable>> {
         let table = Self { db, name, schema };
         Ok(Box::new(table))
@@ -65,10 +65,10 @@ impl ITable for NullTable {
             schema: self.schema.clone(),
             partitions: vec![Partition {
                 name: "".to_string(),
-                version: 0
+                version: 0,
             }],
             statistics: Statistics::default(),
-            description: format!("(Read from Null Engine table  {}.{})", self.db, self.name)
+            description: format!("(Read from Null Engine table  {}.{})", self.db, self.name),
         })
     }
 
@@ -78,7 +78,7 @@ impl ITable for NullTable {
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            vec![block]
+            vec![block],
         )))
     }
 }

--- a/fusequery/query/src/datasources/local/null_table_test.rs
+++ b/fusequery/query/src/datasources/local/null_table_test.rs
@@ -15,7 +15,7 @@ async fn test_null_table() -> anyhow::Result<()> {
         "default".into(),
         "a".into(),
         DataSchemaRefExt::create(vec![DataField::new("a", DataType::UInt64, false)]).into(),
-        TableOptions::default()
+        TableOptions::default(),
     )?;
     table.read_plan(ctx.clone(), &ScanPlan::empty())?;
     assert_eq!(table.engine(), "Null");

--- a/fusequery/query/src/datasources/local/parquet_table.rs
+++ b/fusequery/query/src/datasources/local/parquet_table.rs
@@ -33,7 +33,7 @@ pub struct ParquetTable {
     db: String,
     name: String,
     schema: DataSchemaRef,
-    file: String
+    file: String,
 }
 
 impl ParquetTable {
@@ -41,7 +41,7 @@ impl ParquetTable {
         db: String,
         name: String,
         schema: DataSchemaRef,
-        options: TableOptions
+        options: TableOptions,
     ) -> Result<Box<dyn ITable>> {
         let file = options.get("location");
         return match file {
@@ -50,13 +50,13 @@ impl ParquetTable {
                     db,
                     name,
                     schema,
-                    file: file.trim_matches(|s| s == '\'' || s == '"').to_string()
+                    file: file.trim_matches(|s| s == '\'' || s == '"').to_string(),
                 };
                 Ok(Box::new(table))
             }
             _ => Result::Err(ErrorCodes::BadOption(
-                "Parquet Engine must contains file location options".to_string()
-            ))
+                "Parquet Engine must contains file location options".to_string(),
+            )),
         };
     }
 }
@@ -64,7 +64,7 @@ impl ParquetTable {
 fn read_file(
     file: &str,
     tx: Sender<Option<Result<DataBlock>>>,
-    projection: &[usize]
+    projection: &[usize],
 ) -> Result<()> {
     let file_reader = File::open(file).map_err(|e| ErrorCodes::CannotReadFile(e.to_string()))?;
     let file_reader = SerializedFileReader::new(file_reader)
@@ -90,7 +90,7 @@ fn read_file(
                 let err_msg = format!("Error reading batch from {:?}: {}", file, e.to_string());
 
                 tx.send(Some(Result::Err(ErrorCodes::CannotReadFile(
-                    err_msg.clone()
+                    err_msg.clone(),
                 ))))
                 .map_err(|send_error| ErrorCodes::UnknownException(send_error.to_string()))?;
 
@@ -130,13 +130,13 @@ impl ITable for ParquetTable {
             schema: self.schema.clone(),
             partitions: vec![Partition {
                 name: "".to_string(),
-                version: 0
+                version: 0,
             }],
             statistics: Statistics::default(),
             description: format!(
                 "(Read from Parquet Engine table  {}.{})",
                 self.db, self.name
-            )
+            ),
         })
     }
 

--- a/fusequery/query/src/datasources/local/parquet_table_test.rs
+++ b/fusequery/query/src/datasources/local/parquet_table_test.rs
@@ -17,7 +17,7 @@ async fn test_parquet_table() -> anyhow::Result<()> {
         env::current_dir()?
             .join("../../tests/data/alltypes_plain.parquet")
             .display()
-            .to_string()
+            .to_string(),
     )]
     .iter()
     .cloned()
@@ -28,7 +28,7 @@ async fn test_parquet_table() -> anyhow::Result<()> {
         "default".into(),
         "test_parquet".into(),
         DataSchemaRefExt::create(vec![DataField::new("id", DataType::Int32, false)]).clone(),
-        options
+        options,
     )?;
     table.read_plan(ctx.clone(), &ScanPlan::empty())?;
 

--- a/fusequery/query/src/datasources/remote/remote_database.rs
+++ b/fusequery/query/src/datasources/remote/remote_database.rs
@@ -22,7 +22,7 @@ pub struct RemoteDatabase {
     name: String,
     conf: Config,
     tables: RwLock<HashMap<String, Arc<dyn ITable>>>,
-    store_client: RwLock<Option<StoreClient>>
+    store_client: RwLock<Option<StoreClient>>,
 }
 
 impl RemoteDatabase {
@@ -31,7 +31,7 @@ impl RemoteDatabase {
             name,
             conf,
             tables: RwLock::new(HashMap::default()),
-            store_client: RwLock::new(None)
+            store_client: RwLock::new(None),
         }
     }
 
@@ -65,7 +65,7 @@ impl IDatabase for RemoteDatabase {
 
     fn get_table(&self, _table_name: &str) -> Result<Arc<dyn ITable>> {
         Result::Err(ErrorCodes::UnImplement(
-            "RemoteDatabase get_table not yet implemented"
+            "RemoteDatabase get_table not yet implemented",
         ))
     }
 

--- a/fusequery/query/src/datasources/remote/remote_factory.rs
+++ b/fusequery/query/src/datasources/remote/remote_factory.rs
@@ -11,7 +11,7 @@ use crate::datasources::remote::RemoteDatabase;
 use crate::datasources::IDatabase;
 
 pub struct RemoteFactory {
-    conf: Config
+    conf: Config,
 }
 
 impl RemoteFactory {
@@ -23,7 +23,7 @@ impl RemoteFactory {
         // Load databases from remote.
         let databases: Vec<Arc<dyn IDatabase>> = vec![Arc::new(RemoteDatabase::create(
             self.conf.clone(),
-            "for_test".to_string()
+            "for_test".to_string(),
         ))];
         Ok(databases)
     }

--- a/fusequery/query/src/datasources/remote/remote_table.rs
+++ b/fusequery/query/src/datasources/remote/remote_table.rs
@@ -19,7 +19,7 @@ use crate::sessions::FuseQueryContextRef;
 pub struct RemoteTable {
     pub(crate) db: String,
     name: String,
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl RemoteTable {
@@ -28,7 +28,7 @@ impl RemoteTable {
         db: String,
         name: String,
         schema: DataSchemaRef,
-        _options: TableOptions
+        _options: TableOptions,
     ) -> Result<Box<dyn ITable>> {
         let table = Self { db, name, schema };
         Ok(Box::new(table))
@@ -59,13 +59,13 @@ impl ITable for RemoteTable {
 
     fn read_plan(&self, _ctx: FuseQueryContextRef, _scan: &ScanPlan) -> Result<ReadDataSourcePlan> {
         Result::Err(ErrorCodes::UnImplement(
-            "RemoteTable read_plan not yet implemented"
+            "RemoteTable read_plan not yet implemented",
         ))
     }
 
     async fn read(&self, _ctx: FuseQueryContextRef) -> Result<SendableDataBlockStream> {
         Result::Err(ErrorCodes::UnImplement(
-            "RemoteTable read not yet implemented"
+            "RemoteTable read not yet implemented",
         ))
     }
 }

--- a/fusequery/query/src/datasources/system/clusters_table.rs
+++ b/fusequery/query/src/datasources/system/clusters_table.rs
@@ -24,7 +24,7 @@ use crate::datasources::ITable;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct ClustersTable {
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl ClustersTable {
@@ -34,7 +34,7 @@ impl ClustersTable {
                 DataField::new("name", DataType::Utf8, false),
                 DataField::new("address", DataType::Utf8, false),
                 DataField::new("priority", DataType::UInt8, false),
-            ])
+            ]),
         }
     }
 }
@@ -68,10 +68,10 @@ impl ITable for ClustersTable {
             schema: self.schema.clone(),
             partitions: vec![Partition {
                 name: "".to_string(),
-                version: 0
+                version: 0,
             }],
             statistics: Statistics::default(),
-            description: "(Read from system.clusters table)".to_string()
+            description: "(Read from system.clusters table)".to_string(),
         })
     }
 
@@ -80,15 +80,18 @@ impl ITable for ClustersTable {
         let names: Vec<&str> = nodes.iter().map(|x| x.name.as_str()).collect();
         let addresses: Vec<&str> = nodes.iter().map(|x| x.address.as_str()).collect();
         let priorities: Vec<u8> = nodes.iter().map(|x| x.priority).collect();
-        let block = DataBlock::create(self.schema.clone(), vec![
-            Arc::new(StringArray::from(names)),
-            Arc::new(StringArray::from(addresses)),
-            Arc::new(UInt8Array::from(priorities)),
-        ]);
+        let block = DataBlock::create(
+            self.schema.clone(),
+            vec![
+                Arc::new(StringArray::from(names)),
+                Arc::new(StringArray::from(addresses)),
+                Arc::new(UInt8Array::from(priorities)),
+            ],
+        );
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            vec![block]
+            vec![block],
         )))
     }
 }

--- a/fusequery/query/src/datasources/system/contributors_table.rs
+++ b/fusequery/query/src/datasources/system/contributors_table.rs
@@ -23,13 +23,13 @@ use crate::datasources::ITable;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct ContributorsTable {
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl ContributorsTable {
     pub fn create() -> Self {
         ContributorsTable {
-            schema: DataSchemaRefExt::create(vec![DataField::new("name", DataType::Utf8, false)])
+            schema: DataSchemaRefExt::create(vec![DataField::new("name", DataType::Utf8, false)]),
         }
     }
 }
@@ -63,10 +63,10 @@ impl ITable for ContributorsTable {
             schema: self.schema.clone(),
             partitions: vec![Partition {
                 name: "".to_string(),
-                version: 0
+                version: 0,
             }],
             statistics: Statistics::default(),
-            description: "(Read from system.contributors table)".to_string()
+            description: "(Read from system.contributors table)".to_string(),
         })
     }
 
@@ -75,13 +75,14 @@ impl ITable for ContributorsTable {
             .split_terminator(',')
             .map(|x| x.trim())
             .collect();
-        let block = DataBlock::create(self.schema.clone(), vec![Arc::new(StringArray::from(
-            contributors
-        ))]);
+        let block = DataBlock::create(
+            self.schema.clone(),
+            vec![Arc::new(StringArray::from(contributors))],
+        );
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            vec![block]
+            vec![block],
         )))
     }
 }

--- a/fusequery/query/src/datasources/system/databases_table.rs
+++ b/fusequery/query/src/datasources/system/databases_table.rs
@@ -23,13 +23,13 @@ use crate::datasources::ITable;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct DatabasesTable {
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl DatabasesTable {
     pub fn create() -> Self {
         DatabasesTable {
-            schema: DataSchemaRefExt::create(vec![DataField::new("name", DataType::Utf8, false)])
+            schema: DataSchemaRefExt::create(vec![DataField::new("name", DataType::Utf8, false)]),
         }
     }
 }
@@ -63,10 +63,10 @@ impl ITable for DatabasesTable {
             schema: self.schema.clone(),
             partitions: vec![Partition {
                 name: "".to_string(),
-                version: 0
+                version: 0,
             }],
             statistics: Statistics::default(),
-            description: "(Read from system.databases table)".to_string()
+            description: "(Read from system.databases table)".to_string(),
         })
     }
 
@@ -79,13 +79,16 @@ impl ITable for DatabasesTable {
                     .map(|database_name| database_name.as_str())
                     .collect();
 
-                let block = DataBlock::create(self.schema.clone(), vec![Arc::new(
-                    StringArray::from(databases_name_str)
-                )]);
+                let block = DataBlock::create(
+                    self.schema.clone(),
+                    vec![Arc::new(StringArray::from(databases_name_str))],
+                );
 
-                Box::pin(DataBlockStream::create(self.schema.clone(), None, vec![
-                    block,
-                ]))
+                Box::pin(DataBlockStream::create(
+                    self.schema.clone(),
+                    None,
+                    vec![block],
+                ))
             })
     }
 }

--- a/fusequery/query/src/datasources/system/functions_table.rs
+++ b/fusequery/query/src/datasources/system/functions_table.rs
@@ -24,13 +24,13 @@ use crate::datasources::ITable;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct FunctionsTable {
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl FunctionsTable {
     pub fn create() -> Self {
         FunctionsTable {
-            schema: DataSchemaRefExt::create(vec![DataField::new("name", DataType::Utf8, false)])
+            schema: DataSchemaRefExt::create(vec![DataField::new("name", DataType::Utf8, false)]),
         }
     }
 }
@@ -64,23 +64,24 @@ impl ITable for FunctionsTable {
             schema: self.schema.clone(),
             partitions: vec![Partition {
                 name: "".to_string(),
-                version: 0
+                version: 0,
             }],
             statistics: Statistics::default(),
-            description: "(Read from system.functions table)".to_string()
+            description: "(Read from system.functions table)".to_string(),
         })
     }
 
     async fn read(&self, _ctx: FuseQueryContextRef) -> Result<SendableDataBlockStream> {
         let func_names = FunctionFactory::registered_names();
         let names: Vec<&str> = func_names.iter().map(|x| x.as_ref()).collect();
-        let block = DataBlock::create(self.schema.clone(), vec![Arc::new(StringArray::from(
-            names
-        ))]);
+        let block = DataBlock::create(
+            self.schema.clone(),
+            vec![Arc::new(StringArray::from(names))],
+        );
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            vec![block]
+            vec![block],
         )))
     }
 }

--- a/fusequery/query/src/datasources/system/numbers_stream.rs
+++ b/fusequery/query/src/datasources/system/numbers_stream.rs
@@ -25,14 +25,14 @@ use crate::sessions::FuseQueryContextRef;
 #[derive(Debug, Clone)]
 struct BlockRange {
     begin: u64,
-    end: u64
+    end: u64,
 }
 
 pub struct NumbersStream {
     ctx: FuseQueryContextRef,
     schema: DataSchemaRef,
     block_index: usize,
-    blocks: Vec<BlockRange>
+    blocks: Vec<BlockRange>,
 }
 
 impl NumbersStream {
@@ -41,7 +41,7 @@ impl NumbersStream {
             ctx: ctx.clone(),
             schema,
             block_index: 0,
-            blocks: vec![]
+            blocks: vec![],
         });
         ProgressStream::try_create(stream, ctx.progress_callback()?)
     }
@@ -76,7 +76,7 @@ impl NumbersStream {
                         }
                         blocks.push(BlockRange {
                             begin: range_begin,
-                            end: range_end
+                            end: range_end,
                         });
                     }
                 }
@@ -99,7 +99,7 @@ impl NumbersStream {
                 let buffer = Buffer::from_raw_parts(
                     NonNull::new(me.as_mut_ptr() as *mut u8).unwrap(),
                     me.len() * byte_size,
-                    me.capacity() * byte_size
+                    me.capacity() * byte_size,
                 );
 
                 let arr_data = ArrayData::builder(DataType::UInt64)
@@ -108,9 +108,10 @@ impl NumbersStream {
                     .add_buffer(buffer)
                     .build();
 
-                let block = DataBlock::create(self.schema.clone(), vec![Arc::new(
-                    UInt64Array::from(arr_data)
-                )]);
+                let block = DataBlock::create(
+                    self.schema.clone(),
+                    vec![Arc::new(UInt64Array::from(arr_data))],
+                );
                 Some(block)
             }
         })
@@ -122,7 +123,7 @@ impl Stream for NumbersStream {
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
-        _: &mut Context<'_>
+        _: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let block = self.try_get_one_block()?;
 

--- a/fusequery/query/src/datasources/system/numbers_table.rs
+++ b/fusequery/query/src/datasources/system/numbers_table.rs
@@ -27,7 +27,7 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct NumbersTable {
     table: &'static str,
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl NumbersTable {
@@ -37,8 +37,8 @@ impl NumbersTable {
             schema: DataSchemaRefExt::create(vec![DataField::new(
                 "number",
                 DataType::UInt64,
-                false
-            )])
+                false,
+            )]),
         }
     }
 }
@@ -53,7 +53,7 @@ impl ITable for NumbersTable {
         match self.table {
             "numbers" => "SystemNumbers",
             "numbers_mt" => "SystemNumbersMt",
-            _ => unreachable!()
+            _ => unreachable!(),
         }
     }
 
@@ -91,7 +91,7 @@ impl ITable for NumbersTable {
 
         let statistics = Statistics {
             read_rows: total as usize,
-            read_bytes: ((total) * size_of::<u64>() as u64) as usize
+            read_bytes: ((total) * size_of::<u64>() as u64) as usize,
         };
         ctx.try_set_statistics(&statistics)?;
         ctx.add_total_rows_approx(statistics.read_rows);
@@ -105,14 +105,14 @@ impl ITable for NumbersTable {
             description: format!(
                 "(Read from system.{} table, Read Rows:{}, Read Bytes:{})",
                 self.table, statistics.read_rows, statistics.read_bytes
-            )
+            ),
         })
     }
 
     async fn read(&self, ctx: FuseQueryContextRef) -> Result<SendableDataBlockStream> {
         Ok(Box::pin(NumbersStream::try_create(
             ctx,
-            self.schema.clone()
+            self.schema.clone(),
         )?))
     }
 }
@@ -127,7 +127,9 @@ impl ITableFunction for NumbersTable {
     }
 
     fn as_table<'a>(self: Arc<Self>) -> Arc<dyn ITable + 'a>
-    where Self: 'a {
+    where
+        Self: 'a,
+    {
         self
     }
 }

--- a/fusequery/query/src/datasources/system/numbers_table_test.rs
+++ b/fusequery/query/src/datasources/system/numbers_table_test.rs
@@ -22,10 +22,10 @@ async fn test_number_table() -> anyhow::Result<()> {
         projected_schema: DataSchemaRefExt::create(vec![DataField::new(
             "number",
             DataType::UInt64,
-            false
+            false,
         )]),
         filters: vec![],
-        limit: None
+        limit: None,
     };
     let source_plan = table.read_plan(ctx.clone(), scan)?;
     ctx.try_set_partitions(source_plan.partitions)?;

--- a/fusequery/query/src/datasources/system/one_table.rs
+++ b/fusequery/query/src/datasources/system/one_table.rs
@@ -23,13 +23,13 @@ use crate::datasources::ITable;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct OneTable {
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl OneTable {
     pub fn create() -> Self {
         OneTable {
-            schema: DataSchemaRefExt::create(vec![DataField::new("dummy", DataType::UInt8, false)])
+            schema: DataSchemaRefExt::create(vec![DataField::new("dummy", DataType::UInt8, false)]),
         }
     }
 }
@@ -63,21 +63,22 @@ impl ITable for OneTable {
             schema: self.schema.clone(),
             partitions: vec![Partition {
                 name: "".to_string(),
-                version: 0
+                version: 0,
             }],
             statistics: Statistics::default(),
-            description: "(Read from system.one table)".to_string()
+            description: "(Read from system.one table)".to_string(),
         })
     }
 
     async fn read(&self, _: FuseQueryContextRef) -> Result<SendableDataBlockStream> {
-        let block = DataBlock::create(self.schema.clone(), vec![Arc::new(UInt8Array::from(vec![
-            1u8,
-        ]))]);
+        let block = DataBlock::create(
+            self.schema.clone(),
+            vec![Arc::new(UInt8Array::from(vec![1u8]))],
+        );
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            vec![block]
+            vec![block],
         )))
     }
 }

--- a/fusequery/query/src/datasources/system/settings_table.rs
+++ b/fusequery/query/src/datasources/system/settings_table.rs
@@ -24,7 +24,7 @@ use crate::datasources::ITable;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct SettingsTable {
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl SettingsTable {
@@ -35,7 +35,7 @@ impl SettingsTable {
                 DataField::new("value", DataType::Utf8, false),
                 DataField::new("default_value", DataType::Utf8, false),
                 DataField::new("description", DataType::Utf8, false),
-            ])
+            ]),
         }
     }
 }
@@ -69,10 +69,10 @@ impl ITable for SettingsTable {
             schema: self.schema.clone(),
             partitions: vec![Partition {
                 name: "".to_string(),
-                version: 0
+                version: 0,
             }],
             statistics: Statistics::default(),
-            description: "(Read from system.settings table)".to_string()
+            description: "(Read from system.settings table)".to_string(),
         })
     }
 
@@ -96,16 +96,19 @@ impl ITable for SettingsTable {
         let values: Vec<&str> = values.iter().map(|x| x.as_str()).collect();
         let default_values: Vec<&str> = default_values.iter().map(|x| x.as_str()).collect();
         let descs: Vec<&str> = descs.iter().map(|x| x.as_str()).collect();
-        let block = DataBlock::create(self.schema.clone(), vec![
-            Arc::new(StringArray::from(names)),
-            Arc::new(StringArray::from(values)),
-            Arc::new(StringArray::from(default_values)),
-            Arc::new(StringArray::from(descs)),
-        ]);
+        let block = DataBlock::create(
+            self.schema.clone(),
+            vec![
+                Arc::new(StringArray::from(names)),
+                Arc::new(StringArray::from(values)),
+                Arc::new(StringArray::from(default_values)),
+                Arc::new(StringArray::from(descs)),
+            ],
+        );
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            vec![block]
+            vec![block],
         )))
     }
 }

--- a/fusequery/query/src/datasources/system/system_database.rs
+++ b/fusequery/query/src/datasources/system/system_database.rs
@@ -17,7 +17,7 @@ use crate::datasources::ITableFunction;
 
 pub struct SystemDatabase {
     tables: HashMap<String, Arc<dyn ITable>>,
-    table_functions: HashMap<String, Arc<dyn ITableFunction>>
+    table_functions: HashMap<String, Arc<dyn ITableFunction>>,
 }
 
 impl SystemDatabase {
@@ -51,7 +51,7 @@ impl SystemDatabase {
 
         SystemDatabase {
             tables,
-            table_functions
+            table_functions,
         }
     }
 }
@@ -88,13 +88,13 @@ impl IDatabase for SystemDatabase {
 
     async fn create_table(&self, _plan: CreateTablePlan) -> Result<()> {
         Result::Err(ErrorCodes::UnImplement(
-            "Cannot create table for system database"
+            "Cannot create table for system database",
         ))
     }
 
     async fn drop_table(&self, _plan: DropTablePlan) -> Result<()> {
         Result::Err(ErrorCodes::UnImplement(
-            "Cannot drop table for system database"
+            "Cannot drop table for system database",
         ))
     }
 }

--- a/fusequery/query/src/datasources/system/tables_table.rs
+++ b/fusequery/query/src/datasources/system/tables_table.rs
@@ -23,7 +23,7 @@ use crate::datasources::ITable;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct TablesTable {
-    schema: DataSchemaRef
+    schema: DataSchemaRef,
 }
 
 impl TablesTable {
@@ -33,7 +33,7 @@ impl TablesTable {
                 DataField::new("database", DataType::Utf8, false),
                 DataField::new("name", DataType::Utf8, false),
                 DataField::new("engine", DataType::Utf8, false),
-            ])
+            ]),
         }
     }
 }
@@ -67,10 +67,10 @@ impl ITable for TablesTable {
             schema: self.schema.clone(),
             partitions: vec![Partition {
                 name: "".to_string(),
-                version: 0
+                version: 0,
             }],
             statistics: Statistics::default(),
-            description: "(Read from system.functions table)".to_string()
+            description: "(Read from system.functions table)".to_string(),
         })
     }
 
@@ -81,16 +81,19 @@ impl ITable for TablesTable {
         let names: Vec<&str> = database_tables.iter().map(|(_, v)| v.name()).collect();
         let engines: Vec<&str> = database_tables.iter().map(|(_, v)| v.engine()).collect();
 
-        let block = DataBlock::create(self.schema.clone(), vec![
-            Arc::new(StringArray::from(databases)),
-            Arc::new(StringArray::from(names)),
-            Arc::new(StringArray::from(engines)),
-        ]);
+        let block = DataBlock::create(
+            self.schema.clone(),
+            vec![
+                Arc::new(StringArray::from(databases)),
+                Arc::new(StringArray::from(names)),
+                Arc::new(StringArray::from(engines)),
+            ],
+        );
 
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            vec![block]
+            vec![block],
         )))
     }
 }

--- a/fusequery/query/src/datasources/table_function.rs
+++ b/fusequery/query/src/datasources/table_function.rs
@@ -11,5 +11,6 @@ pub trait ITableFunction: Sync + Send + ITable {
     fn db(&self) -> &str;
 
     fn as_table<'a>(self: Arc<Self>) -> Arc<dyn ITable + 'a>
-    where Self: 'a;
+    where
+        Self: 'a;
 }

--- a/fusequery/query/src/datasources/tests.rs
+++ b/fusequery/query/src/datasources/tests.rs
@@ -28,7 +28,7 @@ async fn test_datasource() -> anyhow::Result<()> {
                 if_not_exists: false,
                 db: "test_db".to_string(),
                 engine: DatabaseEngineType::Local,
-                options: Default::default()
+                options: Default::default(),
             })
             .await?;
 
@@ -40,7 +40,7 @@ async fn test_datasource() -> anyhow::Result<()> {
         datasource
             .drop_database(DropDatabasePlan {
                 if_exists: false,
-                db: "test_db".to_string()
+                db: "test_db".to_string(),
             })
             .await?;
 

--- a/fusequery/query/src/functions/context_function.rs
+++ b/fusequery/query/src/functions/context_function.rs
@@ -17,7 +17,7 @@ impl ContextFunction {
     // such as `SELECT database()`, the arg is ctx.get_default_db()
     pub fn build_args_from_ctx(
         name: &str,
-        ctx: FuseQueryContextRef
+        ctx: FuseQueryContextRef,
     ) -> Result<Vec<ExpressionAction>> {
         // Check the function is supported in common functions.
         if !FunctionFactory::check(name) {
@@ -29,9 +29,9 @@ impl ContextFunction {
 
         Ok(match name.to_lowercase().as_str() {
             "database" => vec![ExpressionAction::Literal(DataValue::Utf8(Some(
-                ctx.get_current_database()
+                ctx.get_current_database(),
             )))],
-            _ => vec![]
+            _ => vec![],
         })
     }
 }

--- a/fusequery/query/src/interpreters/interpreter_database_create.rs
+++ b/fusequery/query/src/interpreters/interpreter_database_create.rs
@@ -15,13 +15,13 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct CreateDatabaseInterpreter {
     ctx: FuseQueryContextRef,
-    plan: CreateDatabasePlan
+    plan: CreateDatabasePlan,
 }
 
 impl CreateDatabaseInterpreter {
     pub fn try_create(
         ctx: FuseQueryContextRef,
-        plan: CreateDatabasePlan
+        plan: CreateDatabasePlan,
     ) -> Result<InterpreterPtr> {
         Ok(Arc::new(CreateDatabaseInterpreter { ctx, plan }))
     }
@@ -40,7 +40,7 @@ impl IInterpreter for CreateDatabaseInterpreter {
         Ok(Box::pin(DataBlockStream::create(
             self.plan.schema(),
             None,
-            vec![]
+            vec![],
         )))
     }
 }

--- a/fusequery/query/src/interpreters/interpreter_database_drop.rs
+++ b/fusequery/query/src/interpreters/interpreter_database_drop.rs
@@ -15,7 +15,7 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct DropDatabaseInterpreter {
     ctx: FuseQueryContextRef,
-    plan: DropDatabasePlan
+    plan: DropDatabasePlan,
 }
 
 impl DropDatabaseInterpreter {
@@ -37,7 +37,7 @@ impl IInterpreter for DropDatabaseInterpreter {
         Ok(Box::pin(DataBlockStream::create(
             self.plan.schema(),
             None,
-            vec![]
+            vec![],
         )))
     }
 }

--- a/fusequery/query/src/interpreters/interpreter_explain.rs
+++ b/fusequery/query/src/interpreters/interpreter_explain.rs
@@ -24,7 +24,7 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct ExplainInterpreter {
     ctx: FuseQueryContextRef,
-    explain: ExplainPlan
+    explain: ExplainPlan,
 }
 
 impl ExplainInterpreter {
@@ -52,11 +52,12 @@ impl IInterpreter for ExplainInterpreter {
                 let pipeline = PipelineBuilder::create(self.ctx.clone(), plan).build()?;
                 format!("{:?}", pipeline)
             }
-            _ => format!("{:?}", plan)
+            _ => format!("{:?}", plan),
         };
-        let block = DataBlock::create(schema.clone(), vec![Arc::new(StringArray::from(vec![
-            result.as_str(),
-        ]))]);
+        let block = DataBlock::create(
+            schema.clone(),
+            vec![Arc::new(StringArray::from(vec![result.as_str()]))],
+        );
         debug!("Explain executor result: {:?}", block);
 
         Ok(Box::pin(DataBlockStream::create(schema, None, vec![block])))

--- a/fusequery/query/src/interpreters/interpreter_explain_test.rs
+++ b/fusequery/query/src/interpreters/interpreter_explain_test.rs
@@ -14,7 +14,7 @@ async fn test_explain_interpreter() -> anyhow::Result<()> {
     let ctx = crate::tests::try_create_context()?;
 
     if let PlanNode::Explain(plan) = PlanParser::create(ctx.clone()).build_from_sql(
-        "explain select number from numbers_mt(10) where (number+1)=4 having (number+1)=4"
+        "explain select number from numbers_mt(10) where (number+1)=4 having (number+1)=4",
     )? {
         let executor = ExplainInterpreter::try_create(ctx, plan)?;
         assert_eq!(executor.name(), "ExplainInterpreter");

--- a/fusequery/query/src/interpreters/interpreter_factory.rs
+++ b/fusequery/query/src/interpreters/interpreter_factory.rs
@@ -35,7 +35,7 @@ impl InterpreterFactory {
             _ => Result::Err(ErrorCodes::UnknownTypeOfQuery(format!(
                 "Can't get the interpreter by plan:{}",
                 plan.name()
-            )))
+            ))),
         }
     }
 }

--- a/fusequery/query/src/interpreters/interpreter_select.rs
+++ b/fusequery/query/src/interpreters/interpreter_select.rs
@@ -16,7 +16,7 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct SelectInterpreter {
     ctx: FuseQueryContextRef,
-    select: SelectPlan
+    select: SelectPlan,
 }
 
 impl SelectInterpreter {

--- a/fusequery/query/src/interpreters/interpreter_setting.rs
+++ b/fusequery/query/src/interpreters/interpreter_setting.rs
@@ -18,7 +18,7 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct SettingInterpreter {
     ctx: FuseQueryContextRef,
-    set: SettingPlan
+    set: SettingPlan,
 }
 
 impl SettingInterpreter {

--- a/fusequery/query/src/interpreters/interpreter_table_create.rs
+++ b/fusequery/query/src/interpreters/interpreter_table_create.rs
@@ -15,7 +15,7 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct CreateTableInterpreter {
     ctx: FuseQueryContextRef,
-    plan: CreateTablePlan
+    plan: CreateTablePlan,
 }
 
 impl CreateTableInterpreter {
@@ -38,7 +38,7 @@ impl IInterpreter for CreateTableInterpreter {
         Ok(Box::pin(DataBlockStream::create(
             self.plan.schema.clone(),
             None,
-            vec![]
+            vec![],
         )))
     }
 }

--- a/fusequery/query/src/interpreters/interpreter_table_drop.rs
+++ b/fusequery/query/src/interpreters/interpreter_table_drop.rs
@@ -15,7 +15,7 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct DropTableInterpreter {
     ctx: FuseQueryContextRef,
-    plan: DropTablePlan
+    plan: DropTablePlan,
 }
 
 impl DropTableInterpreter {
@@ -38,7 +38,7 @@ impl IInterpreter for DropTableInterpreter {
         Ok(Box::pin(DataBlockStream::create(
             self.plan.schema(),
             None,
-            vec![]
+            vec![],
         )))
     }
 }

--- a/fusequery/query/src/interpreters/interpreter_use_database.rs
+++ b/fusequery/query/src/interpreters/interpreter_use_database.rs
@@ -16,7 +16,7 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct UseDatabaseInterpreter {
     ctx: FuseQueryContextRef,
-    plan: UseDatabasePlan
+    plan: UseDatabasePlan,
 }
 
 impl UseDatabaseInterpreter {

--- a/fusequery/query/src/metrics/metric_service.rs
+++ b/fusequery/query/src/metrics/metric_service.rs
@@ -9,7 +9,7 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 use crate::configs::Config;
 
 pub struct MetricService {
-    conf: Config
+    conf: Config,
 }
 
 impl MetricService {

--- a/fusequery/query/src/optimizers/optimizer.rs
+++ b/fusequery/query/src/optimizers/optimizer.rs
@@ -14,7 +14,7 @@ pub trait IOptimizer {
 }
 
 pub struct Optimizer {
-    optimizers: Vec<Box<dyn IOptimizer>>
+    optimizers: Vec<Box<dyn IOptimizer>>,
 }
 
 impl Optimizer {

--- a/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
@@ -30,7 +30,7 @@ pub struct ProjectionPushDownOptimizer {}
 
 struct ProjectionPushDownImpl {
     pub required_columns: HashSet<String>,
-    pub has_projection: bool
+    pub has_projection: bool,
 }
 
 impl<'plan> PlanRewriter<'plan> for ProjectionPushDownImpl {
@@ -81,7 +81,7 @@ impl<'plan> PlanRewriter<'plan> for ProjectionPushDownImpl {
                     schema: projected_schema,
                     partitions: plan.partitions.clone(),
                     statistics: plan.statistics.clone(),
-                    description: plan.description.to_string()
+                    description: plan.description.to_string(),
                 })
             })
     }
@@ -95,7 +95,7 @@ impl ProjectionPushDownImpl {
     pub fn new() -> ProjectionPushDownImpl {
         ProjectionPushDownImpl {
             required_columns: HashSet::new(),
-            has_projection: false
+            has_projection: false,
         }
     }
 

--- a/fusequery/query/src/optimizers/optimizer_projection_push_down_test.rs
+++ b/fusequery/query/src/optimizers/optimizer_projection_push_down_test.rs
@@ -24,7 +24,7 @@ mod tests {
                 DataField::new("b", DataType::Utf8, false),
                 DataField::new("c", DataType::Utf8, false),
             ]),
-            input: Arc::from(PlanBuilder::empty().build()?)
+            input: Arc::from(PlanBuilder::empty().build()?),
         });
 
         let mut projection_push_down = ProjectionPushDownOptimizer::create(ctx);
@@ -49,7 +49,7 @@ mod tests {
         let ctx = crate::tests::try_create_context()?;
 
         let plan = PlanParser::create(ctx.clone()).build_from_sql(
-            "select max(value) as c1, name as c2 from system.settings group by c2"
+            "select max(value) as c1, name as c2 from system.settings group by c2",
         )?;
 
         let mut project_push_down = ProjectionPushDownOptimizer::create(ctx);
@@ -71,7 +71,7 @@ mod tests {
         let total = ctx.get_max_block_size()? as u64;
         let statistics = Statistics {
             read_rows: total as usize,
-            read_bytes: ((total) * size_of::<u64>() as u64) as usize
+            read_bytes: ((total) * size_of::<u64>() as u64) as usize,
         };
         ctx.try_set_statistics(&statistics)?;
         let source_plan = PlanNode::ReadSource(ReadDataSourcePlan {
@@ -89,7 +89,7 @@ mod tests {
                 "test".to_string(),
                 statistics.read_rows,
                 statistics.read_bytes
-            )
+            ),
         });
 
         let filter_plan = PlanBuilder::from(&source_plan)
@@ -99,7 +99,7 @@ mod tests {
         let plan = PlanNode::Projection(ProjectionPlan {
             expr: vec![col("a")],
             schema: DataSchemaRefExt::create(vec![DataField::new("a", DataType::Utf8, false)]),
-            input: Arc::from(filter_plan)
+            input: Arc::from(filter_plan),
         });
 
         let mut projection_push_down = ProjectionPushDownOptimizer::create(ctx);
@@ -122,7 +122,7 @@ mod tests {
         let total = ctx.get_max_block_size()? as u64;
         let statistics = Statistics {
             read_rows: total as usize,
-            read_bytes: ((total) * size_of::<u64>() as u64) as usize
+            read_bytes: ((total) * size_of::<u64>() as u64) as usize,
         };
         ctx.try_set_statistics(&statistics)?;
         let source_plan = PlanNode::ReadSource(ReadDataSourcePlan {
@@ -144,7 +144,7 @@ mod tests {
                 "test".to_string(),
                 statistics.read_rows,
                 statistics.read_bytes
-            )
+            ),
         });
 
         let group_exprs = &[col("a"), col("c")];

--- a/fusequery/query/src/pipelines/processors/pipe.rs
+++ b/fusequery/query/src/pipelines/processors/pipe.rs
@@ -8,7 +8,7 @@ use crate::pipelines::processors::IProcessor;
 
 #[derive(Clone)]
 pub struct Pipe {
-    processors: Vec<Arc<dyn IProcessor>>
+    processors: Vec<Arc<dyn IProcessor>>,
 }
 
 impl Pipe {

--- a/fusequery/query/src/pipelines/processors/pipeline.rs
+++ b/fusequery/query/src/pipelines/processors/pipeline.rs
@@ -15,7 +15,7 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct Pipeline {
     ctx: FuseQueryContextRef,
-    pipes: Vec<Pipe>
+    pipes: Vec<Pipe>,
 }
 
 impl Pipeline {
@@ -32,7 +32,7 @@ impl Pipeline {
     pub fn nums(&self) -> usize {
         match self.pipes.last() {
             None => 0,
-            Some(v) => v.nums()
+            Some(v) => v.nums(),
         }
     }
 
@@ -72,7 +72,7 @@ impl Pipeline {
     ///
     pub fn add_simple_transform(
         &mut self,
-        f: impl Fn() -> Result<Box<dyn IProcessor>>
+        f: impl Fn() -> Result<Box<dyn IProcessor>>,
     ) -> Result<()> {
         let last_pipe = self.last_pipe()?;
         let mut new_pipe = Pipe::create();

--- a/fusequery/query/src/pipelines/processors/pipeline_builder.rs
+++ b/fusequery/query/src/pipelines/processors/pipeline_builder.rs
@@ -37,7 +37,7 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct PipelineBuilder {
     ctx: FuseQueryContextRef,
-    plan: PlanNode
+    plan: PlanNode,
 }
 
 impl PipelineBuilder {
@@ -55,7 +55,7 @@ impl PipelineBuilder {
                     limit = Some(limit_plan.n);
                     Ok(true)
                 }
-                _ => Ok(true)
+                _ => Ok(true),
             }
         })?;
 
@@ -86,7 +86,7 @@ impl PipelineBuilder {
                 other => Result::Err(ErrorCodes::UnknownPlan(format!(
                     "Build pipeline from the plan node unsupported:{:?}",
                     other.name()
-                )))
+                ))),
             }
         })?;
         info!("Pipeline:\n{:?}", pipeline);
@@ -109,7 +109,7 @@ impl PipelineBuilder {
                     self.ctx.clone(),
                     self.ctx.get_id()?,
                     address.clone(),
-                    remote_plan.clone()
+                    remote_plan.clone(),
                 )?;
                 pipeline.add_source(Arc::new(remote_transform))?;
             }
@@ -121,7 +121,7 @@ impl PipelineBuilder {
         pipeline.add_simple_transform(|| {
             Ok(Box::new(ExpressionTransform::try_create(
                 plan.schema.clone(),
-                plan.exprs.clone()
+                plan.exprs.clone(),
             )?))
         })?;
         Ok(true)
@@ -130,7 +130,7 @@ impl PipelineBuilder {
     fn visit_projection_plan(pipeline: &mut Pipeline, plan: &ProjectionPlan) -> Result<bool> {
         pipeline.add_simple_transform(|| {
             Ok(Box::new(ProjectionTransform::try_create(
-                plan.schema.clone()
+                plan.schema.clone(),
             )?))
         })?;
         Ok(true)
@@ -138,13 +138,13 @@ impl PipelineBuilder {
 
     fn visit_aggregator_partial_plan(
         pipeline: &mut Pipeline,
-        plan: &AggregatorPartialPlan
+        plan: &AggregatorPartialPlan,
     ) -> Result<bool> {
         if plan.group_expr.is_empty() {
             pipeline.add_simple_transform(|| {
                 Ok(Box::new(AggregatorPartialTransform::try_create(
                     plan.schema(),
-                    plan.aggr_expr.clone()
+                    plan.aggr_expr.clone(),
                 )?))
             })?;
         } else {
@@ -152,7 +152,7 @@ impl PipelineBuilder {
                 Ok(Box::new(GroupByPartialTransform::create(
                     plan.schema(),
                     plan.aggr_expr.clone(),
-                    plan.group_expr.clone()
+                    plan.group_expr.clone(),
                 )))
             })?;
         }
@@ -161,14 +161,14 @@ impl PipelineBuilder {
 
     fn visit_aggregator_final_plan(
         pipeline: &mut Pipeline,
-        plan: &AggregatorFinalPlan
+        plan: &AggregatorFinalPlan,
     ) -> Result<bool> {
         pipeline.merge_processor()?;
         if plan.group_expr.is_empty() {
             pipeline.add_simple_transform(|| {
                 Ok(Box::new(AggregatorFinalTransform::try_create(
                     plan.schema(),
-                    plan.aggr_expr.clone()
+                    plan.aggr_expr.clone(),
                 )?))
             })?;
         } else {
@@ -176,7 +176,7 @@ impl PipelineBuilder {
                 Ok(Box::new(GroupByFinalTransform::create(
                     plan.schema(),
                     plan.aggr_expr.clone(),
-                    plan.group_expr.clone()
+                    plan.group_expr.clone(),
                 )))
             })?;
         }
@@ -187,7 +187,7 @@ impl PipelineBuilder {
         pipeline.add_simple_transform(|| {
             Ok(Box::new(FilterTransform::try_create(
                 plan.predicate.clone(),
-                false
+                false,
             )?))
         })?;
         Ok(true)
@@ -197,7 +197,7 @@ impl PipelineBuilder {
         pipeline.add_simple_transform(|| {
             Ok(Box::new(FilterTransform::try_create(
                 plan.predicate.clone(),
-                true
+                true,
             )?))
         })?;
         Ok(true)
@@ -206,7 +206,7 @@ impl PipelineBuilder {
     fn visit_sort_plan(
         limit: Option<usize>,
         pipeline: &mut Pipeline,
-        plan: &SortPlan
+        plan: &SortPlan,
     ) -> Result<bool> {
         // processor 1: block ---> sort_stream
         // processor 2: block ---> sort_stream
@@ -215,7 +215,7 @@ impl PipelineBuilder {
             Ok(Box::new(SortPartialTransform::try_create(
                 plan.schema(),
                 plan.order_by.clone(),
-                limit
+                limit,
             )?))
         })?;
 
@@ -226,7 +226,7 @@ impl PipelineBuilder {
             Ok(Box::new(SortMergeTransform::try_create(
                 plan.schema(),
                 plan.order_by.clone(),
-                limit
+                limit,
             )?))
         })?;
 
@@ -241,7 +241,7 @@ impl PipelineBuilder {
                 Ok(Box::new(SortMergeTransform::try_create(
                     plan.schema(),
                     plan.order_by.clone(),
-                    limit
+                    limit,
                 )?))
             })?;
         }
@@ -257,7 +257,7 @@ impl PipelineBuilder {
     fn visit_read_data_source_plan(
         &self,
         pipeline: &mut Pipeline,
-        plan: &ReadDataSourcePlan
+        plan: &ReadDataSourcePlan,
     ) -> Result<bool> {
         // Bind plan partitions to context.
         self.ctx.try_set_partitions(plan.partitions.clone())?;
@@ -275,7 +275,7 @@ impl PipelineBuilder {
             let source = SourceTransform::try_create(
                 self.ctx.clone(),
                 plan.db.as_str(),
-                plan.table.as_str()
+                plan.table.as_str(),
             )?;
             pipeline.add_source(Arc::new(source))?;
         }

--- a/fusequery/query/src/pipelines/processors/pipeline_builder_test.rs
+++ b/fusequery/query/src/pipelines/processors/pipeline_builder_test.rs
@@ -17,7 +17,7 @@ async fn test_distributed_pipeline_build() -> anyhow::Result<()> {
     ctx_more_cpu.set_max_threads(cpus * 40)?;
 
     let plan = PlanParser::create(ctx_more_cpu.clone()).build_from_sql(
-        "select sum(number+1)+2 as sumx from numbers_mt(80000) where (number+1)=4 limit 1"
+        "select sum(number+1)+2 as sumx from numbers_mt(80000) where (number+1)=4 limit 1",
     )?;
     let pipeline = PipelineBuilder::create(ctx, plan).build()?;
     let expect = "LimitTransform × 1 processor\
@@ -42,7 +42,7 @@ async fn test_local_pipeline_builds() -> anyhow::Result<()> {
         query: &'static str,
         plan: &'static str,
         pipeline: &'static str,
-        block: Vec<&'static str>
+        block: Vec<&'static str>,
     }
 
     let tests = vec![

--- a/fusequery/query/src/pipelines/processors/pipeline_display.rs
+++ b/fusequery/query/src/pipelines/processors/pipeline_display.rs
@@ -75,7 +75,7 @@ impl Pipeline {
                                 })?;
                                 let local_pipeline = PipelineBuilder::create(
                                     remote.ctx.clone(),
-                                    remote.plan.clone()
+                                    remote.plan.clone(),
                                 )
                                 .build()?;
                                 let pipeline_display =

--- a/fusequery/query/src/pipelines/processors/pipeline_walker.rs
+++ b/fusequery/query/src/pipelines/processors/pipeline_walker.rs
@@ -10,14 +10,14 @@ use crate::pipelines::processors::Pipeline;
 #[derive(PartialEq)]
 enum WalkOrder {
     PreOrder,
-    PostOrder
+    PostOrder,
 }
 
 impl Pipeline {
     fn walk_base(
         order: WalkOrder,
         pipeline: &Pipeline,
-        mut visitor: impl FnMut(&Pipe) -> Result<bool>
+        mut visitor: impl FnMut(&Pipe) -> Result<bool>,
     ) -> Result<()> {
         let mut pipes = vec![];
 

--- a/fusequery/query/src/pipelines/processors/pipeline_walker_test.rs
+++ b/fusequery/query/src/pipelines/processors/pipeline_walker_test.rs
@@ -12,7 +12,7 @@ async fn test_pipeline_walker() -> anyhow::Result<()> {
     let ctx = crate::tests::try_create_context()?;
 
     let plan = PlanParser::create(ctx.clone()).build_from_sql(
-        "select sum(number+1)+2 as sumx from numbers_mt(80000) where (number+1)=4 limit 1"
+        "select sum(number+1)+2 as sumx from numbers_mt(80000) where (number+1)=4 limit 1",
     )?;
     let pipeline = PipelineBuilder::create(ctx, plan).build()?;
 

--- a/fusequery/query/src/pipelines/processors/processor.rs
+++ b/fusequery/query/src/pipelines/processors/processor.rs
@@ -15,7 +15,7 @@ pub struct FormatterSettings {
     pub indent_char: &'static str,
     pub prefix: &'static str,
     pub prev_ways: usize,
-    pub prev_name: String
+    pub prev_name: String,
 }
 
 #[async_trait::async_trait]

--- a/fusequery/query/src/pipelines/processors/processor_empty.rs
+++ b/fusequery/query/src/pipelines/processors/processor_empty.rs
@@ -29,7 +29,7 @@ impl IProcessor for EmptyProcessor {
 
     fn connect_to(&mut self, _: Arc<dyn IProcessor>) -> Result<()> {
         Result::Err(ErrorCodes::IllegalTransformConnectionState(
-            "Cannot call EmptyProcessor connect_to"
+            "Cannot call EmptyProcessor connect_to",
         ))
     }
 
@@ -45,7 +45,7 @@ impl IProcessor for EmptyProcessor {
         Ok(Box::pin(DataBlockStream::create(
             Arc::new(DataSchema::empty()),
             None,
-            vec![]
+            vec![],
         )))
     }
 }

--- a/fusequery/query/src/pipelines/processors/processor_merge.rs
+++ b/fusequery/query/src/pipelines/processors/processor_merge.rs
@@ -18,14 +18,14 @@ use crate::sessions::FuseQueryContextRef;
 
 pub struct MergeProcessor {
     ctx: FuseQueryContextRef,
-    inputs: Vec<Arc<dyn IProcessor>>
+    inputs: Vec<Arc<dyn IProcessor>>,
 }
 
 impl MergeProcessor {
     pub fn create(ctx: FuseQueryContextRef) -> Self {
         MergeProcessor {
             ctx,
-            inputs: vec![]
+            inputs: vec![],
         }
     }
 }
@@ -53,7 +53,7 @@ impl IProcessor for MergeProcessor {
         let inputs = self.inputs.len();
         match inputs {
             0 => Result::Err(ErrorCodes::IllegalTransformConnectionState(
-                "Merge processor inputs cannot be zero"
+                "Merge processor inputs cannot be zero",
             )),
             1 => self.inputs[0].execute().await,
             _ => {
@@ -67,7 +67,7 @@ impl IProcessor for MergeProcessor {
                                 sender.send(Result::Err(e)).await.ok();
                                 return;
                             }
-                            Ok(stream) => stream
+                            Ok(stream) => stream,
                         };
 
                         while let Some(item) = stream.next().await {

--- a/fusequery/query/src/pipelines/transforms/transform_aggregator_final.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_aggregator_final.rs
@@ -23,7 +23,7 @@ use crate::pipelines::processors::IProcessor;
 pub struct AggregatorFinalTransform {
     funcs: Vec<Box<dyn IFunction>>,
     schema: DataSchemaRef,
-    input: Arc<dyn IProcessor>
+    input: Arc<dyn IProcessor>,
 }
 
 impl AggregatorFinalTransform {
@@ -36,7 +36,7 @@ impl AggregatorFinalTransform {
         Ok(AggregatorFinalTransform {
             funcs,
             schema,
-            input: Arc::new(EmptyProcessor::create())
+            input: Arc::new(EmptyProcessor::create()),
         })
     }
 }
@@ -97,7 +97,7 @@ impl IProcessor for AggregatorFinalTransform {
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            blocks
+            blocks,
         )))
     }
 }

--- a/fusequery/query/src/pipelines/transforms/transform_aggregator_final_test.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_aggregator_final_test.rs
@@ -33,14 +33,14 @@ async fn test_transform_final_aggregator() -> anyhow::Result<()> {
     pipeline.add_simple_transform(|| {
         Ok(Box::new(AggregatorPartialTransform::try_create(
             aggr_partial.schema(),
-            aggr_exprs.to_vec()
+            aggr_exprs.to_vec(),
         )?))
     })?;
     pipeline.merge_processor()?;
     pipeline.add_simple_transform(|| {
         Ok(Box::new(AggregatorFinalTransform::try_create(
             aggr_final.schema(),
-            aggr_exprs.to_vec()
+            aggr_exprs.to_vec(),
         )?))
     })?;
 

--- a/fusequery/query/src/pipelines/transforms/transform_aggregator_partial.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_aggregator_partial.rs
@@ -28,7 +28,7 @@ use crate::pipelines::processors::IProcessor;
 pub struct AggregatorPartialTransform {
     funcs: Vec<Box<dyn IFunction>>,
     schema: DataSchemaRef,
-    input: Arc<dyn IProcessor>
+    input: Arc<dyn IProcessor>,
 }
 
 impl AggregatorPartialTransform {
@@ -41,7 +41,7 @@ impl AggregatorPartialTransform {
         Ok(AggregatorPartialTransform {
             funcs,
             schema,
-            input: Arc::new(EmptyProcessor::create())
+            input: Arc::new(EmptyProcessor::create()),
         })
     }
 }
@@ -99,7 +99,7 @@ impl IProcessor for AggregatorPartialTransform {
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            vec![block]
+            vec![block],
         )))
     }
 }

--- a/fusequery/query/src/pipelines/transforms/transform_aggregator_partial_test.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_aggregator_partial_test.rs
@@ -30,7 +30,7 @@ async fn test_transform_partial_aggregator() -> anyhow::Result<()> {
     pipeline.add_simple_transform(|| {
         Ok(Box::new(AggregatorPartialTransform::try_create(
             aggr_partial.schema(),
-            aggr_exprs.to_vec()
+            aggr_exprs.to_vec(),
         )?))
     })?;
     pipeline.merge_processor()?;

--- a/fusequery/query/src/pipelines/transforms/transform_expression.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_expression.rs
@@ -36,7 +36,7 @@ pub struct ExpressionTransform {
     funcs: Vec<Box<dyn IFunction>>,
     // The final schema(Build by plan_builder.expression).
     schema: DataSchemaRef,
-    input: Arc<dyn IProcessor>
+    input: Arc<dyn IProcessor>,
 }
 
 impl ExpressionTransform {
@@ -59,7 +59,7 @@ impl ExpressionTransform {
         Ok(ExpressionTransform {
             funcs,
             schema,
-            input: Arc::new(EmptyProcessor::create())
+            input: Arc::new(EmptyProcessor::create()),
         })
     }
 }

--- a/fusequery/query/src/pipelines/transforms/transform_expression_test.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_expression_test.rs
@@ -23,14 +23,14 @@ async fn test_transform_expression() -> anyhow::Result<()> {
     if let PlanNode::Expression(plan) = PlanBuilder::create(test_source.number_schema_for_test()?)
         .expression(
             &[col("number"), col("number"), add(col("number"), lit(1u8))],
-            ""
+            "",
         )?
         .build()?
     {
         pipeline.add_simple_transform(|| {
             Ok(Box::new(ExpressionTransform::try_create(
                 plan.schema.clone(),
-                plan.exprs.clone()
+                plan.exprs.clone(),
             )?))
         })?;
     }
@@ -78,7 +78,7 @@ async fn test_transform_expression_error() -> anyhow::Result<()> {
     let result = PlanBuilder::create(test_source.number_schema_for_test()?).project(&[
         col("xnumber"),
         col("number"),
-        add(col("number"), lit(1u8))
+        add(col("number"), lit(1u8)),
     ]);
     let actual = format!("{}", result.err().unwrap());
     let expect = "Code: 1002, displayText = Invalid argument error: Unable to get field named \"xnumber\". Valid fields: [\"number\"].";

--- a/fusequery/query/src/pipelines/transforms/transform_filter.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_filter.rs
@@ -22,7 +22,7 @@ use crate::pipelines::processors::IProcessor;
 
 pub struct FilterTransform {
     func: Box<dyn IFunction>,
-    input: Arc<dyn IProcessor>
+    input: Arc<dyn IProcessor>,
 }
 
 impl FilterTransform {
@@ -37,7 +37,7 @@ impl FilterTransform {
 
         Ok(FilterTransform {
             func,
-            input: Arc::new(EmptyProcessor::create())
+            input: Arc::new(EmptyProcessor::create()),
         })
     }
 }

--- a/fusequery/query/src/pipelines/transforms/transform_filter_test.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_filter_test.rs
@@ -28,7 +28,7 @@ async fn test_transform_filter() -> anyhow::Result<()> {
         pipeline.add_simple_transform(|| {
             Ok(Box::new(FilterTransform::try_create(
                 plan.predicate.clone(),
-                false
+                false,
             )?))
         })?;
     }
@@ -77,7 +77,7 @@ async fn test_transform_filter_error() -> anyhow::Result<()> {
         pipeline.add_simple_transform(|| {
             Ok(Box::new(FilterTransform::try_create(
                 plan.predicate.clone(),
-                false
+                false,
             )?))
         })?;
     }

--- a/fusequery/query/src/pipelines/transforms/transform_groupby_final.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_groupby_final.rs
@@ -30,20 +30,20 @@ pub struct GroupByFinalTransform {
     aggr_exprs: Vec<ExpressionAction>,
     schema: DataSchemaRef,
     input: Arc<dyn IProcessor>,
-    groups: GroupFuncTable
+    groups: GroupFuncTable,
 }
 
 impl GroupByFinalTransform {
     pub fn create(
         schema: DataSchemaRef,
         aggr_exprs: Vec<ExpressionAction>,
-        _group_exprs: Vec<ExpressionAction>
+        _group_exprs: Vec<ExpressionAction>,
     ) -> Self {
         Self {
             aggr_exprs,
             schema,
             input: Arc::new(EmptyProcessor::create()),
-            groups: RwLock::new(HashMap::default())
+            groups: RwLock::new(HashMap::default()),
         }
     }
 }
@@ -150,7 +150,7 @@ impl IProcessor for GroupByFinalTransform {
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            blocks
+            blocks,
         )))
     }
 }

--- a/fusequery/query/src/pipelines/transforms/transform_groupby_final_test.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_groupby_final_test.rs
@@ -21,7 +21,7 @@ async fn test_transform_final_groupby() -> anyhow::Result<()> {
     let aggr_exprs = &[
         add(sum(col("number")), lit(2u64)),
         avg(col("number")),
-        modular(col("number"), lit(3u64))
+        modular(col("number"), lit(3u64)),
     ];
     let group_exprs = &[modular(col("number"), lit(3u64))];
     let aggr_partial = PlanBuilder::create(test_source.number_schema_for_test()?)
@@ -40,7 +40,7 @@ async fn test_transform_final_groupby() -> anyhow::Result<()> {
         Ok(Box::new(GroupByPartialTransform::create(
             aggr_partial.schema(),
             aggr_exprs.to_vec(),
-            group_exprs.to_vec()
+            group_exprs.to_vec(),
         )))
     })?;
     pipeline.merge_processor()?;
@@ -48,7 +48,7 @@ async fn test_transform_final_groupby() -> anyhow::Result<()> {
         Ok(Box::new(GroupByFinalTransform::create(
             aggr_final.schema(),
             aggr_exprs.to_vec(),
-            group_exprs.to_vec()
+            group_exprs.to_vec(),
         )))
     })?;
 

--- a/fusequery/query/src/pipelines/transforms/transform_groupby_partial.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_groupby_partial.rs
@@ -37,21 +37,21 @@ pub struct GroupByPartialTransform {
     group_exprs: Vec<ExpressionAction>,
     schema: DataSchemaRef,
     input: Arc<dyn IProcessor>,
-    groups: GroupFuncTable
+    groups: GroupFuncTable,
 }
 
 impl GroupByPartialTransform {
     pub fn create(
         schema: DataSchemaRef,
         aggr_exprs: Vec<ExpressionAction>,
-        group_exprs: Vec<ExpressionAction>
+        group_exprs: Vec<ExpressionAction>,
     ) -> Self {
         Self {
             aggr_exprs,
             group_exprs,
             schema,
             input: Arc::new(EmptyProcessor::create()),
-            groups: RwLock::new(HashMap::default())
+            groups: RwLock::new(HashMap::default()),
         }
     }
 }
@@ -188,7 +188,7 @@ impl IProcessor for GroupByPartialTransform {
             return Ok(Box::pin(DataBlockStream::create(
                 DataSchemaRefExt::create(vec![]),
                 None,
-                vec![]
+                vec![],
             )));
         }
 
@@ -233,7 +233,7 @@ impl IProcessor for GroupByPartialTransform {
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            vec![block]
+            vec![block],
         )))
     }
 }

--- a/fusequery/query/src/pipelines/transforms/transform_groupby_partial_test.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_groupby_partial_test.rs
@@ -36,7 +36,7 @@ async fn test_transform_partial_groupby() -> anyhow::Result<()> {
         Ok(Box::new(GroupByPartialTransform::create(
             aggr_partial.schema(),
             aggr_exprs.clone(),
-            group_exprs.clone()
+            group_exprs.clone(),
         )))
     })?;
     pipeline.merge_processor()?;

--- a/fusequery/query/src/pipelines/transforms/transform_limit.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_limit.rs
@@ -14,14 +14,14 @@ use crate::pipelines::processors::IProcessor;
 
 pub struct LimitTransform {
     limit: usize,
-    input: Arc<dyn IProcessor>
+    input: Arc<dyn IProcessor>,
 }
 
 impl LimitTransform {
     pub fn try_create(limit: usize) -> Result<Self> {
         Ok(LimitTransform {
             limit,
-            input: Arc::new(EmptyProcessor::create())
+            input: Arc::new(EmptyProcessor::create()),
         })
     }
 }
@@ -48,7 +48,7 @@ impl IProcessor for LimitTransform {
     async fn execute(&self) -> Result<SendableDataBlockStream> {
         Ok(Box::pin(LimitStream::try_create(
             self.input.execute().await?,
-            self.limit
+            self.limit,
         )?))
     }
 }

--- a/fusequery/query/src/pipelines/transforms/transform_projection.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_projection.rs
@@ -16,14 +16,14 @@ use crate::pipelines::processors::IProcessor;
 
 pub struct ProjectionTransform {
     schema: DataSchemaRef,
-    input: Arc<dyn IProcessor>
+    input: Arc<dyn IProcessor>,
 }
 
 impl ProjectionTransform {
     pub fn try_create(schema: DataSchemaRef) -> Result<Self> {
         Ok(ProjectionTransform {
             schema,
-            input: Arc::new(EmptyProcessor::create())
+            input: Arc::new(EmptyProcessor::create()),
         })
     }
 }

--- a/fusequery/query/src/pipelines/transforms/transform_projection_test.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_projection_test.rs
@@ -27,12 +27,12 @@ async fn test_transform_projection() -> anyhow::Result<()> {
         pipeline.add_simple_transform(|| {
             Ok(Box::new(ExpressionTransform::try_create(
                 plan.schema.clone(),
-                plan.expr.clone()
+                plan.expr.clone(),
             )?))
         })?;
         pipeline.add_simple_transform(|| {
             Ok(Box::new(ProjectionTransform::try_create(
-                plan.schema.clone()
+                plan.schema.clone(),
             )?))
         })?;
     }

--- a/fusequery/query/src/pipelines/transforms/transform_remote.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_remote.rs
@@ -20,7 +20,7 @@ pub struct RemoteTransform {
     remote_addr: String,
     pub ctx: FuseQueryContextRef,
     pub plan: PlanNode,
-    input: Arc<dyn IProcessor>
+    input: Arc<dyn IProcessor>,
 }
 
 impl RemoteTransform {
@@ -28,14 +28,14 @@ impl RemoteTransform {
         ctx: FuseQueryContextRef,
         job_id: String,
         remote_addr: String,
-        plan: PlanNode
+        plan: PlanNode,
     ) -> Result<Self> {
         Ok(Self {
             job_id,
             remote_addr,
             ctx,
             plan,
-            input: Arc::new(EmptyProcessor::create())
+            input: Arc::new(EmptyProcessor::create()),
         })
     }
 }
@@ -64,7 +64,7 @@ impl IProcessor for RemoteTransform {
             ctx: FuseQueryContextRef,
             remote_addr: &str,
             job_id: &str,
-            plan: &PlanNode
+            plan: &PlanNode,
         ) -> anyhow::Result<SendableDataBlockStream> {
             let mut client = QueryClient::try_create(remote_addr.to_string().clone()).await?;
             client.set_timeout(ctx.get_flight_client_timeout()?);
@@ -78,10 +78,10 @@ impl IProcessor for RemoteTransform {
                 self.ctx.clone(),
                 &self.remote_addr,
                 &self.job_id,
-                &self.plan
+                &self.plan,
             )
             .await
-            .map_err(ErrorCodes::from)?
+            .map_err(ErrorCodes::from)?,
         ))
     }
 }

--- a/fusequery/query/src/pipelines/transforms/transform_remote_test.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_remote_test.rs
@@ -16,7 +16,7 @@ async fn test_transform_remote_with_local() -> anyhow::Result<()> {
     let remote_addr = crate::tests::try_start_service(1).await?[0].clone();
 
     let plan = PlanBuilder::from(&PlanNode::ReadSource(
-        test_source.number_read_source_plan_for_test(100)?
+        test_source.number_read_source_plan_for_test(100)?,
     ))
     .filter(col("number").eq(lit(99)))?
     .build()?;

--- a/fusequery/query/src/pipelines/transforms/transform_sort_merge.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_sort_merge.rs
@@ -22,20 +22,20 @@ pub struct SortMergeTransform {
     schema: DataSchemaRef,
     exprs: Vec<ExpressionAction>,
     limit: Option<usize>,
-    input: Arc<dyn IProcessor>
+    input: Arc<dyn IProcessor>,
 }
 
 impl SortMergeTransform {
     pub fn try_create(
         schema: DataSchemaRef,
         exprs: Vec<ExpressionAction>,
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> Result<Self> {
         Ok(SortMergeTransform {
             schema,
             exprs,
             limit,
-            input: Arc::new(EmptyProcessor::create())
+            input: Arc::new(EmptyProcessor::create()),
         })
     }
 }
@@ -73,14 +73,14 @@ impl IProcessor for SortMergeTransform {
             _ => vec![DataBlock::merge_sort_blocks(
                 &blocks,
                 &sort_columns_descriptions,
-                self.limit
-            )?]
+                self.limit,
+            )?],
         };
 
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,
-            results
+            results,
         )))
     }
 }

--- a/fusequery/query/src/pipelines/transforms/transform_sort_partial.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_sort_partial.rs
@@ -21,20 +21,20 @@ pub struct SortPartialTransform {
     schema: DataSchemaRef,
     exprs: Vec<ExpressionAction>,
     limit: Option<usize>,
-    input: Arc<dyn IProcessor>
+    input: Arc<dyn IProcessor>,
 }
 
 impl SortPartialTransform {
     pub fn try_create(
         schema: DataSchemaRef,
         exprs: Vec<ExpressionAction>,
-        limit: Option<usize>
+        limit: Option<usize>,
     ) -> Result<Self> {
         Ok(SortPartialTransform {
             schema,
             exprs,
             limit,
-            input: Arc::new(EmptyProcessor::create())
+            input: Arc::new(EmptyProcessor::create()),
         })
     }
 }
@@ -62,14 +62,14 @@ impl IProcessor for SortPartialTransform {
         Ok(Box::pin(SortStream::try_create(
             self.input.execute().await?,
             get_sort_descriptions(&self.schema, &self.exprs)?,
-            self.limit
+            self.limit,
         )?))
     }
 }
 
 pub fn get_sort_descriptions(
     schema: &DataSchemaRef,
-    exprs: &[ExpressionAction]
+    exprs: &[ExpressionAction],
 ) -> Result<Vec<SortColumnDescription>> {
     let mut sort_columns_descriptions = vec![];
     for x in exprs {
@@ -77,13 +77,13 @@ pub fn get_sort_descriptions(
             ExpressionAction::Sort {
                 ref expr,
                 asc,
-                nulls_first
+                nulls_first,
             } => {
                 let column_name = expr.to_data_field(schema)?.name().clone();
                 sort_columns_descriptions.push(SortColumnDescription {
                     column_name,
                     asc,
-                    nulls_first
+                    nulls_first,
                 });
             }
             _ => {

--- a/fusequery/query/src/pipelines/transforms/transform_sort_test.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_sort_test.rs
@@ -31,7 +31,7 @@ async fn test_transform_sort() -> anyhow::Result<()> {
         Ok(Box::new(SortPartialTransform::try_create(
             plan.schema().clone(),
             sort_expression.to_vec(),
-            None
+            None,
         )?))
     })?;
 
@@ -39,7 +39,7 @@ async fn test_transform_sort() -> anyhow::Result<()> {
         Ok(Box::new(SortMergeTransform::try_create(
             plan.schema().clone(),
             sort_expression.to_vec(),
-            None
+            None,
         )?))
     })?;
 
@@ -49,7 +49,7 @@ async fn test_transform_sort() -> anyhow::Result<()> {
             Ok(Box::new(SortMergeTransform::try_create(
                 plan.schema().clone(),
                 sort_expression.to_vec(),
-                None
+                None,
             )?))
         })?;
     }

--- a/fusequery/query/src/pipelines/transforms/transform_source.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_source.rs
@@ -16,7 +16,7 @@ use crate::sessions::FuseQueryContextRef;
 pub struct SourceTransform {
     ctx: FuseQueryContextRef,
     db: String,
-    table: String
+    table: String,
 }
 
 impl SourceTransform {
@@ -24,7 +24,7 @@ impl SourceTransform {
         Ok(SourceTransform {
             ctx,
             db: db.to_string(),
-            table: table.to_string()
+            table: table.to_string(),
         })
     }
 }
@@ -37,7 +37,7 @@ impl IProcessor for SourceTransform {
 
     fn connect_to(&mut self, _: Arc<dyn IProcessor>) -> Result<()> {
         Result::Err(ErrorCodes::LogicalError(
-            "Cannot call SourceTransform connect_to"
+            "Cannot call SourceTransform connect_to",
         ))
     }
 

--- a/fusequery/query/src/planners/plan_scheduler.rs
+++ b/fusequery/query/src/planners/plan_scheduler.rs
@@ -16,7 +16,7 @@ pub struct PlanScheduler;
 
 /// ReadSourceRewriter will replace all ReadDataSourcePlan in a plan tree with given `new_source_plan`
 struct ReadSourceRewriter {
-    new_source_plan: ReadDataSourcePlan
+    new_source_plan: ReadDataSourcePlan,
 }
 
 impl<'plan> PlanRewriter<'plan> for ReadSourceRewriter {
@@ -35,7 +35,7 @@ impl PlanScheduler {
     /// Schedule the plan to Local or Remote mode.
     pub fn reschedule(
         ctx: FuseQueryContextRef,
-        plan: &PlanNode
+        plan: &PlanNode,
     ) -> Result<Vec<(String, PlanNode)>> {
         let mut results = vec![];
         let max_threads = ctx.get_max_threads()? as usize;
@@ -50,7 +50,7 @@ impl PlanScheduler {
                         source_plan = node.clone();
                         Ok(false)
                     }
-                    _ => Ok(true)
+                    _ => Ok(true),
                 }
             })?;
         }
@@ -108,7 +108,7 @@ impl PlanScheduler {
                     let left = total_chunks - num_chunks_so_far;
                     chunk_size = min(
                         (p_usize * total_chunks - remainder) / priority_sum + 1,
-                        left
+                        left,
                     );
 
                     info!(
@@ -121,7 +121,7 @@ impl PlanScheduler {
                 }
                 new_source_plan.partitions = vec![];
                 new_source_plan.partitions.extend_from_slice(
-                    &all_parts[num_chunks_so_far..num_chunks_so_far + chunk_size]
+                    &all_parts[num_chunks_so_far..num_chunks_so_far + chunk_size],
                 );
                 num_chunks_so_far += chunk_size;
 

--- a/fusequery/query/src/servers/clickhouse/clickhouse_handler.rs
+++ b/fusequery/query/src/servers/clickhouse/clickhouse_handler.rs
@@ -31,7 +31,7 @@ use crate::sessions::SessionManagerRef;
 use crate::sql::PlanParser;
 
 struct Session {
-    ctx: FuseQueryContextRef
+    ctx: FuseQueryContextRef,
 }
 
 impl Session {
@@ -45,13 +45,13 @@ pub fn to_clickhouse_err(res: ErrorCodes) -> clickhouse_srv::errors::Error {
         code: res.code() as u32,
         name: "DB:Exception".to_string(),
         message: res.message(),
-        stack_trace: res.backtrace()
+        stack_trace: res.backtrace(),
     })
 }
 
 enum BlockItem {
     Block(Result<ClickHouseBlock>),
-    ProgressTicker
+    ProgressTicker,
 }
 
 #[async_trait::async_trait]
@@ -59,7 +59,7 @@ impl ClickHouseSession for Session {
     async fn execute_query(
         &self,
         ctx: &mut CHContext,
-        connection: &mut Connection
+        connection: &mut Connection,
     ) -> clickhouse_srv::errors::Result<()> {
         self.ctx.reset().map_err(to_clickhouse_err)?;
         let start = Instant::now();
@@ -161,7 +161,7 @@ impl ClickHouseSession for Session {
         clickhouse_srv::types::Progress {
             rows: values.read_rows as u64,
             bytes: values.read_bytes as u64,
-            total_rows: 0
+            total_rows: 0,
         }
     }
 }
@@ -169,7 +169,7 @@ impl ClickHouseSession for Session {
 pub struct ClickHouseHandler {
     conf: Config,
     cluster: ClusterRef,
-    session_manager: SessionManagerRef
+    session_manager: SessionManagerRef,
 }
 
 impl ClickHouseHandler {
@@ -177,7 +177,7 @@ impl ClickHouseHandler {
         Self {
             conf,
             cluster,
-            session_manager
+            session_manager,
         }
     }
 

--- a/fusequery/query/src/servers/clickhouse/clickhouse_stream.rs
+++ b/fusequery/query/src/servers/clickhouse/clickhouse_stream.rs
@@ -19,7 +19,7 @@ use futures::stream::Stream;
 use futures::StreamExt;
 
 pub struct ClickHouseStream {
-    input: SendableDataBlockStream
+    input: SendableDataBlockStream,
 }
 
 impl ClickHouseStream {
@@ -118,13 +118,15 @@ impl Stream for ClickHouseStream {
         self.input.poll_next_unpin(ctx).map(|x| match x {
             Some(Ok(v)) => Some(self.convert_block(v)),
             // Some(Err(e)) => Some(Err(e)),
-            _other => None
+            _other => None,
         })
     }
 }
 
 fn build_primitive_column<T>(values: &DataArrayRef) -> Result<Vec<Option<T::Native>>>
-where T: ArrowPrimitiveType {
+where
+    T: ArrowPrimitiveType,
+{
     let values = as_primitive_array::<T>(values);
 
     Ok(match values.null_count() {
@@ -140,7 +142,7 @@ where T: ArrowPrimitiveType {
                     Some(values.value(i))
                 }
             })
-            .collect::<Vec<Option<T::Native>>>()
+            .collect::<Vec<Option<T::Native>>>(),
     })
 }
 
@@ -160,7 +162,7 @@ fn build_boolean_column(values: &DataArrayRef) -> Result<Vec<Option<u8>>> {
                     Some(values.value(i) as u8)
                 }
             })
-            .collect::<Vec<Option<u8>>>()
+            .collect::<Vec<Option<u8>>>(),
     })
 }
 
@@ -179,6 +181,6 @@ fn build_string_column(values: &DataArrayRef) -> Result<Vec<Option<&str>>> {
                     Some(values.value(i))
                 }
             })
-            .collect::<Vec<Option<&str>>>()
+            .collect::<Vec<Option<&str>>>(),
     })
 }

--- a/fusequery/query/src/servers/mysql/endpoints/endpoint_on_init.rs
+++ b/fusequery/query/src/servers/mysql/endpoints/endpoint_on_init.rs
@@ -32,7 +32,7 @@ pub fn done<W: std::io::Write>(writer: InitWriter<'_, W>) -> impl FnOnce(Input) 
     move |res: Input| -> Output {
         match res {
             Err(error) => MySQLOnInitEndpoint::err(error, writer),
-            Ok(value) => MySQLOnInitEndpoint::ok(value, writer)
+            Ok(value) => MySQLOnInitEndpoint::ok(value, writer),
         }
     }
 }

--- a/fusequery/query/src/servers/mysql/endpoints/endpoint_on_query.rs
+++ b/fusequery/query/src/servers/mysql/endpoints/endpoint_on_query.rs
@@ -47,7 +47,7 @@ impl<'a, T: std::io::Write> IMySQLEndpoint<QueryResultWriter<'a, T>> for MySQLOn
                 _ => Err(ErrorCodes::UnImplement(format!(
                     "Unsupported column type:{:?}",
                     field.data_type()
-                )))
+                ))),
             }
         }
 
@@ -56,7 +56,7 @@ impl<'a, T: std::io::Write> IMySQLEndpoint<QueryResultWriter<'a, T>> for MySQLOn
                 table: "".to_string(),
                 column: field.name().to_string(),
                 coltype: column_type,
-                colflags: ColumnFlags::empty()
+                colflags: ColumnFlags::empty(),
             })
         }
 
@@ -101,7 +101,7 @@ type Output = std::io::Result<()>;
 
 // TODO: Maybe can use generic to abstract all MySQLEndpoints done function
 pub fn done<W: std::io::Write>(
-    writer: QueryResultWriter<'_, W>
+    writer: QueryResultWriter<'_, W>,
 ) -> impl FnOnce(Input) -> Output + '_ {
     move |res: Input| -> Output {
         match res {

--- a/fusequery/query/src/servers/mysql/mysql_handler.rs
+++ b/fusequery/query/src/servers/mysql/mysql_handler.rs
@@ -27,7 +27,7 @@ use crate::sessions::SessionManagerRef;
 use crate::sql::PlanParser;
 
 struct Session {
-    ctx: FuseQueryContextRef
+    ctx: FuseQueryContextRef,
 }
 
 impl Session {
@@ -42,7 +42,7 @@ impl<W: io::Write> MysqlShim<W> for Session {
     fn on_prepare(&mut self, _: &str, writer: StatementMetaWriter<W>) -> std::io::Result<()> {
         writer.error(
             ErrorKind::ER_UNKNOWN_ERROR,
-            "Prepare is not support in DataFuse.".as_bytes()
+            "Prepare is not support in DataFuse.".as_bytes(),
         )
     }
 
@@ -50,11 +50,11 @@ impl<W: io::Write> MysqlShim<W> for Session {
         &mut self,
         _: u32,
         _: ParamParser,
-        writer: QueryResultWriter<W>
+        writer: QueryResultWriter<W>,
     ) -> std::io::Result<()> {
         writer.error(
             ErrorKind::ER_UNKNOWN_ERROR,
-            "Execute is not support in DataFuse.".as_bytes()
+            "Execute is not support in DataFuse.".as_bytes(),
         )
     }
 
@@ -80,7 +80,7 @@ impl<W: io::Write> MysqlShim<W> for Session {
             runtime.block_on(
                 interpreter
                     .execute()
-                    .and_then(|stream| stream.collect::<Result<Vec<DataBlock>>>())
+                    .and_then(|stream| stream.collect::<Result<Vec<DataBlock>>>()),
             )
         }
 
@@ -117,7 +117,7 @@ impl<W: io::Write> MysqlShim<W> for Session {
 pub struct MySQLHandler {
     conf: Config,
     cluster: ClusterRef,
-    session_manager: SessionManagerRef
+    session_manager: SessionManagerRef,
 }
 
 impl MySQLHandler {
@@ -125,7 +125,7 @@ impl MySQLHandler {
         MySQLHandler {
             conf,
             cluster,
-            session_manager
+            session_manager,
         }
     }
 

--- a/fusequery/query/src/sessions/context.rs
+++ b/fusequery/query/src/sessions/context.rs
@@ -38,7 +38,7 @@ pub struct FuseQueryContext {
     partition_queue: Arc<RwLock<VecDeque<Partition>>>,
     current_database: Arc<RwLock<String>>,
     progress: Arc<Progress>,
-    runtime: Arc<RwLock<Runtime>>
+    runtime: Arc<RwLock<Runtime>>,
 }
 
 pub type FuseQueryContextRef = Arc<FuseQueryContext>;
@@ -56,7 +56,7 @@ impl FuseQueryContext {
             partition_queue: Arc::new(RwLock::new(VecDeque::new())),
             current_database: Arc::new(RwLock::new(String::from("default"))),
             progress: Arc::new(Progress::create()),
-            runtime: Arc::new(RwLock::new(Runtime::with_worker_threads(cpus)?))
+            runtime: Arc::new(RwLock::new(Runtime::with_worker_threads(cpus)?)),
         };
         // Default settings.
         ctx.initial_settings()?;
@@ -89,7 +89,7 @@ impl FuseQueryContext {
     pub fn execute_task<T>(&self, task: T) -> JoinHandle<T::Output>
     where
         T: Future + Send + 'static,
-        T::Output: Send + 'static
+        T::Output: Send + 'static,
     {
         self.runtime.read().spawn(task)
     }
@@ -144,7 +144,7 @@ impl FuseQueryContext {
         let statistics = self.statistics.read();
         Ok(Statistics {
             read_rows: statistics.read_rows,
-            read_bytes: statistics.read_bytes
+            read_bytes: statistics.read_bytes,
         })
     }
 

--- a/fusequery/query/src/sessions/sessions.rs
+++ b/fusequery/query/src/sessions/sessions.rs
@@ -15,7 +15,7 @@ use crate::sessions::FuseQueryContext;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct SessionManager {
-    sessions: RwLock<HashMap<String, FuseQueryContextRef>>
+    sessions: RwLock<HashMap<String, FuseQueryContextRef>>,
 }
 
 pub type SessionManagerRef = Arc<SessionManager>;
@@ -23,7 +23,7 @@ pub type SessionManagerRef = Arc<SessionManager>;
 impl SessionManager {
     pub fn create() -> SessionManagerRef {
         Arc::new(SessionManager {
-            sessions: RwLock::new(HashMap::new())
+            sessions: RwLock::new(HashMap::new()),
         })
     }
 

--- a/fusequery/query/src/sessions/settings.rs
+++ b/fusequery/query/src/sessions/settings.rs
@@ -13,13 +13,13 @@ use common_infallible::RwLock;
 #[derive(Debug, Clone)]
 pub struct Settings {
     // DataValue is of DataValue::Struct([name, value, default_value, description])
-    settings: Arc<RwLock<HashMap<&'static str, DataValue>>>
+    settings: Arc<RwLock<HashMap<&'static str, DataValue>>>,
 }
 
 impl Settings {
     pub fn create() -> Self {
         Settings {
-            settings: Arc::new(RwLock::new(HashMap::default()))
+            settings: Arc::new(RwLock::new(HashMap::default())),
         }
     }
 

--- a/fusequery/query/src/sql/plan_parser.rs
+++ b/fusequery/query/src/sql/plan_parser.rs
@@ -42,7 +42,7 @@ use crate::sql::DfStatement;
 use crate::sql::SQLCommon;
 
 pub struct PlanParser {
-    ctx: FuseQueryContextRef
+    ctx: FuseQueryContextRef,
 }
 
 impl PlanParser {
@@ -80,9 +80,9 @@ impl PlanParser {
                     "SELECT name FROM system.tables where database = '{}' ORDER BY database, name",
                     self.ctx.get_current_database()
                 )
-                .as_str()
+                .as_str(),
             ),
-            DfStatement::ShowSettings(_) => self.build_from_sql("SELECT name FROM system.settings")
+            DfStatement::ShowSettings(_) => self.build_from_sql("SELECT name FROM system.settings"),
         }
     }
 
@@ -96,7 +96,7 @@ impl PlanParser {
             _ => Result::Err(ErrorCodes::SyntaxException(format!(
                 "Unsupported statement {:?}",
                 statement
-            )))
+            ))),
         }
     }
 
@@ -105,7 +105,7 @@ impl PlanParser {
         let plan = self.sql_statement_to_plan(&explain.statement)?;
         Ok(PlanNode::Explain(ExplainPlan {
             typ: explain.typ,
-            input: Arc::new(plan)
+            input: Arc::new(plan),
         }))
     }
 
@@ -125,7 +125,7 @@ impl PlanParser {
             if_not_exists: create.if_not_exists,
             db: name,
             engine: create.engine,
-            options
+            options,
         }))
     }
 
@@ -138,7 +138,7 @@ impl PlanParser {
 
         Ok(PlanNode::DropDatabase(DropDatabasePlan {
             if_exists: drop.if_exists,
-            db: name
+            db: name,
         }))
     }
 
@@ -178,7 +178,7 @@ impl PlanParser {
             [("Key".to_string(), "Value".to_string())]
                 .iter()
                 .cloned()
-                .collect()
+                .collect(),
         ));
         Ok(PlanNode::CreateTable(CreateTablePlan {
             if_not_exists: create.if_not_exists,
@@ -186,7 +186,7 @@ impl PlanParser {
             table,
             schema,
             engine: create.engine,
-            options
+            options,
         }))
     }
 
@@ -204,7 +204,7 @@ impl PlanParser {
         Ok(PlanNode::DropTable(DropTablePlan {
             if_exists: drop.if_exists,
             db,
-            table
+            table,
         }))
     }
 
@@ -217,7 +217,7 @@ impl PlanParser {
             _ => Result::Err(ErrorCodes::UnImplement(format!(
                 "Query {} not implemented yet",
                 query.body
-            )))
+            ))),
         }
     }
 
@@ -226,7 +226,7 @@ impl PlanParser {
         &self,
         select: &sqlparser::ast::Select,
         limit: &Option<sqlparser::ast::Expr>,
-        order_by: &[OrderByExpr]
+        order_by: &[OrderByExpr],
     ) -> Result<PlanNode> {
         // From.
         let plan = self.plan_tables_with_joins(&select.from)?;
@@ -248,7 +248,7 @@ impl PlanParser {
                 Ok(ExpressionAction::Sort {
                     expr: Box::new(self.sql_to_rex(&e.expr, &plan.schema())?),
                     asc: e.asc.unwrap_or(true),
-                    nulls_first: e.nulls_first.unwrap_or(true)
+                    nulls_first: e.nulls_first.unwrap_or(true),
                 })
             })
             .collect::<Result<Vec<ExpressionAction>>>()?;
@@ -280,7 +280,7 @@ impl PlanParser {
         let plan = self.limit(&plan, limit)?;
 
         Ok(PlanNode::Select(SelectPlan {
-            input: Arc::new(plan)
+            input: Arc::new(plan),
         }))
     }
 
@@ -288,21 +288,21 @@ impl PlanParser {
     fn sql_select_to_rex(
         &self,
         sql: &sqlparser::ast::SelectItem,
-        schema: &DataSchema
+        schema: &DataSchema,
     ) -> Result<ExpressionAction> {
         match sql {
             sqlparser::ast::SelectItem::UnnamedExpr(expr) => self.sql_to_rex(expr, schema),
             sqlparser::ast::SelectItem::ExprWithAlias { expr, alias } => {
                 Ok(ExpressionAction::Alias(
                     alias.value.clone(),
-                    Box::new(self.sql_to_rex(&expr, schema)?)
+                    Box::new(self.sql_to_rex(&expr, schema)?),
                 ))
             }
             sqlparser::ast::SelectItem::Wildcard => Ok(ExpressionAction::Wildcard),
             _ => Result::Err(ErrorCodes::UnImplement(format!(
                 "SelectItem: {:?} are not supported",
                 sql
-            )))
+            ))),
         }
     }
 
@@ -310,7 +310,7 @@ impl PlanParser {
         match from.len() {
             0 => self.plan_with_dummy_source(),
             1 => self.plan_table_with_joins(&from[0]),
-            _ => Result::Err(ErrorCodes::SyntaxException("Cannot support JOIN clause"))
+            _ => Result::Err(ErrorCodes::SyntaxException("Cannot support JOIN clause")),
         }
     }
 
@@ -329,7 +329,7 @@ impl PlanParser {
                     PlanNode::Scan(ref dummy_scan_plan) => table
                         .read_plan(self.ctx.clone(), dummy_scan_plan)
                         .map(PlanNode::ReadSource),
-                    _unreachable_plan => panic!("Logical error: cannot downcast to scan plan")
+                    _unreachable_plan => panic!("Logical error: cannot downcast to scan plan"),
                 })
         })
     }
@@ -356,7 +356,7 @@ impl PlanParser {
                 if !args.is_empty() {
                     if name.0.len() >= 2 {
                         return Result::Err(ErrorCodes::BadArguments(
-                            "Currently table can't have arguments"
+                            "Currently table can't have arguments",
                         ));
                     }
 
@@ -386,7 +386,7 @@ impl PlanParser {
                             schema.as_ref(),
                             None,
                             table_args,
-                            None
+                            None,
                         )
                         .and_then(|builder| builder.build())
                     })
@@ -396,7 +396,7 @@ impl PlanParser {
                     PlanNode::Scan(ref scan) => table
                         .read_plan(self.ctx.clone(), scan)
                         .map(PlanNode::ReadSource),
-                    _unreachable_plan => panic!("Logical error: Cannot downcast to scan plan")
+                    _unreachable_plan => panic!("Logical error: Cannot downcast to scan plan"),
                 })
             }
             Derived { subquery, .. } => self.query_to_plan(subquery),
@@ -411,7 +411,7 @@ impl PlanParser {
     pub fn sql_to_rex(
         &self,
         expr: &sqlparser::ast::Expr,
-        schema: &DataSchema
+        schema: &DataSchema,
     ) -> Result<ExpressionAction> {
         fn value_to_rex(value: &sqlparser::ast::Value) -> Result<ExpressionAction> {
             match value {
@@ -419,25 +419,25 @@ impl PlanParser {
                     DataValue::try_from_literal(n).map(ExpressionAction::Literal)
                 }
                 sqlparser::ast::Value::SingleQuotedString(ref value) => Ok(
-                    ExpressionAction::Literal(DataValue::Utf8(Some(value.clone())))
+                    ExpressionAction::Literal(DataValue::Utf8(Some(value.clone()))),
                 ),
                 sqlparser::ast::Value::Interval {
                     value,
                     leading_field,
                     leading_precision,
                     last_field,
-                    fractional_seconds_precision
+                    fractional_seconds_precision,
                 } => SQLCommon::make_sql_interval_to_literal(
                     value,
                     leading_field,
                     leading_precision,
                     last_field,
-                    fractional_seconds_precision
+                    fractional_seconds_precision,
                 ),
                 other => Result::Err(ErrorCodes::SyntaxException(format!(
                     "Unsupported value expression: {}, type: {:?}",
                     value, other
-                )))
+                ))),
             }
         }
 
@@ -450,7 +450,7 @@ impl PlanParser {
                 Ok(ExpressionAction::BinaryExpression {
                     op: format!("{}", op),
                     left: Box::new(self.sql_to_rex(left, schema)?),
-                    right: Box::new(self.sql_to_rex(right, schema)?)
+                    right: Box::new(self.sql_to_rex(right, schema)?),
                 })
             }
             sqlparser::ast::Expr::Nested(e) => self.sql_to_rex(e, schema),
@@ -461,7 +461,7 @@ impl PlanParser {
                 // common::functions::udf::database arg is ctx.get_default()
                 let ctx_args = ContextFunction::build_args_from_ctx(
                     e.name.to_string().as_str(),
-                    self.ctx.clone()
+                    self.ctx.clone(),
                 )?;
                 if !ctx_args.is_empty() {
                     args.extend_from_slice(ctx_args.as_slice());
@@ -481,16 +481,16 @@ impl PlanParser {
 
                 Ok(ExpressionAction::Function {
                     op: e.name.to_string(),
-                    args
+                    args,
                 })
             }
             sqlparser::ast::Expr::Wildcard => Ok(ExpressionAction::Wildcard),
             sqlparser::ast::Expr::TypedString { data_type, value } => {
                 SQLCommon::make_data_type(data_type).map(|data_type| ExpressionAction::Cast {
                     expr: Box::new(ExpressionAction::Literal(DataValue::Utf8(Some(
-                        value.clone()
+                        value.clone(),
                     )))),
-                    data_type
+                    data_type,
                 })
             }
             sqlparser::ast::Expr::Cast { expr, data_type } => self
@@ -503,7 +503,7 @@ impl PlanParser {
             sqlparser::ast::Expr::Substring {
                 expr,
                 substring_from,
-                substring_for
+                substring_for,
             } => {
                 let mut args = Vec::with_capacity(3);
                 args.push(self.sql_to_rex(expr, schema)?);
@@ -521,27 +521,27 @@ impl PlanParser {
 
                 Ok(ExpressionAction::Function {
                     op: "substring".to_string(),
-                    args
+                    args,
                 })
             }
             other => Result::Err(ErrorCodes::SyntaxException(format!(
                 "Unsupported expression: {}, type: {:?}",
                 expr, other
-            )))
+            ))),
         }
     }
 
     pub fn set_variable_to_plan(
         &self,
         variable: &sqlparser::ast::Ident,
-        values: &[sqlparser::ast::SetVariableValue]
+        values: &[sqlparser::ast::SetVariableValue],
     ) -> Result<PlanNode> {
         let mut vars = vec![];
         for value in values {
             let variable = variable.value.clone();
             let value = match value {
                 sqlparser::ast::SetVariableValue::Ident(v) => v.value.clone(),
-                sqlparser::ast::SetVariableValue::Literal(v) => v.to_string()
+                sqlparser::ast::SetVariableValue::Literal(v) => v.to_string(),
             };
             vars.push(VarValue { variable, value });
         }
@@ -552,7 +552,7 @@ impl PlanParser {
     fn filter(
         &self,
         plan: &PlanNode,
-        predicate: &Option<sqlparser::ast::Expr>
+        predicate: &Option<sqlparser::ast::Expr>,
     ) -> Result<PlanNode> {
         match *predicate {
             Some(ref predicate_expr) => {
@@ -563,7 +563,7 @@ impl PlanParser {
                             .and_then(|builder| builder.build())
                     })
             }
-            _ => Ok(plan.clone())
+            _ => Ok(plan.clone()),
         }
     }
 
@@ -571,7 +571,7 @@ impl PlanParser {
     fn having(
         &self,
         plan: &PlanNode,
-        predicate: &Option<sqlparser::ast::Expr>
+        predicate: &Option<sqlparser::ast::Expr>,
     ) -> Result<PlanNode> {
         match *predicate {
             Some(ref predicate_expr) => {
@@ -582,7 +582,7 @@ impl PlanParser {
                             .and_then(|builder| builder.build())
                     })
             }
-            _ => Ok(plan.clone())
+            _ => Ok(plan.clone()),
         }
     }
 
@@ -598,7 +598,7 @@ impl PlanParser {
         &self,
         input: &PlanNode,
         aggr_expr: &[ExpressionAction],
-        group_by: &[sqlparser::ast::Expr]
+        group_by: &[sqlparser::ast::Expr],
     ) -> Result<PlanNode> {
         let group_expr = group_by
             .iter()
@@ -629,7 +629,7 @@ impl PlanParser {
                 Ok(ExpressionAction::Sort {
                     expr: Box::new(self.sql_to_rex(&e.expr, &input.schema())?),
                     asc: e.asc.unwrap_or(true),
-                    nulls_first: e.nulls_first.unwrap_or(true)
+                    nulls_first: e.nulls_first.unwrap_or(true),
                 })
             })
             .collect::<Result<Vec<ExpressionAction>>>()?;
@@ -648,15 +648,15 @@ impl PlanParser {
                     .and_then(|limit_expr| match limit_expr {
                         ExpressionAction::Literal(DataValue::UInt64(Some(n))) => Ok(n as usize),
                         _ => Err(ErrorCodes::SyntaxException(
-                            "Unexpected expression for LIMIT clause"
-                        ))
+                            "Unexpected expression for LIMIT clause",
+                        )),
                     })?;
 
                 PlanBuilder::from(&input)
                     .limit(n)
                     .and_then(|builder| builder.build())
             }
-            _ => Ok(input.clone())
+            _ => Ok(input.clone()),
         }
     }
 
@@ -665,7 +665,7 @@ impl PlanParser {
         &self,
         input: &PlanNode,
         exprs: &[ExpressionAction],
-        desc: &str
+        desc: &str,
     ) -> Result<PlanNode> {
         if exprs.is_empty() {
             return Ok(input.clone());

--- a/fusequery/query/src/sql/plan_parser_test.rs
+++ b/fusequery/query/src/sql/plan_parser_test.rs
@@ -12,7 +12,7 @@ fn test_plan_parser() -> anyhow::Result<()> {
         name: &'static str,
         sql: &'static str,
         expect: &'static str,
-        error: &'static str
+        error: &'static str,
     }
 
     let tests = vec![

--- a/fusequery/query/src/sql/sql_common.rs
+++ b/fusequery/query/src/sql/sql_common.rs
@@ -36,7 +36,7 @@ impl SQLCommon {
             _ => Result::Err(ErrorCodes::IllegalDataType(format!(
                 "The SQL data type {:?} is not implemented",
                 sql_type
-            )))
+            ))),
         }
     }
 
@@ -47,7 +47,7 @@ impl SQLCommon {
         leading_field: &Option<DateTimeField>,
         leading_precision: &Option<u64>,
         last_field: &Option<DateTimeField>,
-        fractional_seconds_precision: &Option<u64>
+        fractional_seconds_precision: &Option<u64>,
     ) -> Result<ExpressionAction> {
         if leading_field.is_some() {
             return Result::Err(ErrorCodes::SyntaxException(format!(
@@ -152,7 +152,7 @@ impl SQLCommon {
 
             let (diff_month, diff_days, diff_millis) = calculate_from_part(
                 interval_period_str.unwrap(),
-                parts.next().unwrap_or("second")
+                parts.next().unwrap_or("second"),
             )?;
 
             result_month += diff_month as i64;
@@ -200,13 +200,13 @@ impl SQLCommon {
 
         if result_month != 0 {
             return Ok(ExpressionAction::Literal(DataValue::IntervalYearMonth(
-                Some(result_month as i32)
+                Some(result_month as i32),
             )));
         }
 
         let result: i64 = (result_days << 32) | result_millis;
         Ok(ExpressionAction::Literal(DataValue::IntervalDayTime(Some(
-            result
+            result,
         ))))
     }
 }

--- a/fusequery/query/src/sql/sql_parser_test.rs
+++ b/fusequery/query/src/sql/sql_parser_test.rs
@@ -50,11 +50,11 @@ mod tests {
         ColumnDef {
             name: Ident {
                 value: name.into(),
-                quote_style: None
+                quote_style: None,
             },
             data_type,
             collation: None,
-            options: vec![]
+            options: vec![],
         }
     }
 
@@ -66,7 +66,7 @@ mod tests {
                 if_not_exists: false,
                 name: ObjectName(vec![Ident::new("db1")]),
                 engine: DatabaseEngineType::Remote,
-                options: vec![]
+                options: vec![],
             });
             expect_parse_ok(sql, expected)?;
         }
@@ -77,7 +77,7 @@ mod tests {
                 if_not_exists: true,
                 name: ObjectName(vec![Ident::new("db1")]),
                 engine: DatabaseEngineType::Remote,
-                options: vec![]
+                options: vec![],
             });
             expect_parse_ok(sql, expected)?;
         }
@@ -88,7 +88,7 @@ mod tests {
                 if_not_exists: false,
                 name: ObjectName(vec![Ident::new("db1")]),
                 engine: DatabaseEngineType::Local,
-                options: vec![]
+                options: vec![],
             });
             expect_parse_ok(sql, expected)?;
         }
@@ -108,7 +108,7 @@ mod tests {
             let sql = "DROP DATABASE db1";
             let expected = DfStatement::DropDatabase(DfDropDatabase {
                 if_exists: false,
-                name: ObjectName(vec![Ident::new("db1")])
+                name: ObjectName(vec![Ident::new("db1")]),
             });
             expect_parse_ok(sql, expected)?;
         }
@@ -116,7 +116,7 @@ mod tests {
             let sql = "DROP DATABASE IF EXISTS db1";
             let expected = DfStatement::DropDatabase(DfDropDatabase {
                 if_exists: true,
-                name: ObjectName(vec![Ident::new("db1")])
+                name: ObjectName(vec![Ident::new("db1")]),
             });
             expect_parse_ok(sql, expected)?;
         }
@@ -135,8 +135,8 @@ mod tests {
             engine: TableEngineType::Csv,
             options: vec![SqlOption {
                 name: Ident::new("LOCATION".to_string()),
-                value: Value::SingleQuotedString("/data/33.csv".into())
-            }]
+                value: Value::SingleQuotedString("/data/33.csv".into()),
+            }],
         });
         expect_parse_ok(sql, expected)?;
 
@@ -153,8 +153,8 @@ mod tests {
             engine: TableEngineType::Parquet,
             options: vec![SqlOption {
                 name: Ident::new("LOCATION".to_string()),
-                value: Value::SingleQuotedString("foo.parquet".into())
-            }]
+                value: Value::SingleQuotedString("foo.parquet".into()),
+            }],
         });
         expect_parse_ok(sql, expected)?;
 
@@ -162,7 +162,7 @@ mod tests {
         let sql = "CREATE TABLE t(c1 int) ENGINE = XX location = 'foo.parquet' ";
         expect_parse_error(
             sql,
-            "Expected Engine must one of Parquet, JSONEachRaw, Null or CSV, found: XX"
+            "Expected Engine must one of Parquet, JSONEachRaw, Null or CSV, found: XX",
         )?;
 
         Ok(())
@@ -174,7 +174,7 @@ mod tests {
             let sql = "DROP TABLE t1";
             let expected = DfStatement::DropTable(DfDropTable {
                 if_exists: false,
-                name: ObjectName(vec![Ident::new("t1")])
+                name: ObjectName(vec![Ident::new("t1")]),
             });
             expect_parse_ok(sql, expected)?;
         }
@@ -182,7 +182,7 @@ mod tests {
             let sql = "DROP TABLE IF EXISTS t1";
             let expected = DfStatement::DropTable(DfDropTable {
                 if_exists: true,
-                name: ObjectName(vec![Ident::new("t1")])
+                name: ObjectName(vec![Ident::new("t1")]),
             });
             expect_parse_ok(sql, expected)?;
         }
@@ -204,14 +204,14 @@ mod tests {
         expect_parse_ok(
             "USe db1",
             DfStatement::UseDatabase(DfUseDatabase {
-                name: ObjectName(vec![Ident::new("db1")])
-            })
+                name: ObjectName(vec![Ident::new("db1")]),
+            }),
         )?;
         expect_parse_ok(
             "use db1",
             DfStatement::UseDatabase(DfUseDatabase {
-                name: ObjectName(vec![Ident::new("db1")])
-            })
+                name: ObjectName(vec![Ident::new("db1")]),
+            }),
         )?;
 
         Ok(())

--- a/fusequery/query/src/sql/sql_statement.rs
+++ b/fusequery/query/src/sql/sql_statement.rs
@@ -22,7 +22,7 @@ pub struct DfShowSettings;
 #[derive(Debug, Clone, PartialEq)]
 pub struct DfExplain {
     pub typ: ExplainType,
-    pub statement: Box<SQLStatement>
+    pub statement: Box<SQLStatement>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -32,13 +32,13 @@ pub struct DfCreateTable {
     pub name: ObjectName,
     pub columns: Vec<ColumnDef>,
     pub engine: TableEngineType,
-    pub options: Vec<SqlOption>
+    pub options: Vec<SqlOption>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DfDropTable {
     pub if_exists: bool,
-    pub name: ObjectName
+    pub name: ObjectName,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -46,18 +46,18 @@ pub struct DfCreateDatabase {
     pub if_not_exists: bool,
     pub name: ObjectName,
     pub engine: DatabaseEngineType,
-    pub options: Vec<SqlOption>
+    pub options: Vec<SqlOption>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DfDropDatabase {
     pub if_exists: bool,
-    pub name: ObjectName
+    pub name: ObjectName,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DfUseDatabase {
-    pub name: ObjectName
+    pub name: ObjectName,
 }
 
 /// Tokens parsed by `DFParser` are converted into these values.
@@ -79,5 +79,5 @@ pub enum DfStatement {
     DropTable(DfDropTable),
 
     // Settings.
-    ShowSettings(DfShowSettings)
+    ShowSettings(DfShowSettings),
 }

--- a/fusequery/query/src/tests/number.rs
+++ b/fusequery/query/src/tests/number.rs
@@ -19,7 +19,7 @@ use crate::sessions::FuseQueryContextRef;
 pub struct NumberTestData {
     ctx: FuseQueryContextRef,
     db: &'static str,
-    table: &'static str
+    table: &'static str,
 }
 
 impl NumberTestData {
@@ -27,7 +27,7 @@ impl NumberTestData {
         NumberTestData {
             ctx,
             db: "system",
-            table: "numbers_mt"
+            table: "numbers_mt",
         }
     }
 
@@ -40,15 +40,18 @@ impl NumberTestData {
     pub fn number_read_source_plan_for_test(&self, numbers: i64) -> Result<ReadDataSourcePlan> {
         let datasource = crate::datasources::DataSource::try_create()?;
         let table = datasource.get_table(self.db, self.table)?;
-        table.read_plan(self.ctx.clone(), &ScanPlan {
-            schema_name: self.db.to_string(),
-            table_schema: Arc::new(DataSchema::empty()),
-            table_args: Some(ExpressionAction::Literal(DataValue::Int64(Some(numbers)))),
-            projection: None,
-            projected_schema: Arc::new(DataSchema::empty()),
-            filters: vec![],
-            limit: None
-        })
+        table.read_plan(
+            self.ctx.clone(),
+            &ScanPlan {
+                schema_name: self.db.to_string(),
+                table_schema: Arc::new(DataSchema::empty()),
+                table_args: Some(ExpressionAction::Literal(DataValue::Int64(Some(numbers)))),
+                projection: None,
+                projected_schema: Arc::new(DataSchema::empty()),
+                filters: vec![],
+                limit: None,
+            },
+        )
     }
 
     pub fn number_source_transform_for_test(&self, numbers: i64) -> Result<SourceTransform> {

--- a/fusequery/query/src/tests/service.rs
+++ b/fusequery/query/src/tests/service.rs
@@ -42,7 +42,7 @@ pub async fn try_create_context_with_nodes(nums: usize) -> Result<FuseQueryConte
             name: format!("node{}", i),
             priority: 10,
             address: addr.clone(),
-            local: false
+            local: false,
         })?;
     }
     Ok(ctx)
@@ -51,7 +51,7 @@ pub async fn try_create_context_with_nodes(nums: usize) -> Result<FuseQueryConte
 // Start a cluster and return the context who has the cluster info.
 pub async fn try_create_context_with_nodes_and_priority(
     nums: usize,
-    p: &[u8]
+    p: &[u8],
 ) -> Result<FuseQueryContextRef> {
     // p is the priority array of the nodes.
     // Its length of it should be nums.
@@ -63,7 +63,7 @@ pub async fn try_create_context_with_nodes_and_priority(
             name: format!("node{}", i),
             priority: p[i],
             address: addr.clone(),
-            local: false
+            local: false,
         })?;
     }
     Ok(ctx)

--- a/fusestore/store/build.rs
+++ b/fusestore/store/build.rs
@@ -38,7 +38,7 @@ fn commit_info() -> String {
             hash.trim_end(),
             date
         ),
-        _ => String::new()
+        _ => String::new(),
     }
 }
 

--- a/fusestore/store/src/api/rpc/flight_service.rs
+++ b/fusestore/store/src/api/rpc/flight_service.rs
@@ -54,7 +54,7 @@ pub type FlightStream<T> =
 /// StoreFlightImpl provides data access API-s for FuseQuery, in arrow-flight protocol.
 pub struct StoreFlightImpl {
     token: FlightToken,
-    action_handler: ActionHandler
+    action_handler: ActionHandler,
 }
 
 impl StoreFlightImpl {
@@ -62,7 +62,7 @@ impl StoreFlightImpl {
         Self {
             token: FlightToken::create(),
             // TODO pass in action handler
-            action_handler: ActionHandler::create(fs)
+            action_handler: ActionHandler::create(fs),
         }
     }
 
@@ -86,7 +86,7 @@ impl FlightService for StoreFlightImpl {
     type HandshakeStream = FlightStream<HandshakeResponse>;
     async fn handshake(
         &self,
-        request: Request<Streaming<HandshakeRequest>>
+        request: Request<Streaming<HandshakeRequest>>,
     ) -> Result<Response<Self::HandshakeStream>, Status> {
         let req = request
             .into_inner()
@@ -101,7 +101,7 @@ impl FlightService for StoreFlightImpl {
         let user = "root";
         if auth.username == user {
             let claim = FlightClaim {
-                username: user.to_string()
+                username: user.to_string(),
             };
             let token = self
                 .token
@@ -125,21 +125,21 @@ impl FlightService for StoreFlightImpl {
     type ListFlightsStream = FlightStream<FlightInfo>;
     async fn list_flights(
         &self,
-        _request: Request<Criteria>
+        _request: Request<Criteria>,
     ) -> Result<Response<Self::ListFlightsStream>, Status> {
         unimplemented!()
     }
 
     async fn get_flight_info(
         &self,
-        _request: Request<FlightDescriptor>
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
         unimplemented!()
     }
 
     async fn get_schema(
         &self,
-        _request: Request<FlightDescriptor>
+        _request: Request<FlightDescriptor>,
     ) -> Result<Response<SchemaResult>, Status> {
         unimplemented!()
     }
@@ -148,7 +148,7 @@ impl FlightService for StoreFlightImpl {
         Pin<Box<dyn Stream<Item = Result<FlightData, tonic::Status>> + Send + Sync + 'static>>;
     async fn do_get(
         &self,
-        request: Request<Ticket>
+        request: Request<Ticket>,
     ) -> Result<Response<Self::DoGetStream>, Status> {
         // Check token.
         let _claim = self.check_token(&request.metadata())?;
@@ -162,7 +162,7 @@ impl FlightService for StoreFlightImpl {
 
                 let (tx, rx): (
                     Sender<Result<FlightData, tonic::Status>>,
-                    Receiver<Result<FlightData, tonic::Status>>
+                    Receiver<Result<FlightData, tonic::Status>>,
                 ) = tokio::sync::mpsc::channel(2);
 
                 self.action_handler.do_pull_file(key, tx).await?;
@@ -177,7 +177,7 @@ impl FlightService for StoreFlightImpl {
     type DoPutStream = FlightStream<PutResult>;
     async fn do_put(
         &self,
-        _request: Request<Streaming<FlightData>>
+        _request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoPutStream>, Status> {
         unimplemented!()
     }
@@ -185,7 +185,7 @@ impl FlightService for StoreFlightImpl {
     type DoExchangeStream = FlightStream<FlightData>;
     async fn do_exchange(
         &self,
-        _request: Request<Streaming<FlightData>>
+        _request: Request<Streaming<FlightData>>,
     ) -> Result<Response<Self::DoExchangeStream>, Status> {
         unimplemented!()
     }
@@ -193,7 +193,7 @@ impl FlightService for StoreFlightImpl {
     type DoActionStream = FlightStream<arrow_flight::Result>;
     async fn do_action(
         &self,
-        request: Request<Action>
+        request: Request<Action>,
     ) -> Result<Response<Self::DoActionStream>, Status> {
         // Check token.
         let _claim = self.check_token(&request.metadata())?;
@@ -208,7 +208,7 @@ impl FlightService for StoreFlightImpl {
     type ListActionsStream = FlightStream<ActionType>;
     async fn list_actions(
         &self,
-        _request: Request<Empty>
+        _request: Request<Empty>,
     ) -> Result<Response<Self::ListActionsStream>, Status> {
         unimplemented!()
     }
@@ -216,7 +216,7 @@ impl FlightService for StoreFlightImpl {
 impl StoreFlightImpl {
     fn once_stream_resp(
         &self,
-        action_rst: StoreDoActionResult
+        action_rst: StoreDoActionResult,
     ) -> Result<Response<FlightStream<arrow_flight::Result>>, Status> {
         let rst = arrow_flight::Result::from(action_rst);
 

--- a/fusestore/store/src/api/rpc/flight_service_test.rs
+++ b/fusestore/store/src/api/rpc/flight_service_test.rs
@@ -26,7 +26,7 @@ async fn test_flight_create_database() -> anyhow::Result<()> {
             if_not_exists: false,
             db: "db1".to_string(),
             engine: DatabaseEngineType::Local,
-            options: Default::default()
+            options: Default::default(),
         };
 
         let res = client.create_database(plan.clone()).await;
@@ -40,7 +40,7 @@ async fn test_flight_create_database() -> anyhow::Result<()> {
             if_not_exists: false,
             db: "db2".to_string(),
             engine: DatabaseEngineType::Local,
-            options: Default::default()
+            options: Default::default(),
         };
 
         let res = client.create_database(plan.clone()).await;
@@ -79,7 +79,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
             if_not_exists: false,
             db: "db1".to_string(),
             engine: DatabaseEngineType::Local,
-            options: Default::default()
+            options: Default::default(),
         };
 
         let res = client.create_database(plan.clone()).await;
@@ -98,7 +98,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
             [("Key".to_string(), "Value".to_string())]
                 .iter()
                 .cloned()
-                .collect()
+                .collect(),
         ));
 
         // Create table plan.
@@ -110,7 +110,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
             // TODO check get_table
             options: maplit::hashmap! {"opt‐1".into() => "val-1".into()},
             // TODO
-            engine: TableEngineType::JsonEachRaw
+            engine: TableEngineType::JsonEachRaw,
         };
 
         {
@@ -123,7 +123,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
                 table_id: 1,
                 db: "db1".into(),
                 name: "tb2".into(),
-                schema: schema.clone()
+                schema: schema.clone(),
             };
             assert_eq!(want, got, "get created table");
         }
@@ -138,7 +138,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
                 table_id: 2,
                 db: "db1".into(),
                 name: "tb2".into(),
-                schema: schema.clone()
+                schema: schema.clone(),
             };
             assert_eq!(want, got, "get created table");
         }
@@ -163,7 +163,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
                 table_id: 2,
                 db: "db1".into(),
                 name: "tb2".into(),
-                schema: schema.clone()
+                schema: schema.clone(),
             };
             assert_eq!(want, got, "get old table");
         }

--- a/fusestore/store/src/api/rpc_service.rs
+++ b/fusestore/store/src/api/rpc_service.rs
@@ -14,7 +14,7 @@ use crate::configs::Config;
 use crate::localfs::LocalFS;
 
 pub struct StoreServer {
-    conf: Config
+    conf: Config,
 }
 
 impl StoreServer {

--- a/fusestore/store/src/bin/fuse-store.rs
+++ b/fusestore/store/src/bin/fuse-store.rs
@@ -11,7 +11,7 @@ use log::info;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let conf = Config::create_from_args();
     env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or(conf.log_level.to_lowercase().as_str())
+        env_logger::Env::default().default_filter_or(conf.log_level.to_lowercase().as_str()),
     )
     .init();
 

--- a/fusestore/store/src/configs/config.rs
+++ b/fusestore/store/src/configs/config.rs
@@ -24,7 +24,7 @@ pub struct Config {
         env = "FUSE_QUERY_RPC_API_ADDRESS",
         default_value = "127.0.0.1:9191"
     )]
-    pub rpc_api_address: String
+    pub rpc_api_address: String,
 }
 
 impl Config {
@@ -34,7 +34,7 @@ impl Config {
             version: include_str!(concat!(env!("OUT_DIR"), "/version-info.txt")).to_string(),
             log_level: "debug".to_string(),
             metric_api_address: "127.0.0.1:7171".to_string(),
-            rpc_api_address: "127.0.0.1:9191".to_string()
+            rpc_api_address: "127.0.0.1:9191".to_string(),
         }
     }
 

--- a/fusestore/store/src/data_part/appender.rs
+++ b/fusestore/store/src/data_part/appender.rs
@@ -23,12 +23,13 @@ use crate::fs::IFileSystem;
 
 #[allow(dead_code)] // temporarily allowed
 pub(crate) struct Appender<FS> {
-    fs: FS // owned type? to be discussed later.
+    fs: FS, // owned type? to be discussed later.
 }
 
 #[allow(dead_code)] // temporarily allowed
 impl<FS> Appender<FS>
-where FS: IFileSystem
+where
+    FS: IFileSystem,
 {
     pub fn new(fs: FS) -> Self {
         Appender { fs }
@@ -40,7 +41,7 @@ where FS: IFileSystem
     pub async fn append_data(
         &self,
         path: String,
-        mut stream: std::pin::Pin<Box<dyn futures::Stream<Item = FlightData>>>
+        mut stream: std::pin::Pin<Box<dyn futures::Stream<Item = FlightData>>>,
     ) -> Result<Vec<String>> {
         if let Some(flight_data) = stream.next().await {
             let data_schema = DataSchema::try_from(&flight_data)?;

--- a/fusestore/store/src/dfs/distributed_fs.rs
+++ b/fusestore/store/src/dfs/distributed_fs.rs
@@ -23,14 +23,14 @@ pub struct Dfs {
     /// The local fs to store data copies.
     /// The distributed fs is a cluster of local-fs organized with a meta data service.
     pub local_fs: LocalFS,
-    pub meta_node: Arc<MetaNode>
+    pub meta_node: Arc<MetaNode>,
 }
 
 impl Dfs {
     pub fn create(local_fs: LocalFS, meta_node: Arc<MetaNode>) -> Dfs {
         Dfs {
             local_fs,
-            meta_node
+            meta_node,
         }
     }
 }
@@ -50,8 +50,8 @@ impl IFileSystem for Dfs {
             txid: None,
             cmd: Cmd::AddFile {
                 key: path,
-                value: "".into()
-            }
+                value: "".into(),
+            },
         };
         let _resp = self.meta_node.write(req).await?;
         Ok(())

--- a/fusestore/store/src/engine/mem_engine.rs
+++ b/fusestore/store/src/engine/mem_engine.rs
@@ -16,7 +16,7 @@ use crate::protobuf::Table;
 pub struct MemEngine {
     pub dbs: HashMap<String, Db>,
     pub next_id: i64,
-    pub next_ver: i64
+    pub next_ver: i64,
 }
 
 impl MemEngine {
@@ -25,7 +25,7 @@ impl MemEngine {
         let e = MemEngine {
             dbs: HashMap::new(),
             next_id: 0,
-            next_ver: 0
+            next_ver: 0,
         };
         Arc::new(Mutex::new(e))
     }
@@ -34,7 +34,7 @@ impl MemEngine {
     pub fn create_database(
         &mut self,
         cmd: CmdCreateDatabase,
-        if_not_exists: bool
+        if_not_exists: bool,
     ) -> anyhow::Result<i64> {
         // TODO: support plan.engine plan.options
         let curr = self.dbs.get(&cmd.db_name);
@@ -69,7 +69,7 @@ impl MemEngine {
     pub fn create_table(
         &mut self,
         cmd: CmdCreateTable,
-        if_not_exists: bool
+        if_not_exists: bool,
     ) -> Result<i64, Status> {
         // TODO: support plan.engine plan.options
 

--- a/fusestore/store/src/engine/mem_engine_test.rs
+++ b/fusestore/store/src/engine/mem_engine_test.rs
@@ -25,8 +25,8 @@ fn test_mem_engine_create_database() -> anyhow::Result<()> {
             db_id: -1,
             ver: -1,
             table_name_to_id: HashMap::new(),
-            tables: HashMap::new()
-        })
+            tables: HashMap::new(),
+        }),
     };
     let cmdbar = CmdCreateDatabase {
         db_name: "bar".into(),
@@ -34,8 +34,8 @@ fn test_mem_engine_create_database() -> anyhow::Result<()> {
             db_id: -1,
             ver: -1,
             table_name_to_id: HashMap::new(),
-            tables: HashMap::new()
-        })
+            tables: HashMap::new(),
+        }),
     };
 
     {
@@ -99,8 +99,8 @@ fn test_mem_engine_create_get_table() -> anyhow::Result<()> {
             db_id: -1,
             ver: -1,
             table_name_to_id: HashMap::new(),
-            tables: HashMap::new()
-        })
+            tables: HashMap::new(),
+        }),
     };
 
     let cmd_table = CmdCreateTable {
@@ -111,8 +111,8 @@ fn test_mem_engine_create_get_table() -> anyhow::Result<()> {
             ver: -1,
             schema: vec![1, 2, 3],
             options: maplit::hashmap! {"key".into() => "val".into()},
-            placement_policy: vec![1, 2, 3]
-        })
+            placement_policy: vec![1, 2, 3],
+        }),
     };
 
     {

--- a/fusestore/store/src/executor/action_handler.rs
+++ b/fusestore/store/src/executor/action_handler.rs
@@ -39,14 +39,14 @@ pub struct ActionHandler {
     // db_spec: DatabaseSpec,
     // TODO delegate table/database RW to fs
     meta: Arc<Mutex<MemEngine>>,
-    fs: Arc<dyn IFileSystem>
+    fs: Arc<dyn IFileSystem>,
 }
 
 impl ActionHandler {
     pub fn create(fs: Arc<dyn IFileSystem>) -> Self {
         ActionHandler {
             meta: MemEngine::create(),
-            fs
+            fs,
         }
     }
 
@@ -55,7 +55,7 @@ impl ActionHandler {
     pub async fn do_pull_file(
         &self,
         key: String,
-        tx: Sender<Result<FlightData, tonic::Status>>
+        tx: Sender<Result<FlightData, tonic::Status>>,
     ) -> Result<(), Status> {
         // TODO: stream read if the file is too large.
         let buf = self
@@ -83,7 +83,7 @@ impl ActionHandler {
             StoreDoAction::DropTable(_) => {
                 Err(Status::internal("Store drop database unimplemented"))
             }
-            StoreDoAction::GetTable(a) => self.get_table(a).await
+            StoreDoAction::GetTable(a) => self.get_table(a).await,
         }
     }
 
@@ -98,8 +98,8 @@ impl ActionHandler {
                 db_id: -1,
                 ver: -1,
                 table_name_to_id: HashMap::new(),
-                tables: HashMap::new()
-            })
+                tables: HashMap::new(),
+            }),
         };
 
         let database_id = meta
@@ -107,7 +107,7 @@ impl ActionHandler {
             .map_err(|e| Status::internal(e.to_string()))?;
 
         Ok(StoreDoActionResult::CreateDatabase(
-            CreateDatabaseActionResult { database_id }
+            CreateDatabaseActionResult { database_id },
         ))
     }
 
@@ -132,19 +132,19 @@ impl ActionHandler {
             options: plan.options,
 
             // TODO
-            placement_policy: vec![]
+            placement_policy: vec![],
         };
 
         let cmd = CmdCreateTable {
             db_name,
             table_name,
-            table: Some(table)
+            table: Some(table),
         };
 
         let table_id = meta.create_table(cmd, plan.if_not_exists)?;
 
         Ok(StoreDoActionResult::CreateTable(CreateTableActionResult {
-            table_id
+            table_id,
         }))
     }
 
@@ -168,7 +168,7 @@ impl ActionHandler {
             table_id: table.table_id,
             db: db_name,
             name: table_name,
-            schema: Arc::new(schema)
+            schema: Arc::new(schema),
         });
 
         Ok(rst)

--- a/fusestore/store/src/executor/action_handler_test.rs
+++ b/fusestore/store/src/executor/action_handler_test.rs
@@ -37,7 +37,7 @@ async fn test_action_handler_do_pull_file() -> anyhow::Result<()> {
         // pull file
         let (tx, mut rx): (
             Sender<Result<FlightData, tonic::Status>>,
-            Receiver<Result<FlightData, tonic::Status>>
+            Receiver<Result<FlightData, tonic::Status>>,
         ) = tokio::sync::mpsc::channel(2);
 
         hdlr.do_pull_file("foo".into(), tx).await?;

--- a/fusestore/store/src/fs/ifs.rs
+++ b/fusestore/store/src/fs/ifs.rs
@@ -9,7 +9,8 @@ use crate::fs::ListResult;
 /// Abstract storage layer API.
 #[async_trait]
 pub trait IFileSystem
-where Self: Sync + Send
+where
+    Self: Sync + Send,
 {
     /// Add file atomically.
     /// AKA put_if_absent

--- a/fusestore/store/src/fs/list_result.rs
+++ b/fusestore/store/src/fs/list_result.rs
@@ -7,7 +7,7 @@ use std::fmt::Formatter;
 #[derive(Debug)]
 pub struct ListResult {
     pub dirs: Vec<String>,
-    pub files: Vec<String>
+    pub files: Vec<String>,
 }
 
 impl PartialEq for ListResult {

--- a/fusestore/store/src/localfs/local_fs.rs
+++ b/fusestore/store/src/localfs/local_fs.rs
@@ -13,14 +13,14 @@ use crate::fs::IFileSystem;
 use crate::fs::ListResult;
 
 pub struct LocalFS {
-    root: PathBuf
+    root: PathBuf,
 }
 
 /// IFS implementation on local file-system.
 impl LocalFS {
     pub fn try_create(root: String) -> anyhow::Result<LocalFS> {
         let f = LocalFS {
-            root: PathBuf::from(root)
+            root: PathBuf::from(root),
         };
         Ok(f)
     }
@@ -84,7 +84,7 @@ impl IFileSystem for LocalFS {
                         files.push(f);
                     }
                 }
-                Err(e) => return Err(e).context("LocalFS: fail to read entry")
+                Err(e) => return Err(e).context("LocalFS: fail to read entry"),
             }
         }
 

--- a/fusestore/store/src/meta_service/meta.rs
+++ b/fusestore/store/src/meta_service/meta.rs
@@ -28,7 +28,7 @@ pub struct Meta {
 
     // cluster nodes, key distribution etc.
     pub slots: Vec<Slot>,
-    pub nodes: HashMap<NodeId, Node>
+    pub nodes: HashMap<NodeId, Node>,
 }
 
 impl Meta {
@@ -55,7 +55,7 @@ impl Meta {
 
             Cmd::AddNode {
                 ref node_id,
-                ref node
+                ref node,
             } => {
                 if self.nodes.contains_key(node_id) {
                     let prev = self.nodes.get(node_id);
@@ -88,13 +88,13 @@ impl Meta {
 /// A slot is assigned to several physical servers(normally 3 for durability).
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Slot {
-    pub node_ids: Vec<NodeId>
+    pub node_ids: Vec<NodeId>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Node {
     pub name: String,
-    pub address: String
+    pub address: String,
 }
 
 impl Display for Node {

--- a/fusestore/store/src/meta_service/meta_service_impl.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl.rs
@@ -13,7 +13,7 @@ use crate::meta_service::MetaService;
 use crate::meta_service::RaftMes;
 
 pub struct MetaServiceImpl {
-    pub meta_node: Arc<MetaNode>
+    pub meta_node: Arc<MetaNode>,
 }
 
 impl MetaServiceImpl {
@@ -29,7 +29,7 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self))]
     async fn write(
         &self,
-        request: tonic::Request<RaftMes>
+        request: tonic::Request<RaftMes>,
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
         let mes = request.into_inner();
         let req: ClientRequest = mes.try_into()?;
@@ -48,7 +48,7 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self))]
     async fn get(
         &self,
-        request: tonic::Request<GetReq>
+        request: tonic::Request<GetReq>,
     ) -> Result<tonic::Response<GetReply>, tonic::Status> {
         let req = request.into_inner();
         let resp = self.meta_node.get_file(&req.key).await;
@@ -56,13 +56,13 @@ impl MetaService for MetaServiceImpl {
             Some(v) => GetReply {
                 ok: true,
                 key: req.key,
-                value: v
+                value: v,
             },
             None => GetReply {
                 ok: false,
                 key: req.key,
-                value: "".into()
-            }
+                value: "".into(),
+            },
         };
 
         Ok(tonic::Response::new(rst))
@@ -71,7 +71,7 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self))]
     async fn append_entries(
         &self,
-        request: tonic::Request<RaftMes>
+        request: tonic::Request<RaftMes>,
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
         let req = request.into_inner();
 
@@ -93,7 +93,7 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self))]
     async fn install_snapshot(
         &self,
-        request: tonic::Request<RaftMes>
+        request: tonic::Request<RaftMes>,
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
         let req = request.into_inner();
 
@@ -115,7 +115,7 @@ impl MetaService for MetaServiceImpl {
     #[tracing::instrument(level = "info", skip(self))]
     async fn vote(
         &self,
-        request: tonic::Request<RaftMes>
+        request: tonic::Request<RaftMes>,
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
         let req = request.into_inner();
 

--- a/fusestore/store/src/meta_service/meta_service_impl_test.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl_test.rs
@@ -37,8 +37,8 @@ async fn test_meta_server_set_get() -> anyhow::Result<()> {
             txid: None,
             cmd: Cmd::AddFile {
                 key: "foo".to_string(),
-                value: "bar".to_string()
-            }
+                value: "bar".to_string(),
+            },
         };
         let rst = client.write(req).await?.into_inner();
         let resp: ClientResponse = rst.into();
@@ -64,8 +64,8 @@ async fn test_meta_server_set_get() -> anyhow::Result<()> {
             txid: None,
             cmd: Cmd::AddFile {
                 key: "foo".to_string(),
-                value: "bar".to_string()
-            }
+                value: "bar".to_string(),
+            },
         };
         let rst = client.write(req).await?.into_inner();
         let resp: ClientResponse = rst.into();
@@ -84,8 +84,8 @@ async fn test_meta_server_set_get() -> anyhow::Result<()> {
             txid: None,
             cmd: Cmd::SetFile {
                 key: "foo".to_string(),
-                value: "bar2".to_string()
-            }
+                value: "bar2".to_string(),
+            },
         };
         let rst = client.write(req).await?.into_inner();
         let resp: ClientResponse = rst.into();

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -63,7 +63,7 @@ pub enum Cmd {
     // Override the record with key.
     SetFile { key: String, value: String },
     // Add node if absent
-    AddNode { node_id: NodeId, node: Node }
+    AddNode { node_id: NodeId, node: Node },
 }
 
 impl fmt::Display for Cmd {
@@ -91,14 +91,14 @@ pub struct RaftTxId {
     /// The serial number of this request.
     /// TODO(xp): a client must generate consistent `client` and globally unique serial.
     /// TODO(xp): in this impl the state machine records only one serial, which implies serial must be monotonic incremental for every client.
-    pub serial: u64
+    pub serial: u64,
 }
 
 impl RaftTxId {
     pub fn new(client: &str, serial: u64) -> Self {
         Self {
             client: client.to_string(),
-            serial
+            serial,
         }
     }
 }
@@ -114,7 +114,7 @@ pub struct ClientRequest {
     pub txid: Option<RaftTxId>,
 
     /// The action a client want to take.
-    pub cmd: Cmd
+    pub cmd: Cmd,
 }
 
 impl AppData for ClientRequest {}
@@ -122,7 +122,7 @@ impl AppData for ClientRequest {}
 impl tonic::IntoRequest<RaftMes> for ClientRequest {
     fn into_request(self) -> tonic::Request<RaftMes> {
         let mes = RaftMes {
-            data: serde_json::to_string(&self).expect("fail to serialize")
+            data: serde_json::to_string(&self).expect("fail to serialize"),
         };
         tonic::Request::new(mes)
     }
@@ -130,7 +130,7 @@ impl tonic::IntoRequest<RaftMes> for ClientRequest {
 impl tonic::IntoRequest<RaftMes> for AppendEntriesRequest<ClientRequest> {
     fn into_request(self) -> tonic::Request<RaftMes> {
         let mes = RaftMes {
-            data: serde_json::to_string(&self).expect("fail to serialize")
+            data: serde_json::to_string(&self).expect("fail to serialize"),
         };
         tonic::Request::new(mes)
     }
@@ -138,7 +138,7 @@ impl tonic::IntoRequest<RaftMes> for AppendEntriesRequest<ClientRequest> {
 impl tonic::IntoRequest<RaftMes> for InstallSnapshotRequest {
     fn into_request(self) -> tonic::Request<RaftMes> {
         let mes = RaftMes {
-            data: serde_json::to_string(&self).expect("fail to serialize")
+            data: serde_json::to_string(&self).expect("fail to serialize"),
         };
         tonic::Request::new(mes)
     }
@@ -146,7 +146,7 @@ impl tonic::IntoRequest<RaftMes> for InstallSnapshotRequest {
 impl tonic::IntoRequest<RaftMes> for VoteRequest {
     fn into_request(self) -> tonic::Request<RaftMes> {
         let mes = RaftMes {
-            data: serde_json::to_string(&self).expect("fail to serialize")
+            data: serde_json::to_string(&self).expect("fail to serialize"),
         };
         tonic::Request::new(mes)
     }
@@ -169,12 +169,12 @@ pub enum ClientResponse {
         // The value before applying a ClientRequest.
         prev: Option<String>,
         // The value after applying a ClientRequest.
-        result: Option<String>
+        result: Option<String>,
     },
     Node {
         prev: Option<Node>,
-        result: Option<Node>
-    }
+        result: Option<Node>,
+    },
 }
 
 impl AppDataResponse for ClientResponse {}
@@ -202,7 +202,7 @@ impl From<(Option<String>, Option<String>)> for ClientResponse {
     fn from(v: (Option<String>, Option<String>)) -> Self {
         ClientResponse::String {
             prev: v.0,
-            result: v.1
+            result: v.1,
         }
     }
 }
@@ -210,7 +210,7 @@ impl From<(Option<Node>, Option<Node>)> for ClientResponse {
     fn from(v: (Option<Node>, Option<Node>)) -> Self {
         ClientResponse::Node {
             prev: v.0,
-            result: v.1
+            result: v.1,
         }
     }
 }
@@ -219,7 +219,7 @@ impl From<(Option<Node>, Option<Node>)> for ClientResponse {
 #[derive(Clone, Debug, Error)]
 pub enum ShutdownError {
     #[error("unsafe storage error")]
-    UnsafeStorageError
+    UnsafeStorageError,
 }
 
 /// The application snapshot type which the `MemStore` works with.
@@ -232,7 +232,7 @@ pub struct MemStoreSnapshot {
     /// The last memberhsip config included in this snapshot.
     pub membership: MembershipConfig,
     /// The data of the state machine at the time of this snapshot.
-    pub data: Vec<u8>
+    pub data: Vec<u8>,
 }
 
 /// The state machine of the `MemStore`.
@@ -243,7 +243,7 @@ pub struct MemStoreStateMachine {
     /// (serial, ClientResponse)
     pub client_serial_responses: HashMap<String, (u64, ClientResponse)>,
 
-    pub meta: Meta
+    pub meta: Meta,
 }
 
 impl MemStoreStateMachine {
@@ -288,7 +288,7 @@ pub struct MemStore {
 
     // Channels for publishing applied index
     pub applied_tx: watch::Sender<u64>,
-    pub applied_rx: watch::Receiver<u64>
+    pub applied_rx: watch::Receiver<u64>,
 }
 
 impl MemStore {
@@ -307,7 +307,7 @@ impl MemStore {
             hs,
             current_snapshot,
             applied_tx: tx,
-            applied_rx: rx
+            applied_rx: rx,
         }
     }
 
@@ -318,7 +318,7 @@ impl MemStore {
         log: BTreeMap<u64, Entry<ClientRequest>>,
         sm: MemStoreStateMachine,
         hs: Option<HardState>,
-        current_snapshot: Option<MemStoreSnapshot>
+        current_snapshot: Option<MemStoreSnapshot>,
     ) -> Self {
         let log = RwLock::new(log);
         let sm = RwLock::new(sm);
@@ -333,7 +333,7 @@ impl MemStore {
             hs,
             current_snapshot,
             applied_tx: tx,
-            applied_rx: rx
+            applied_rx: rx,
         }
     }
 
@@ -364,11 +364,11 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
         let cfg_opt = log.values().rev().find_map(|entry| match &entry.payload {
             EntryPayload::ConfigChange(cfg) => Some(cfg.membership.clone()),
             EntryPayload::SnapshotPointer(snap) => Some(snap.membership.clone()),
-            _ => None
+            _ => None,
         });
         Ok(match cfg_opt {
             Some(cfg) => cfg,
-            None => MembershipConfig::new_initial(self.id)
+            None => MembershipConfig::new_initial(self.id),
         })
     }
 
@@ -382,7 +382,7 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
             Some(inner) => {
                 let (last_log_index, last_log_term) = match log.values().rev().next() {
                     Some(log) => (log.index, log.term),
-                    None => (0, 0)
+                    None => (0, 0),
                 };
                 let last_applied_log = sm.last_applied_log;
                 let st = InitialState {
@@ -390,7 +390,7 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
                     last_log_term,
                     last_applied_log,
                     hard_state: inner.clone(),
-                    membership
+                    membership,
                 };
                 tracing::info!("build initial state from storage: {:?}", st);
                 Ok(st)
@@ -461,7 +461,7 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
     async fn apply_entry_to_state_machine(
         &self,
         index: &u64,
-        data: &ClientRequest
+        data: &ClientRequest,
     ) -> Result<ClientResponse> {
         let mut sm = self.sm.write().await;
         let resp = sm.apply(*index, data)?;
@@ -501,7 +501,7 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
                 .skip_while(|entry| entry.index > last_applied_log)
                 .find_map(|entry| match &entry.payload {
                     EntryPayload::ConfigChange(cfg) => Some(cfg.membership.clone()),
-                    _ => None
+                    _ => None,
                 })
                 .unwrap_or_else(|| MembershipConfig::new_initial(self.id));
         } // Release log read lock.
@@ -522,15 +522,15 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
                     last_applied_log,
                     term,
                     "".into(),
-                    membership_config.clone()
-                )
+                    membership_config.clone(),
+                ),
             );
 
             let snapshot = MemStoreSnapshot {
                 index: last_applied_log,
                 term,
                 membership: membership_config.clone(),
-                data
+                data,
             };
             snapshot_bytes = serde_json::to_vec(&snapshot)?;
             *current_snapshot = Some(snapshot);
@@ -544,7 +544,7 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
             term,
             index: last_applied_log,
             membership: membership_config.clone(),
-            snapshot: Box::new(Cursor::new(snapshot_bytes))
+            snapshot: Box::new(Cursor::new(snapshot_bytes)),
         })
     }
 
@@ -560,7 +560,7 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
         term: u64,
         delete_through: Option<u64>,
         id: String,
-        snapshot: Box<Self::Snapshot>
+        snapshot: Box<Self::Snapshot>,
     ) -> Result<()> {
         tracing::info!(
             { snapshot_size = snapshot.get_ref().len() },
@@ -579,7 +579,7 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
                 .skip_while(|entry| entry.index > index)
                 .find_map(|entry| match &entry.payload {
                     EntryPayload::ConfigChange(cfg) => Some(cfg.membership.clone()),
-                    _ => None
+                    _ => None,
                 })
                 .unwrap_or_else(|| MembershipConfig::new_initial(self.id));
 
@@ -587,11 +587,11 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
                 Some(through) => {
                     *log = log.split_off(&(through + 1));
                 }
-                None => log.clear()
+                None => log.clear(),
             }
             log.insert(
                 index,
-                Entry::new_snapshot_pointer(index, term, id, membership_config)
+                Entry::new_snapshot_pointer(index, term, id, membership_config),
             );
         }
 
@@ -617,16 +617,16 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
                     index: snapshot.index,
                     term: snapshot.term,
                     membership: snapshot.membership.clone(),
-                    snapshot: Box::new(Cursor::new(reader))
+                    snapshot: Box::new(Cursor::new(reader)),
                 }))
             }
-            None => Ok(None)
+            None => Ok(None),
         }
     }
 }
 
 pub struct Network {
-    sto: Arc<MemStore>
+    sto: Arc<MemStore>,
 }
 
 impl Network {
@@ -637,7 +637,7 @@ impl Network {
     #[tracing::instrument(level = "info", skip(self), fields(myid=self.sto.id))]
     pub async fn make_client(
         &self,
-        node_id: &NodeId
+        node_id: &NodeId,
     ) -> anyhow::Result<MetaServiceClient<Channel>> {
         let addr = self.sto.get_node_addr(node_id).await?;
         tracing::info!("connect: id={}: {}", node_id, addr);
@@ -653,7 +653,7 @@ impl RaftNetwork<ClientRequest> for Network {
     async fn append_entries(
         &self,
         target: NodeId,
-        rpc: AppendEntriesRequest<ClientRequest>
+        rpc: AppendEntriesRequest<ClientRequest>,
     ) -> Result<AppendEntriesResponse> {
         let mut client = self.make_client(&target).await?;
         let resp = client.append_entries(rpc).await?;
@@ -667,7 +667,7 @@ impl RaftNetwork<ClientRequest> for Network {
     async fn install_snapshot(
         &self,
         target: NodeId,
-        rpc: InstallSnapshotRequest
+        rpc: InstallSnapshotRequest,
     ) -> Result<InstallSnapshotResponse> {
         let mut client = self.make_client(&target).await?;
         let resp = client.install_snapshot(rpc).await?;
@@ -699,7 +699,7 @@ pub struct MetaNode {
     pub raft: MetaRaft,
     pub running_tx: watch::Sender<()>,
     pub running_rx: watch::Receiver<()>,
-    pub join_handles: Mutex<Vec<JoinHandle<anyhow::Result<()>>>>
+    pub join_handles: Mutex<Vec<JoinHandle<anyhow::Result<()>>>>,
 }
 
 impl MemStore {
@@ -742,7 +742,7 @@ pub struct MetaNodeBuilder {
     config: Option<Config>,
     sto: Option<Arc<MemStore>>,
     monitor_metrics: bool,
-    start_grpc_service: bool
+    start_grpc_service: bool,
 }
 
 impl MetaNodeBuilder {
@@ -774,7 +774,7 @@ impl MetaNodeBuilder {
             raft,
             running_tx: tx,
             running_rx: rx,
-            join_handles: Mutex::new(Vec::new())
+            join_handles: Mutex::new(Vec::new()),
         });
 
         if self.monitor_metrics {
@@ -815,11 +815,11 @@ impl MetaNode {
             config: Some(
                 Config::build("foo_cluster".into())
                     .validate()
-                    .expect("fail to build raft config")
+                    .expect("fail to build raft config"),
             ),
             sto: None,
             monitor_metrics: true,
-            start_grpc_service: true
+            start_grpc_service: true,
         }
     }
 
@@ -1039,9 +1039,9 @@ impl MetaNode {
                     node_id,
                     node: Node {
                         name: "".to_string(),
-                        address: addr
-                    }
-                }
+                        address: addr,
+                    },
+                },
             })
             .await?;
         Ok(_resp)
@@ -1100,7 +1100,7 @@ impl MetaNode {
     #[tracing::instrument(level = "info", skip(self))]
     pub async fn write_to_local_leader(
         &self,
-        req: ClientRequest
+        req: ClientRequest,
     ) -> anyhow::Result<ClientResponse> {
         // TODO: respond ForwardToLeader error
         let write_rst = self.raft.client_write(ClientWriteRequest::new(req)).await;
@@ -1111,7 +1111,7 @@ impl MetaNode {
             Ok(v) => v,
             // ClientWriteError::RaftError(re)
             // ClientWriteError::ForwardToLeader(_req, _node_id)
-            Err(e) => return Err(anyhow::anyhow!("{:}", e))
+            Err(e) => return Err(anyhow::anyhow!("{:}", e)),
         };
 
         Ok(resp.data)

--- a/fusestore/store/src/meta_service/raftmeta_test.rs
+++ b/fusestore/store/src/meta_service/raftmeta_test.rs
@@ -31,7 +31,7 @@ async fn test_state_machine_apply_add() -> anyhow::Result<()> {
         &str,
         &str,
         Option<String>,
-        Option<String>
+        Option<String>,
     )> = vec![
         (
             "add on none",
@@ -39,7 +39,7 @@ async fn test_state_machine_apply_add() -> anyhow::Result<()> {
             "k1",
             "v1",
             None,
-            Some("v1".to_string())
+            Some("v1".to_string()),
         ),
         (
             "add on existent",
@@ -47,7 +47,7 @@ async fn test_state_machine_apply_add() -> anyhow::Result<()> {
             "k1",
             "v2",
             Some("v1".to_string()),
-            None
+            None,
         ),
         (
             "dup set with same serial, even with diff key, got the previous result",
@@ -55,7 +55,7 @@ async fn test_state_machine_apply_add() -> anyhow::Result<()> {
             "k2",
             "v3",
             Some("v1".to_string()),
-            None
+            None,
         ),
         (
             "diff client, same serial",
@@ -63,18 +63,21 @@ async fn test_state_machine_apply_add() -> anyhow::Result<()> {
             "k2",
             "v3",
             None,
-            Some("v3".to_string())
+            Some("v3".to_string()),
         ),
         ("no txid", None, "k3", "v4", None, Some("v4".to_string())),
     ];
     for (name, txid, k, v, want_prev, want_result) in cases.iter() {
-        let resp = sm.apply(5, &ClientRequest {
-            txid: txid.clone(),
-            cmd: Cmd::AddFile {
-                key: k.to_string(),
-                value: v.to_string()
-            }
-        });
+        let resp = sm.apply(
+            5,
+            &ClientRequest {
+                txid: txid.clone(),
+                cmd: Cmd::AddFile {
+                    key: k.to_string(),
+                    value: v.to_string(),
+                },
+            },
+        );
         assert_eq!(
             ClientResponse::String {
                 prev: want_prev.clone(),
@@ -100,7 +103,7 @@ async fn test_state_machine_apply_set() -> anyhow::Result<()> {
         &str,
         &str,
         Option<String>,
-        Option<String>
+        Option<String>,
     )> = vec![
         (
             "set on none",
@@ -108,7 +111,7 @@ async fn test_state_machine_apply_set() -> anyhow::Result<()> {
             "k1",
             "v1",
             None,
-            Some("v1".to_string())
+            Some("v1".to_string()),
         ),
         (
             "set on existent",
@@ -116,7 +119,7 @@ async fn test_state_machine_apply_set() -> anyhow::Result<()> {
             "k1",
             "v2",
             Some("v1".to_string()),
-            Some("v2".to_string())
+            Some("v2".to_string()),
         ),
         (
             "dup set with same serial, even with diff key, got the previous result",
@@ -124,7 +127,7 @@ async fn test_state_machine_apply_set() -> anyhow::Result<()> {
             "k2",
             "v3",
             Some("v1".to_string()),
-            Some("v2".to_string())
+            Some("v2".to_string()),
         ),
         (
             "diff client, same serial",
@@ -132,7 +135,7 @@ async fn test_state_machine_apply_set() -> anyhow::Result<()> {
             "k2",
             "v3",
             None,
-            Some("v3".to_string())
+            Some("v3".to_string()),
         ),
         (
             "no txid",
@@ -140,17 +143,20 @@ async fn test_state_machine_apply_set() -> anyhow::Result<()> {
             "k2",
             "v4",
             Some("v3".to_string()),
-            Some("v4".to_string())
+            Some("v4".to_string()),
         ),
     ];
     for (name, txid, k, v, want_prev, want_result) in cases.iter() {
-        let resp = sm.apply(5, &ClientRequest {
-            txid: txid.clone(),
-            cmd: Cmd::SetFile {
-                key: k.to_string(),
-                value: v.to_string()
-            }
-        });
+        let resp = sm.apply(
+            5,
+            &ClientRequest {
+                txid: txid.clone(),
+                cmd: Cmd::SetFile {
+                    key: k.to_string(),
+                    value: v.to_string(),
+                },
+            },
+        );
         assert_eq!(
             ClientResponse::String {
                 prev: want_prev.clone(),
@@ -324,7 +330,7 @@ async fn setup_leader() -> anyhow::Result<(NodeId, Arc<MetaNode>)> {
 async fn setup_non_voter(
     leader: Arc<MetaNode>,
     id: NodeId,
-    addr: &str
+    addr: &str,
 ) -> anyhow::Result<(NodeId, Arc<MetaNode>)> {
     let mn = MetaNode::boot_non_voter(id, addr).await?;
     let mut rx = mn.raft.metrics();
@@ -372,8 +378,8 @@ async fn assert_write_synced(meta_nodes: Vec<Arc<MetaNode>>, key: &str) -> anyho
                 txid: None,
                 cmd: Cmd::SetFile {
                     key: key.to_string(),
-                    value: key.to_string()
-                }
+                    value: key.to_string(),
+                },
             })
             .await?;
     }
@@ -397,7 +403,7 @@ async fn assert_applied_index(meta_nodes: Vec<Arc<MetaNode>>, at_least: u64) -> 
         wait_for_applied(
             &format!("n{}", i,),
             &mut mn.sto.applied_rx.clone(),
-            at_least
+            at_least,
         )
         .await;
     }
@@ -407,7 +413,7 @@ async fn assert_applied_index(meta_nodes: Vec<Arc<MetaNode>>, at_least: u64) -> 
 async fn assert_get_file(
     meta_nodes: Vec<Arc<MetaNode>>,
     key: &str,
-    value: &str
+    value: &str,
 ) -> anyhow::Result<()> {
     for i in 0..meta_nodes.len() {
         let mn = meta_nodes[i].clone();
@@ -430,7 +436,9 @@ async fn assert_connection(addr: &str) -> anyhow::Result<()> {
 // wait for raft metrics to a state that satisfies `func`.
 #[tracing::instrument(level = "info", skip(func, mrx))]
 async fn wait_for<T>(msg: &str, mrx: &mut Receiver<RaftMetrics>, func: T) -> RaftMetrics
-where T: Fn(&RaftMetrics) -> bool {
+where
+    T: Fn(&RaftMetrics) -> bool,
+{
     loop {
         let latest = mrx.borrow().clone();
         tracing::info!("start wait for {:} metrics: {:?}", msg, latest);

--- a/fusestore/store/src/metrics/metric_service.rs
+++ b/fusestore/store/src/metrics/metric_service.rs
@@ -9,7 +9,7 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 use crate::configs::Config;
 
 pub struct MetricService {
-    conf: Config
+    conf: Config,
 }
 
 impl MetricService {


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

## Summary

`rustfmt` will not trim these commas by default. I think it's better to obey this behavior. Otherwise, many developers with `format-on-save` on will keep being bothered by IDE/Code Editor.

FYI, https://github.com/rust-dev-tools/fmt-rfcs/issues/42#issuecomment-263738648

## Changelog

- Other

## Related Issues

None.

## Test Plan

Unit Tests
Stateless Tests
