### PR TITLE
DataBlock with constant column

### DIFF
--- a/common/aggregate_functions/src/aggregate_max.rs
+++ b/common/aggregate_functions/src/aggregate_max.rs
@@ -50,14 +50,20 @@ impl IAggregateFunction for AggregateMaxFunction {
     }
 
     fn accumulate(&mut self, columns: &[DataColumnarValue], _input_rows: usize) -> Result<()> {
+        let value = match &columns[0] {
+            DataColumnarValue::Array(array) => DataArrayAggregate::data_array_aggregate_op(
+                DataValueAggregateOperator::Max,
+                array.clone()
+            ),
+            DataColumnarValue::Constant(s, _) => Ok(s.clone())
+        }?;
+
         self.state = DataValueAggregate::data_value_aggregate_op(
             DataValueAggregateOperator::Max,
             self.state.clone(),
-            DataArrayAggregate::data_array_aggregate_op(
-                DataValueAggregateOperator::Max,
-                columns[0].to_array()?
-            )?
+            value
         )?;
+
         Ok(())
     }
 

--- a/common/aggregate_functions/src/aggregate_min.rs
+++ b/common/aggregate_functions/src/aggregate_min.rs
@@ -50,14 +50,20 @@ impl IAggregateFunction for AggregateMinFunction {
     }
 
     fn accumulate(&mut self, columns: &[DataColumnarValue], _input_rows: usize) -> Result<()> {
+        let value = match &columns[0] {
+            DataColumnarValue::Array(array) => DataArrayAggregate::data_array_aggregate_op(
+                DataValueAggregateOperator::Min,
+                array.clone()
+            ),
+            DataColumnarValue::Constant(s, _) => Ok(s.clone())
+        }?;
+
         self.state = DataValueAggregate::data_value_aggregate_op(
             DataValueAggregateOperator::Min,
             self.state.clone(),
-            DataArrayAggregate::data_array_aggregate_op(
-                DataValueAggregateOperator::Min,
-                columns[0].to_array()?
-            )?
+            value
         )?;
+
         Ok(())
     }
 

--- a/common/datablocks/src/data_block.rs
+++ b/common/datablocks/src/data_block.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use common_arrow::arrow;
 use common_arrow::arrow::record_batch::RecordBatch;
 use common_datavalues::DataArrayRef;
