### PR TITLE
Fixed #581 : dummy metadata removed

### DIFF
--- a/fusequery/query/src/sql/plan_parser.rs
+++ b/fusequery/query/src/sql/plan_parser.rs
@@ -209,14 +209,7 @@ impl PlanParser {
             );
         }
 
-        // Schema with metadata(due to serde must set metadata).
-        let schema = Arc::new(DataSchema::new_with_metadata(
-            fields,
-            [("Key".to_string(), "Value".to_string())]
-                .iter()
-                .cloned()
-                .collect()
-        ));
+        let schema = DataSchemaRefExt::create(fields);
         Ok(PlanNode::CreateTable(CreateTablePlan {
             if_not_exists: create.if_not_exists,
             db,


### PR DESCRIPTION
## Summary

A simple fix that removes dummy metadata while constructing the plan for the `create table .... ` statement.

## Related Issues

Fixes #581

## Test Plan

Covered by existing tests