+use common_datavalues::DataColumnarValue;
 use common_datavalues::DataSchema;
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCodes;
@@ -19,11 +20,19 @@ use crate::pretty_format_blocks;
 #[derive(Clone)]
 pub struct DataBlock {
     schema: DataSchemaRef,
-    columns: Vec<DataArrayRef>
+    columns: Vec<DataColumnarValue>
 }
 
 impl DataBlock {
-    pub fn create(schema: DataSchemaRef, columns: Vec<DataArrayRef>) -> Self {
+    pub fn create(schema: DataSchemaRef, columns: Vec<DataColumnarValue>) -> Self {
+        DataBlock { schema, columns }
+    }
+
+    pub fn create_by_array(schema: DataSchemaRef, arrays: Vec<DataArrayRef>) -> Self {
+        let columns = arrays
+            .iter()
+            .map(|array| DataColumnarValue::Array(array.clone()))
+            .collect();
         DataBlock { schema, columns }
     }
 
@@ -37,7 +46,7 @@ impl DataBlock {
     pub fn empty_with_schema(schema: DataSchemaRef) -> Self {
         let mut columns = vec![];
         for f in schema.fields().iter() {
-            columns.push(arrow::array::new_empty_array(f.data_type()))
+            columns.push(arrow::array::new_empty_array(f.data_type()).into())
         }
         DataBlock { schema, columns }
     }
@@ -54,7 +63,7 @@ impl DataBlock {
         if self.columns.is_empty() {
             0
         } else {
-            self.columns[0].data().len()
+            self.columns[0].len()
         }
     }
 
@@ -67,15 +76,15 @@ impl DataBlock {
         self.columns.iter().map(|x| x.get_array_memory_size()).sum()
     }
 
-    pub fn column(&self, index: usize) -> &DataArrayRef {
+    pub fn column(&self, index: usize) -> &DataColumnarValue {
         &self.columns[index]
     }
 
-    pub fn columns(&self) -> &[DataArrayRef] {
+    pub fn columns(&self) -> &[DataColumnarValue] {
         &self.columns
     }
 
-    pub fn try_column_by_name(&self, name: &str) -> Result<&DataArrayRef> {
+    pub fn try_column_by_name(&self, name: &str) -> Result<&DataColumnarValue> {
         if name == "*" {
             Ok(&self.columns[0])
         } else {
@@ -84,7 +93,7 @@ impl DataBlock {
         }
     }
 
-    pub fn column_by_name(&self, name: &str) -> Option<&DataArrayRef> {
+    pub fn column_by_name(&self, name: &str) -> Option<&DataColumnarValue> {
         if self.is_empty() {
             return None;
         }
@@ -99,13 +108,27 @@ impl DataBlock {
             None
         }
     }
+
+    pub fn try_array_by_name(&self, name: &str) -> Result<DataArrayRef> {
+        if name == "*" {
+            self.columns[0].to_array()
+        } else {
+            let idx = self.schema.index_of(name)?;
+            self.columns[idx].to_array()
+        }
+    }
 }
 
 impl TryFrom<DataBlock> for RecordBatch {
     type Error = ErrorCodes;
 
     fn try_from(v: DataBlock) -> Result<RecordBatch> {
-        Ok(RecordBatch::try_new(v.schema.clone(), v.columns.clone())?)
+        let columns = v
+            .columns()
+            .iter()
+            .map(|c| c.to_array())
+            .collect::<Result<Vec<_>>>()?;
+        Ok(RecordBatch::try_new(v.schema.clone(), columns)?)
     }
 }
 
@@ -113,7 +136,10 @@ impl TryFrom<arrow::record_batch::RecordBatch> for DataBlock {
     type Error = ErrorCodes;
 
     fn try_from(v: arrow::record_batch::RecordBatch) -> Result<DataBlock> {
-        Ok(DataBlock::create(v.schema(), Vec::from(v.columns())))
+        Ok(DataBlock::create_by_array(
+            v.schema(),
+            Vec::from(v.columns())
+        ))
     }
 }
 

--- a/common/datablocks/src/data_block_debug.rs
+++ b/common/datablocks/src/data_block_debug.rs
@@ -87,8 +87,8 @@ fn create_table(results: &[DataBlock]) -> Result<Table> {
         for row in 0..batch.num_rows() {
             let mut cells = Vec::new();
             for col in 0..batch.num_columns() {
-                let column = batch.column(col);
-                cells.push(Cell::new(&array_value_to_string(&column, row)?));
+                let array = batch.column(col).to_array()?;
+                cells.push(Cell::new(&array_value_to_string(&array, row)?));
             }
             table.add_row(Row::new(cells));
         }

--- a/common/datablocks/src/data_block_kernel.rs
+++ b/common/datablocks/src/data_block_kernel.rs
@@ -2,9 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use common_arrow::arrow::array::Array;
 use common_arrow::arrow::array::UInt32Builder;
 use common_arrow::arrow::compute;
 use common_datavalues::DataArrayMerge;
+use common_datavalues::DataColumnarValue;
 use common_exception::ErrorCodes;
 use common_exception::Result;
 
@@ -22,13 +24,21 @@ impl DataBlock {
         batch_indices.append_slice(indices)?;
         let batch_indices = batch_indices.finish();
 
-        let takes = raw
+        let columns = raw
             .columns()
             .iter()
-            .map(|array| compute::take(array.as_ref(), &batch_indices, None).unwrap())
-            .collect::<Vec<_>>();
+            .map(|column| match column {
+                DataColumnarValue::Array(array) => {
+                    let taked_array = compute::take(array.as_ref(), &batch_indices, None)?;
+                    Ok(DataColumnarValue::Array(taked_array))
+                }
+                DataColumnarValue::Constant(v, _) => {
+                    Ok(DataColumnarValue::Constant(v.clone(), indices.len()))
+                }
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-        Ok(DataBlock::create(raw.schema().clone(), takes))
+        Ok(DataBlock::create(raw.schema().clone(), columns))
     }
 
     pub fn concat_blocks(blocks: &[DataBlock]) -> Result<DataBlock> {
@@ -43,16 +53,21 @@ impl DataBlock {
             }
         }
 
-        let mut values = Vec::with_capacity(first_block.num_columns());
+        let mut arrays = Vec::with_capacity(first_block.num_columns());
         for (i, _f) in blocks[0].schema().fields().iter().enumerate() {
             let mut arr = Vec::with_capacity(blocks.len());
             for block in blocks.iter() {
-                arr.push(block.column(i).as_ref());
+                arr.push(block.column(i).to_array()?);
             }
-            values.push(compute::concat(&arr)?);
+
+            let arr: Vec<&dyn Array> = arr.iter().map(|c| c.as_ref()).collect();
+            arrays.push(compute::concat(&arr)?);
         }
 
-        Ok(DataBlock::create(first_block.schema().clone(), values))
+        Ok(DataBlock::create_by_array(
+            first_block.schema().clone(),
+            arrays
+        ))
     }
 
     pub fn sort_block(
@@ -64,7 +79,7 @@ impl DataBlock {
             .iter()
             .map(|f| {
                 Ok(compute::SortColumn {
-                    values: block.try_column_by_name(&f.column_name)?.clone(),
+                    values: block.try_array_by_name(&f.column_name)?.clone(),
                     options: Some(compute::SortOptions {
                         descending: !f.asc,
                         nulls_first: f.nulls_first
@@ -74,13 +89,7 @@ impl DataBlock {
             .collect::<Result<Vec<_>>>()?;
 
         let indices = compute::lexsort_to_indices(&order_columns, limit)?;
-        let columns = block
-            .columns()
-            .iter()
-            .map(|c| compute::take(c.as_ref(), &indices, None))
-            .collect::<anyhow::Result<Vec<_>, _>>()?;
-
-        Ok(DataBlock::create(block.schema().clone(), columns))
+        DataBlock::block_take_by_indices(&block, indices.values())
     }
 
     pub fn merge_sort_block(
@@ -101,7 +110,7 @@ impl DataBlock {
         for block in [lhs, rhs].iter() {
             let columns = sort_columns_descriptions
                 .iter()
-                .map(|f| Ok(block.try_column_by_name(&f.column_name)?.clone()))
+                .map(|f| Ok(block.try_array_by_name(&f.column_name)?.clone()))
                 .collect::<Result<Vec<_>>>()?;
             sort_arrays.push(columns);
         }
@@ -128,10 +137,14 @@ impl DataBlock {
             .columns()
             .iter()
             .zip(rhs.columns().iter())
-            .map(|(a, b)| DataArrayMerge::merge_array(a, b, &indices))
+            .map(|(a, b)| {
+                let a = a.to_array()?;
+                let b = b.to_array()?;
+                DataArrayMerge::merge_array(&a, &b, &indices)
+            })
             .collect::<Result<Vec<_>>>()?;
 
-        Ok(DataBlock::create(lhs.schema().clone(), arrays))
+        Ok(DataBlock::create_by_array(lhs.schema().clone(), arrays))
     }
 
     pub fn merge_sort_blocks(

--- a/common/datablocks/src/data_block_kernel_test.rs
+++ b/common/datablocks/src/data_block_kernel_test.rs
@@ -15,7 +15,7 @@ fn test_data_block_kernel_take() -> anyhow::Result<()> {
         DataField::new("b", DataType::Utf8, false),
     ]);
 
-    let raw = DataBlock::create(schema.clone(), vec![
+    let raw = DataBlock::create_by_array(schema.clone(), vec![
         Arc::new(Int64Array::from(vec![1, 2, 3])),
         Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
     ]);
@@ -50,15 +50,15 @@ fn test_data_block_kernel_concat() -> anyhow::Result<()> {
     ]);
 
     let blocks = vec![
-        DataBlock::create(schema.clone(), vec![
+        DataBlock::create_by_array(schema.clone(), vec![
             Arc::new(Int64Array::from(vec![1, 2, 3])),
             Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
         ]),
-        DataBlock::create(schema.clone(), vec![
+        DataBlock::create_by_array(schema.clone(), vec![
             Arc::new(Int64Array::from(vec![4, 5, 6])),
             Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
         ]),
-        DataBlock::create(schema.clone(), vec![
+        DataBlock::create_by_array(schema.clone(), vec![
             Arc::new(Int64Array::from(vec![7, 8, 9])),
             Arc::new(StringArray::from(vec!["b1", "b2", "b3"])),
         ]),
@@ -100,7 +100,7 @@ fn test_data_block_sort() -> anyhow::Result<()> {
         DataField::new("b", DataType::Utf8, false),
     ]);
 
-    let raw = DataBlock::create(schema.clone(), vec![
+    let raw = DataBlock::create_by_array(schema.clone(), vec![
         Arc::new(Int64Array::from(vec![6, 4, 3, 2, 1, 7])),
         Arc::new(StringArray::from(vec!["b1", "b2", "b3", "b4", "b5", "b6"])),
     ]);

--- a/common/datablocks/src/data_block_test.rs
+++ b/common/datablocks/src/data_block_test.rs
@@ -23,7 +23,7 @@ fn test_data_block() -> anyhow::Result<()> {
     assert_eq!(3, block.column(0).len());
 
     assert_eq!(true, block.column_by_name("a").is_some());
-    assert_eq!(None, block.column_by_name("a_not_found"));
+    assert_eq!(true, block.column_by_name("a_not_found").is_none());
 
     Ok(())
 }

--- a/common/datablocks/src/data_block_test.rs
+++ b/common/datablocks/src/data_block_test.rs
@@ -12,7 +12,7 @@ fn test_data_block() -> anyhow::Result<()> {
 
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Int64, false)]);
 
-    let block = DataBlock::create(schema.clone(), vec![Arc::new(Int64Array::from(vec![
+    let block = DataBlock::create_by_array(schema.clone(), vec![Arc::new(Int64Array::from(vec![
         1, 2, 3,
     ]))]);
     assert_eq!(&schema, block.schema());

--- a/common/datavalues/src/data_columnar_value.rs
+++ b/common/datavalues/src/data_columnar_value.rs
@@ -23,6 +23,7 @@ pub enum DataColumnarValue {
 }
 
 impl DataColumnarValue {
+    #[inline]
     pub fn data_type(&self) -> DataType {
         let x = match self {
             DataColumnarValue::Array(v) => v.data_type().clone(),
@@ -39,6 +40,7 @@ impl DataColumnarValue {
         }
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         match self {
             DataColumnarValue::Array(array) => array.len(),
@@ -46,10 +48,36 @@ impl DataColumnarValue {
         }
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         match self {
             DataColumnarValue::Array(array) => array.len() == 0,
             DataColumnarValue::Constant(_, size) => *size == 0
+        }
+    }
+
+    #[inline]
+    pub fn get_array_memory_size(&self) -> usize {
+        match self {
+            DataColumnarValue::Array(array) => array.get_array_memory_size(),
+            DataColumnarValue::Constant(scalar, size) => scalar
+                .to_array_with_size(*size)
+                .and_then(|arr| Ok(arr.get_array_memory_size()))
+                .unwrap_or(0)
+        }
+    }
+
+    // kernels
+    #[inline]
+    pub fn limit(&self, keep: usize) -> Self {
+        match self {
+            // limited_columns.push(arrow::compute::limit(&block.column(i).to_array()?, keep));]
+            DataColumnarValue::Array(array) => {
+                DataColumnarValue::Array(arrow::compute::limit(array, keep))
+            }
+            DataColumnarValue::Constant(scalar, size) => {
+                Ok(DataColumnarValue::Constant(scalar, keep))
+            }
         }
     }
 }

--- a/common/datavalues/src/data_columnar_value.rs
+++ b/common/datavalues/src/data_columnar_value.rs
@@ -4,6 +4,7 @@
 
 use std::sync::Arc;
 
+use common_arrow::arrow;
 use common_arrow::arrow::datatypes::ArrowPrimitiveType;
 use common_exception::Result;
 
@@ -62,21 +63,21 @@ impl DataColumnarValue {
             DataColumnarValue::Array(array) => array.get_array_memory_size(),
             DataColumnarValue::Constant(scalar, size) => scalar
                 .to_array_with_size(*size)
-                .and_then(|arr| Ok(arr.get_array_memory_size()))
+                .map(|arr| arr.get_array_memory_size())
                 .unwrap_or(0)
         }
     }
 
     // kernels
     #[inline]
-    pub fn limit(&self, keep: usize) -> Self {
+    pub fn limit(&self, keep: usize) -> DataColumnarValue {
         match self {
             // limited_columns.push(arrow::compute::limit(&block.column(i).to_array()?, keep));]
             DataColumnarValue::Array(array) => {
                 DataColumnarValue::Array(arrow::compute::limit(array, keep))
             }
-            DataColumnarValue::Constant(scalar, size) => {
-                Ok(DataColumnarValue::Constant(scalar, keep))
+            DataColumnarValue::Constant(scalar, _) => {
+                DataColumnarValue::Constant(scalar.clone(), keep)
             }
         }
     }

--- a/common/datavalues/src/data_value_kernel.rs
+++ b/common/datavalues/src/data_value_kernel.rs
@@ -8,6 +8,7 @@ use common_exception::ErrorCodes;
 use common_exception::Result;
 
 use crate::DataArrayRef;
+use crate::DataColumnarValue;
 use crate::DataValue;
 
 impl DataValue {
@@ -186,6 +187,15 @@ impl DataValue {
         }
     }
 
+    #[inline]
+    pub fn try_from_column(column: &DataColumnarValue, index: usize) -> Result<DataValue> {
+        match column {
+            DataColumnarValue::Constant(scalar, _) => Ok(scalar.clone()),
+            DataColumnarValue::Array(array) => try_from_array(array, index)
+        }
+    }
+
+    #[inline]
     /// Converts a value in `array` at `index` into a ScalarValue
     pub fn try_from_array(array: &DataArrayRef, index: usize) -> Result<DataValue> {
         match array.data_type() {

--- a/common/datavalues/src/data_value_kernel_test.rs
+++ b/common/datavalues/src/data_value_kernel_test.rs
@@ -33,8 +33,8 @@ fn test_data_value_kernel_concat_row_key() -> anyhow::Result<()> {
             Arc::new(Float32Array::from(vec![4.0, 3.0])),
             Arc::new(Float64Array::from(vec![4.0, 3.0])),
         ],
-        expect: vec!["[2, 0, 0, 0, 0, 0, 0, 0, 120, 49, 1, 4, 0, 4, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 4, 4, 0, 4, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 64, 0, 0, 0, 0, 0, 0, 16, 64]", 
-                     "[2, 0, 0, 0, 0, 0, 0, 0, 120, 50, 2, 3, 0, 3, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 3, 0, 3, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 64, 0, 0, 0, 0, 0, 0, 8, 64]", 
+        expect: vec!["[2, 0, 0, 0, 0, 0, 0, 0, 120, 49, 1, 4, 0, 4, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 4, 4, 0, 4, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 64, 0, 0, 0, 0, 0, 0, 16, 64]",
+                     "[2, 0, 0, 0, 0, 0, 0, 0, 120, 50, 2, 3, 0, 3, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 3, 3, 0, 3, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 64, 0, 0, 0, 0, 0, 0, 8, 64]",
         ],
         error: vec![""],
     }];
@@ -43,7 +43,11 @@ fn test_data_value_kernel_concat_row_key() -> anyhow::Result<()> {
         for row in 0..2 {
             let mut key: Vec<u8> = vec![];
             for col in 0..t.args.len() {
-                DataValue::concat_row_to_one_key(&t.args[col], row, &mut key)?;
+                DataValue::concat_row_to_one_key(
+                    &DataColumnarValue::Array(t.args[col].clone()),
+                    row,
+                    &mut key
+                )?;
             }
             assert_eq!(format!("{:?}", key), t.expect[row]);
         }

--- a/common/functions/src/function_column_test.rs
+++ b/common/functions/src/function_column_test.rs
@@ -12,16 +12,15 @@ use crate::*;
 #[test]
 fn test_column_function() -> anyhow::Result<()> {
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Boolean, false)]);
-    let block = DataBlock::create(schema.clone(), vec![Arc::new(BooleanArray::from(vec![
-        true, true, true, false,
-    ]))]);
+    let block =
+        DataBlock::create_by_array(schema.clone(), vec![Arc::new(BooleanArray::from(vec![
+            true, true, true, false,
+        ]))]);
 
     // Ok.
     {
         let col = ColumnFunction::try_create("a")?;
-        let columns = vec![DataColumnarValue::Array(
-            block.try_column_by_name("a")?.clone()
-        )];
+        let columns = vec![block.try_column_by_name("a")?.clone()];
         let _ = col.eval(&columns, block.num_rows())?;
     }
 

--- a/common/streams/src/stream_limit.rs
+++ b/common/streams/src/stream_limit.rs
@@ -5,7 +5,6 @@
 use std::task::Context;
 use std::task::Poll;
 
-use common_arrow::arrow;
 use common_datablocks::DataBlock;
 use common_exception::Result;
 use futures::Stream;
@@ -43,7 +42,7 @@ impl LimitStream {
             for i in 0..block.num_columns() {
                 limited_columns.push(block.column(i).limit(keep));
             }
-            Ok(Some(DataBlock::create_by_array(
+            Ok(Some(DataBlock::create(
                 block.schema().clone(),
                 limited_columns
             )))

--- a/common/streams/src/stream_limit.rs
+++ b/common/streams/src/stream_limit.rs
@@ -41,9 +41,9 @@ impl LimitStream {
 
             let mut limited_columns = Vec::with_capacity(block.num_columns());
             for i in 0..block.num_columns() {
-                limited_columns.push(arrow::compute::limit(block.column(i), keep));
+                limited_columns.push(block.column(i).limit(keep));
             }
-            Ok(Some(DataBlock::create(
+            Ok(Some(DataBlock::create_by_array(
                 block.schema().clone(),
                 limited_columns
             )))

--- a/common/streams/src/stream_progress_test.rs
+++ b/common/streams/src/stream_progress_test.rs
@@ -15,7 +15,7 @@ async fn test_progress_stream() -> anyhow::Result<()> {
 
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Int64, false)]);
 
-    let block = DataBlock::create(schema.clone(), vec![Arc::new(Int64Array::from(vec![
+    let block = DataBlock::create_by_array(schema.clone(), vec![Arc::new(Int64Array::from(vec![
         1, 2, 3,
     ]))]);
 

--- a/fusequery/query/src/datasources/system/clusters_table.rs
+++ b/fusequery/query/src/datasources/system/clusters_table.rs
@@ -80,7 +80,7 @@ impl ITable for ClustersTable {
         let names: Vec<&str> = nodes.iter().map(|x| x.name.as_str()).collect();
         let addresses: Vec<&str> = nodes.iter().map(|x| x.address.as_str()).collect();
         let priorities: Vec<u8> = nodes.iter().map(|x| x.priority).collect();
-        let block = DataBlock::create(self.schema.clone(), vec![
+        let block = DataBlock::create_by_array(self.schema.clone(), vec![
             Arc::new(StringArray::from(names)),
             Arc::new(StringArray::from(addresses)),
             Arc::new(UInt8Array::from(priorities)),

--- a/fusequery/query/src/datasources/system/contributors_table.rs
+++ b/fusequery/query/src/datasources/system/contributors_table.rs
@@ -75,9 +75,9 @@ impl ITable for ContributorsTable {
             .split_terminator(',')
             .map(|x| x.trim())
             .collect();
-        let block = DataBlock::create(self.schema.clone(), vec![Arc::new(StringArray::from(
-            contributors
-        ))]);
+        let block = DataBlock::create_by_array(self.schema.clone(), vec![Arc::new(
+            StringArray::from(contributors)
+        )]);
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,

--- a/fusequery/query/src/datasources/system/databases_table.rs
+++ b/fusequery/query/src/datasources/system/databases_table.rs
@@ -79,7 +79,7 @@ impl ITable for DatabasesTable {
                     .map(|database_name| database_name.as_str())
                     .collect();
 
-                let block = DataBlock::create(self.schema.clone(), vec![Arc::new(
+                let block = DataBlock::create_by_array(self.schema.clone(), vec![Arc::new(
                     StringArray::from(databases_name_str)
                 )]);
 

--- a/fusequery/query/src/datasources/system/functions_table.rs
+++ b/fusequery/query/src/datasources/system/functions_table.rs
@@ -74,9 +74,9 @@ impl ITable for FunctionsTable {
     async fn read(&self, _ctx: FuseQueryContextRef) -> Result<SendableDataBlockStream> {
         let func_names = FunctionFactory::registered_names();
         let names: Vec<&str> = func_names.iter().map(|x| x.as_ref()).collect();
-        let block = DataBlock::create(self.schema.clone(), vec![Arc::new(StringArray::from(
-            names
-        ))]);
+        let block = DataBlock::create_by_array(self.schema.clone(), vec![Arc::new(
+            StringArray::from(names)
+        )]);
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,

--- a/fusequery/query/src/datasources/system/numbers_stream.rs
+++ b/fusequery/query/src/datasources/system/numbers_stream.rs
@@ -108,7 +108,7 @@ impl NumbersStream {
                     .add_buffer(buffer)
                     .build();
 
-                let block = DataBlock::create(self.schema.clone(), vec![Arc::new(
+                let block = DataBlock::create_by_array(self.schema.clone(), vec![Arc::new(
                     UInt64Array::from(arr_data)
                 )]);
                 Some(block)

--- a/fusequery/query/src/datasources/system/one_table.rs
+++ b/fusequery/query/src/datasources/system/one_table.rs
@@ -71,9 +71,9 @@ impl ITable for OneTable {
     }
 
     async fn read(&self, _: FuseQueryContextRef) -> Result<SendableDataBlockStream> {
-        let block = DataBlock::create(self.schema.clone(), vec![Arc::new(UInt8Array::from(vec![
-            1u8,
-        ]))]);
+        let block = DataBlock::create_by_array(self.schema.clone(), vec![Arc::new(
+            UInt8Array::from(vec![1u8])
+        )]);
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,

--- a/fusequery/query/src/datasources/system/settings_table.rs
+++ b/fusequery/query/src/datasources/system/settings_table.rs
@@ -96,7 +96,7 @@ impl ITable for SettingsTable {
         let values: Vec<&str> = values.iter().map(|x| x.as_str()).collect();
         let default_values: Vec<&str> = default_values.iter().map(|x| x.as_str()).collect();
         let descs: Vec<&str> = descs.iter().map(|x| x.as_str()).collect();
-        let block = DataBlock::create(self.schema.clone(), vec![
+        let block = DataBlock::create_by_array(self.schema.clone(), vec![
             Arc::new(StringArray::from(names)),
             Arc::new(StringArray::from(values)),
             Arc::new(StringArray::from(default_values)),

--- a/fusequery/query/src/datasources/system/tables_table.rs
+++ b/fusequery/query/src/datasources/system/tables_table.rs
@@ -81,7 +81,7 @@ impl ITable for TablesTable {
         let names: Vec<&str> = database_tables.iter().map(|(_, v)| v.name()).collect();
         let engines: Vec<&str> = database_tables.iter().map(|(_, v)| v.engine()).collect();
 
-        let block = DataBlock::create(self.schema.clone(), vec![
+        let block = DataBlock::create_by_array(self.schema.clone(), vec![
             Arc::new(StringArray::from(databases)),
             Arc::new(StringArray::from(names)),
             Arc::new(StringArray::from(engines)),

--- a/fusequery/query/src/interpreters/interpreter_explain.rs
+++ b/fusequery/query/src/interpreters/interpreter_explain.rs
@@ -54,9 +54,10 @@ impl IInterpreter for ExplainInterpreter {
             }
             _ => format!("{:?}", plan)
         };
-        let block = DataBlock::create(schema.clone(), vec![Arc::new(StringArray::from(vec![
-            result.as_str(),
-        ]))]);
+        let block =
+            DataBlock::create_by_array(schema.clone(), vec![Arc::new(StringArray::from(vec![
+                result.as_str(),
+            ]))]);
         debug!("Explain executor result: {:?}", block);
 
         Ok(Box::pin(DataBlockStream::create(schema, None, vec![block])))

--- a/fusequery/query/src/pipelines/transforms/transform_aggregator_final.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_aggregator_final.rs
@@ -67,7 +67,8 @@ impl IProcessor for AggregatorFinalTransform {
         while let Some(block) = stream.next().await {
             let block = block?;
             for (i, func) in funcs.iter_mut().enumerate() {
-                if let DataValue::Utf8(Some(col)) = DataValue::try_from_array(block.column(i), 0)? {
+                if let DataValue::Utf8(Some(col)) = DataValue::try_from_column(block.column(i), 0)?
+                {
                     let val: DataValue = serde_json::from_str(&col)?;
                     if let DataValue::Struct(states) = val {
                         func.merge(&states)?;

--- a/fusequery/query/src/pipelines/transforms/transform_aggregator_final.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_aggregator_final.rs
@@ -90,7 +90,10 @@ impl IProcessor for AggregatorFinalTransform {
 
         let mut blocks = vec![];
         if !final_result.is_empty() {
-            blocks.push(DataBlock::create(self.schema.clone(), final_result));
+            blocks.push(DataBlock::create_by_array(
+                self.schema.clone(),
+                final_result
+            ));
         }
 
         Ok(Box::pin(DataBlockStream::create(

--- a/fusequery/query/src/pipelines/transforms/transform_aggregator_partial.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_aggregator_partial.rs
@@ -99,7 +99,7 @@ impl IProcessor for AggregatorPartialTransform {
             columns.push(col);
         }
 
-        let block = DataBlock::create(self.schema.clone(), columns);
+        let block = DataBlock::create_by_array(self.schema.clone(), columns);
 
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),

--- a/fusequery/query/src/pipelines/transforms/transform_expression_executor.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_expression_executor.rs
@@ -75,9 +75,7 @@ impl ExpressionExecutor {
 
             match action {
                 ActionNode::Input(input) => {
-                    let column =
-                        DataColumnarValue::Array(block.try_column_by_name(&input.name)?.clone());
-
+                    let column = block.try_column_by_name(&input.name)?.clone();
                     column_map.insert(input.name.clone(), column);
                 }
                 ActionNode::Function(f) => {
@@ -129,10 +127,10 @@ impl ExpressionExecutor {
                     column_map.keys()
                 ))
             })?;
-            project_columns.push(column.to_array()?);
+            project_columns.push(column.clone());
         }
         // projection to remove unused columns
-        Ok(DataBlock::create_by_array(
+        Ok(DataBlock::create(
             self.output_schema.clone(),
             project_columns
         ))

--- a/fusequery/query/src/pipelines/transforms/transform_expression_executor.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_expression_executor.rs
@@ -132,7 +132,7 @@ impl ExpressionExecutor {
             project_columns.push(column.to_array()?);
         }
         // projection to remove unused columns
-        Ok(DataBlock::create(
+        Ok(DataBlock::create_by_array(
             self.output_schema.clone(),
             project_columns
         ))

--- a/fusequery/query/src/pipelines/transforms/transform_filter.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_filter.rs
@@ -88,7 +88,7 @@ impl IProcessor for FilterTransform {
          -> Result<DataBlock> {
             let block = block?;
             let filter_block = executor.execute(&block)?;
-            let filter_array = filter_block.try_column_by_name(column_name)?;
+            let filter_array = filter_block.try_column_by_name(column_name)?.to_array()?;
             // Downcast to boolean array
             let filter_array = datavalues::downcast_array!(filter_array, BooleanArray)?;
 

--- a/fusequery/query/src/pipelines/transforms/transform_groupby_final.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_groupby_final.rs
@@ -187,7 +187,7 @@ impl IProcessor for GroupByFinalTransform {
 
         let mut blocks = vec![];
         if !columns.is_empty() {
-            let block = DataBlock::create(self.schema.clone(), columns);
+            let block = DataBlock::create_by_array(self.schema.clone(), columns);
             blocks.push(block);
         }
 

--- a/fusequery/query/src/pipelines/transforms/transform_groupby_final.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_groupby_final.rs
@@ -93,14 +93,14 @@ impl IProcessor for GroupByFinalTransform {
             let block = block?;
             for row in 0..block.num_rows() {
                 if let DataValue::Binary(Some(group_key)) =
-                    DataValue::try_from_array(block.column(1 + aggr_funcs_len), row)?
+                    DataValue::try_from_column(block.column(1 + aggr_funcs_len), row)?
                 {
                     match groups.get_mut(&group_key) {
                         None => {
                             let mut funcs = aggr_funcs.clone();
                             for (i, func) in funcs.iter_mut().enumerate() {
                                 if let DataValue::Utf8(Some(col)) =
-                                    DataValue::try_from_array(block.column(i), row)?
+                                    DataValue::try_from_column(block.column(i), row)?
                                 {
                                     let val: DataValue = serde_json::from_str(&col)?;
                                     if let DataValue::Struct(states) = val {
@@ -111,7 +111,7 @@ impl IProcessor for GroupByFinalTransform {
                             groups.insert(group_key.clone(), funcs);
 
                             if let DataValue::Utf8(Some(col)) =
-                                DataValue::try_from_array(block.column(aggr_funcs_len), row)?
+                                DataValue::try_from_column(block.column(aggr_funcs_len), row)?
                             {
                                 let val: DataValue = serde_json::from_str(&col)?;
                                 if let DataValue::Struct(states) = val {
@@ -122,7 +122,7 @@ impl IProcessor for GroupByFinalTransform {
                         Some(funcs) => {
                             for (i, func) in funcs.iter_mut().enumerate() {
                                 if let DataValue::Utf8(Some(col)) =
-                                    DataValue::try_from_array(block.column(i), row)?
+                                    DataValue::try_from_column(block.column(i), row)?
                                 {
                                     let val: DataValue = serde_json::from_str(&col)?;
                                     if let DataValue::Struct(states) = val {

--- a/fusequery/query/src/pipelines/transforms/transform_groupby_partial.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_groupby_partial.rs
@@ -256,7 +256,7 @@ impl IProcessor for GroupByPartialTransform {
         }
         columns.push(Arc::new(group_key_builder.finish()));
 
-        let block = DataBlock::create(self.schema.clone(), columns);
+        let block = DataBlock::create_by_array(self.schema.clone(), columns);
         Ok(Box::pin(DataBlockStream::create(
             self.schema.clone(),
             None,

--- a/fusequery/query/src/pipelines/transforms/transform_groupby_partial.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_groupby_partial.rs
@@ -138,8 +138,8 @@ impl IProcessor for GroupByPartialTransform {
                 let mut group_key_len = 0;
                 for col in &group_columns {
                     let typ = col.data_type();
-                    if common_datavalues::is_integer(typ) {
-                        group_key_len += common_datavalues::numeric_byte_size(typ)?;
+                    if common_datavalues::is_integer(&typ) {
+                        group_key_len += common_datavalues::numeric_byte_size(&typ)?;
                     } else {
                         group_key_len += 4;
                     }
@@ -157,7 +157,7 @@ impl IProcessor for GroupByPartialTransform {
                         None => {
                             let mut group_values = Vec::with_capacity(group_key.len());
                             for col in &group_columns {
-                                group_values.push(DataValue::try_from_array(col, row)?);
+                                group_values.push(DataValue::try_from_column(col, row)?);
                             }
                             group_indices
                                 .insert(group_key.clone(), (vec![row as u32], group_values));

--- a/fusequery/query/src/servers/clickhouse/clickhouse_stream.rs
+++ b/fusequery/query/src/servers/clickhouse/clickhouse_stream.rs
@@ -34,68 +34,68 @@ impl ClickHouseStream {
         }
 
         for i in 0..block.num_columns() {
-            let column = block.column(i);
+            let column = block.column(i).to_array()?;
             let name = block.schema().field(i).name();
 
             match column.data_type() {
                 DataType::Int8 => {
-                    let data = build_primitive_column::<Int8Type>(column)?;
+                    let data = build_primitive_column::<Int8Type>(&column)?;
                     result = result.column(name, data);
                 }
                 DataType::Int16 => {
-                    let data = build_primitive_column::<Int16Type>(column)?;
+                    let data = build_primitive_column::<Int16Type>(&column)?;
                     result = result.column(name, data);
                 }
                 DataType::Int32 => {
-                    let data = build_primitive_column::<Int32Type>(column)?;
+                    let data = build_primitive_column::<Int32Type>(&column)?;
                     result = result.column(name, data);
                 }
                 DataType::Int64 => {
-                    let data = build_primitive_column::<Int64Type>(column)?;
+                    let data = build_primitive_column::<Int64Type>(&column)?;
                     result = result.column(name, data);
                 }
                 DataType::UInt8 => {
-                    let data = build_primitive_column::<UInt8Type>(column)?;
+                    let data = build_primitive_column::<UInt8Type>(&column)?;
                     result = result.column(name, data);
                 }
                 DataType::UInt16 => {
-                    let data = build_primitive_column::<UInt16Type>(column)?;
+                    let data = build_primitive_column::<UInt16Type>(&column)?;
                     result = result.column(name, data);
                 }
                 DataType::UInt32 => {
-                    let data = build_primitive_column::<UInt32Type>(column)?;
+                    let data = build_primitive_column::<UInt32Type>(&column)?;
                     result = result.column(name, data);
                 }
                 DataType::UInt64 => {
-                    let data = build_primitive_column::<UInt64Type>(column)?;
+                    let data = build_primitive_column::<UInt64Type>(&column)?;
                     result = result.column(name, data);
                 }
 
                 DataType::Float32 => {
-                    let data = build_primitive_column::<Float32Type>(column)?;
+                    let data = build_primitive_column::<Float32Type>(&column)?;
                     result = result.column(name, data);
                 }
                 DataType::Float64 => {
-                    let data = build_primitive_column::<Float64Type>(column)?;
+                    let data = build_primitive_column::<Float64Type>(&column)?;
                     result = result.column(name, data);
                 }
 
                 DataType::Date32 => {
-                    let data = build_primitive_column::<Date32Type>(column)?;
+                    let data = build_primitive_column::<Date32Type>(&column)?;
                     result = result.column(name, data);
                 }
                 DataType::Date64 => {
-                    let data = build_primitive_column::<Date64Type>(column)?;
+                    let data = build_primitive_column::<Date64Type>(&column)?;
                     result = result.column(name, data);
                 }
 
                 DataType::Boolean => {
-                    let data = build_boolean_column(column)?;
+                    let data = build_boolean_column(&column)?;
                     result = result.column(name, data);
                 }
 
                 DataType::Utf8 => {
-                    let data = build_string_column(column)?;
+                    let data = build_string_column(&column)?;
                     result = result.column(name, data);
                 }
 

--- a/fusequery/query/src/servers/mysql/endpoints/endpoint_on_query.rs
+++ b/fusequery/query/src/servers/mysql/endpoints/endpoint_on_query.rs
@@ -75,10 +75,10 @@ impl<'a, T: std::io::Write> IMySQLEndpoint<QueryResultWriter<'a, T>> for MySQLOn
                         for row_index in 0..rows_size {
                             let mut row = Vec::with_capacity(columns_size);
                             for column_index in 0..columns_size {
-                                let column = block.column(column_index);
+                                let column = block.column(column_index).to_array().unwrap();
                                 // We are already in convert_schema checks all supported to string columns
                                 // So `array_value_to_string(column, r).unwrap()` is safe.
-                                row.push(array_value_to_string(column, row_index).unwrap());
+                                row.push(array_value_to_string(&column, row_index).unwrap());
                             }
 
                             row_writer.write_row(row)?;

--- a/fusequery/query/src/sql/plan_parser.rs
+++ b/fusequery/query/src/sql/plan_parser.rs
@@ -300,7 +300,7 @@ impl PlanParser {
                         })
                         .collect::<Vec<_>>();
 
-                    DataBlock::create(schema.clone(), cols)
+                    DataBlock::create_by_array(schema.clone(), cols)
                 })
                 .collect();
             log::info!("data block is {:?}", blocks);

--- a/fusestore/store/src/api/rpc/flight_service_test.rs
+++ b/fusestore/store/src/api/rpc/flight_service_test.rs
@@ -204,7 +204,7 @@ async fn test_do_append() -> anyhow::Result<()> {
     let expected_rows = col0.data().len() * 2;
     let expected_cols = 2;
 
-    let block = DataBlock::create(schema.clone(), vec![col0, col1]);
+    let block = DataBlock::create_by_array(schema.clone(), vec![col0, col1]);
     let batches = vec![block.clone(), block];
     let num_batch = batches.len();
     let stream = futures::stream::iter(batches);

--- a/fusestore/store/src/data_part/appender_test.rs
+++ b/fusestore/store/src/data_part/appender_test.rs
@@ -36,7 +36,7 @@ mod test {
 
         let col0 = Arc::new(Int64Array::from(vec![0, 1, 2]));
         let col1 = Arc::new(StringArray::from(vec!["str1", "str2", "str3"]));
-        let block = DataBlock::create(schema.clone(), vec![col0.clone(), col1.clone()]);
+        let block = DataBlock::create_by_array(schema.clone(), vec![col0.clone(), col1.clone()]);
 
         let buffer = write_in_memory(block)?;
 


### PR DESCRIPTION
## Summary

Make DataBlock support constant columns.

## Changelog

- Improvement

## Related Issues

None

## Test Plan

Performance tests



`fusequery-v0.4.4-nightly-linux-x86_64 ` vs   `current`

Sum before:
```

SELECT sum(3)
FROM numbers(10000000000)

┌──────sum(3)─┐
│ 30000000000 │
└─────────────┘
↘ Progress: 10.00 billion rows, 80.07 GB (588.89 million rows/s., 4.72 GB/s.)
1 rows in set. Elapsed: 16.981 sec. Processed 10.00 billion rows, 80.07 GB (588.89 million rows/s., 4.72 GB/s.)
```


Sum after:

```
SELECT sum(3)
FROM numbers(10000000000)

┌──────sum(3)─┐
│ 30000000000 │
└─────────────┘
↙ Progress: 10.00 billion rows, 80.07 GB (27.57 billion rows/s., 220.76 GB/s.)
1 rows in set. Elapsed: 0.363 sec. Processed 10.00 billion rows, 80.07 GB (27.57 billion rows/s., 220.74 GB/s.)

```



Min before:
```
datafuse :) SELECT min(3)
:-] FROM numbers(10000000000);

SELECT min(3)
FROM numbers(10000000000)

┌─min(3)─┐
│      3 │
└────────┘
← Progress: 10.00 billion rows, 80.07 GB (669.27 million rows/s., 5.36 GB/s.)
1 rows in set. Elapsed: 14.942 sec. Processed 10.00 billion rows, 80.07 GB (669.27 million rows/s., 5.36 GB/s.)
```




Min after:
```
SELECT min(3)
FROM numbers(10000000000)


┌─min(3)─┐
│      3 │
└────────┘
↘ Progress: 10.00 billion rows, 80.07 GB (24.71 billion rows/s., 197.84 GB/s.)
1 rows in set. Elapsed: 0.405 sec. Processed 10.00 billion rows, 80.07 GB (24.71 billion rows/s., 197.83 GB/s.)
```



