### PR TITLE
Implements Feature 630

### DIFF
--- a/common/flights/src/lib.rs
+++ b/common/flights/src/lib.rs
@@ -12,6 +12,7 @@ pub use store_do_action::CreateDatabaseAction;
 pub use store_do_action::CreateDatabaseActionResult;
 pub use store_do_action::CreateTableAction;
 pub use store_do_action::CreateTableActionResult;
+pub use store_do_action::DataPartInfo;
 pub use store_do_action::DropDatabaseAction;
 pub use store_do_action::DropDatabaseActionResult;
 pub use store_do_action::DropTableAction;
@@ -20,10 +21,12 @@ pub use store_do_action::GetTableAction;
 pub use store_do_action::GetTableActionResult;
 pub use store_do_action::ReadPlanAction;
 pub use store_do_action::ReadPlanActionResult;
+pub use store_do_action::ScanPartitionAction;
+pub use store_do_action::ScanPartitionResult;
 pub use store_do_action::StoreDoAction;
 pub use store_do_action::StoreDoActionResult;
+pub use store_do_get::ReadAction;
 pub use store_do_get::StoreDoGet;
-// TODO refine these
 pub use store_do_put::get_do_put_meta;
 pub use store_do_put::set_do_put_meta;
 pub use store_do_put::AppendResult;
@@ -34,7 +37,7 @@ mod flight_token;
 mod store_client;
 mod store_do_action;
 mod store_do_get;
-pub mod store_do_put;
+mod store_do_put;
 
 // ProtoBuf generated files.
 #[allow(clippy::all)]

--- a/common/flights/src/store_client.rs
+++ b/common/flights/src/store_client.rs
@@ -285,12 +285,12 @@ impl StoreClient {
                             .send(flight_data_from_arrow_batch(&batch, &ipc_write_opt).1)
                             .await
                         {
-                            log::info!("failed to send flight-data to downstream, breaking out");
+                            log::error!("failed to send flight-data to downstream, breaking out");
                             break;
                         }
                     }
                     Err(e) => {
-                        log::info!(
+                        log::error!(
                             "failed to convert DataBlock to RecordBatch , breaking out, {:?}",
                             e
                         );

--- a/common/flights/src/store_do_action.rs
+++ b/common/flights/src/store_do_action.rs
@@ -13,7 +13,9 @@ use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
+use common_planners::Partition;
 use common_planners::ScanPlan;
+use common_planners::Statistics;
 use prost::Message;
 use tonic::Request;
 
@@ -71,6 +73,19 @@ pub struct GetTableActionResult {
     pub schema: DataSchemaRef,
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct ScanPartitionAction {
+    pub scan_plan: ScanPlan,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct DataPartInfo {
+    pub partition: Partition,
+    pub stats: Statistics,
+}
+
+pub type ScanPartitionResult = Option<Vec<DataPartInfo>>;
+
 // Action wrapper for do_action.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub enum StoreDoAction {
@@ -79,6 +94,7 @@ pub enum StoreDoAction {
     DropDatabase(DropDatabaseAction),
     CreateTable(CreateTableAction),
     DropTable(DropTableAction),
+    ScanPartition(ScanPartitionAction),
     GetTable(GetTableAction),
 }
 
@@ -89,6 +105,7 @@ pub enum StoreDoActionResult {
     DropDatabase(DropDatabaseActionResult),
     CreateTable(CreateTableActionResult),
     DropTable(DropTableActionResult),
+    ScanPartition(ScanPartitionResult),
     GetTable(GetTableActionResult),
 }
 

--- a/common/flights/src/store_do_get.rs
+++ b/common/flights/src/store_do_get.rs
@@ -18,7 +18,7 @@ pub struct ReadAction {
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ScanPartitionsAction {
-    pub can_plan: ScanPlan,
+    pub scan_plan: ScanPlan,
 }
 
 /// Pull a file. This is used to replicate data between store servers, which is only used internally.

--- a/common/flights/src/store_do_get.rs
+++ b/common/flights/src/store_do_get.rs
@@ -6,13 +6,19 @@
 use std::convert::TryInto;
 
 use common_arrow::arrow_flight::Ticket;
-use common_planners::Partitions;
+use common_planners::Partition;
 use common_planners::PlanNode;
+use common_planners::ScanPlan;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct ReadAction {
-    pub partition: Partitions,
+    pub partition: Partition,
     pub push_down: PlanNode,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct ScanPartitionsAction {
+    pub can_plan: ScanPlan,
 }
 
 /// Pull a file. This is used to replicate data between store servers, which is only used internally.

--- a/common/planners/src/plan_partition.rs
+++ b/common/planners/src/plan_partition.rs
@@ -4,7 +4,7 @@
 
 pub type Partitions = Vec<Partition>;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct Partition {
     pub name: String,
     pub version: u64,

--- a/common/planners/src/plan_read_datasource.rs
+++ b/common/planners/src/plan_read_datasource.rs
@@ -21,6 +21,7 @@ pub struct ReadDataSourcePlan {
     pub statistics: Statistics,
     pub description: String,
     pub scan_plan: Arc<ScanPlan>,
+    pub remote: bool,
 }
 
 impl ReadDataSourcePlan {
@@ -33,6 +34,7 @@ impl ReadDataSourcePlan {
             statistics: Statistics::default(),
             description: "".to_string(),
             scan_plan: Arc::new(ScanPlan::empty()),
+            remote: false,
         }
     }
 

--- a/common/planners/src/plan_statistics.rs
+++ b/common/planners/src/plan_statistics.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq)]
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Debug)]
 pub struct Statistics {
     /// Total rows of the query read.
     pub read_rows: usize,

--- a/common/planners/src/test.rs
+++ b/common/planners/src/test.rs
@@ -43,6 +43,7 @@ impl Test {
                 statistics.read_rows, statistics.read_bytes
             ),
             scan_plan: Arc::new(ScanPlan::empty()),
+            remote: false,
         }))
     }
 

--- a/common/streams/src/stream.rs
+++ b/common/streams/src/stream.rs
@@ -6,4 +6,4 @@ use common_datablocks::DataBlock;
 use common_exception::Result;
 
 pub type SendableDataBlockStream =
-    std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<DataBlock>> + Sync + Send>>;
+    std::pin::Pin<Box<dyn futures::stream::Stream<Item = Result<DataBlock>> + Send>>;

--- a/fusequery/query/src/datasources/datasource.rs
+++ b/fusequery/query/src/datasources/datasource.rs
@@ -11,12 +11,14 @@ use common_infallible::RwLock;
 use common_planners::CreateDatabasePlan;
 use common_planners::DatabaseEngineType;
 use common_planners::DropDatabasePlan;
+use common_planners::TableOptions;
 
 use crate::configs::Config;
 use crate::datasources::local::LocalDatabase;
 use crate::datasources::local::LocalFactory;
 use crate::datasources::remote::RemoteDatabase;
 use crate::datasources::remote::RemoteFactory;
+use crate::datasources::remote::RemoteTable;
 use crate::datasources::system::SystemFactory;
 use crate::datasources::IDatabase;
 use crate::datasources::ITable;
@@ -31,11 +33,17 @@ pub trait IDataSource: Sync + Send {
     fn get_table_function(&self, name: &str) -> Result<Arc<dyn ITableFunction>>;
     async fn create_database(&self, plan: CreateDatabasePlan) -> Result<()>;
     async fn drop_database(&self, plan: DropDatabasePlan) -> Result<()>;
+
+    // This is an adhoc solution for the metadata syncing problem, far from elegant. let's tweak this later.
+    //
+    // The reason of not extending IDataSource::get_table (e.g. by adding a remote_hint parameter):
+    // Implementation of fetching remote table involves async operations which is not
+    // straight forward (but not infeasible) to do in a non-async method.
+    async fn get_remote_table(&self, db_name: &str, table_name: &str) -> Result<Arc<dyn ITable>>;
 }
 
 // Maintain all the databases of user.
 pub struct DataSource {
-    // conf: Config,
     databases: RwLock<HashMap<String, Arc<dyn IDatabase>>>,
     table_functions: RwLock<HashMap<String, Arc<dyn ITableFunction>>>,
     remote_factory: RemoteFactory,
@@ -130,6 +138,36 @@ impl IDataSource for DataSource {
 
         let table = database.get_table(table_name)?;
         Ok(table.clone())
+    }
+
+    async fn get_remote_table(&self, db_name: &str, table_name: &str) -> Result<Arc<dyn ITable>> {
+        match self.get_table(db_name, table_name) {
+            Ok(t) if t.is_local() => Err(ErrorCodes::LogicalError(format!(
+                "local table {}.{} exists, which is used as remote",
+                db_name, table_name
+            ))),
+            tbl @ Ok(_) => tbl,
+            _ => {
+                let cli_provider = self.remote_factory.store_client_provider();
+                let mut store_cli = cli_provider.try_get_client().await?;
+                let res = store_cli
+                    .get_table(db_name.to_string(), table_name.to_string())
+                    .await?;
+                let remote_table = RemoteTable::try_create(
+                    db_name.to_string(),
+                    table_name.to_string(),
+                    res.schema,
+                    self.remote_factory.store_client_provider().clone(),
+                    TableOptions::new(),
+                )?;
+
+                // Remote_table we've got here is NOT cached.
+                //
+                // Since we should solve the metadata synchronization problem in a more reasonable way,
+                // let's postpone it until we have taken all the things into account.
+                Ok(Arc::from(remote_table))
+            }
+        }
     }
 
     fn get_all_tables(&self) -> Result<Vec<(String, Arc<dyn ITable>)>> {

--- a/fusequery/query/src/datasources/local/csv_table.rs
+++ b/fusequery/query/src/datasources/local/csv_table.rs
@@ -105,6 +105,7 @@ impl ITable for CsvTable {
             statistics: Statistics::default(),
             description: format!("(Read from CSV Engine table  {}.{})", self.db, self.name),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/datasources/local/null_table.rs
+++ b/fusequery/query/src/datasources/local/null_table.rs
@@ -76,6 +76,7 @@ impl ITable for NullTable {
             statistics: Statistics::default(),
             description: format!("(Read from Null Engine table  {}.{})", self.db, self.name),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/datasources/local/parquet_table.rs
+++ b/fusequery/query/src/datasources/local/parquet_table.rs
@@ -143,6 +143,7 @@ impl ITable for ParquetTable {
                 self.db, self.name
             ),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/datasources/remote/mod.rs
+++ b/fusequery/query/src/datasources/remote/mod.rs
@@ -4,7 +4,10 @@
 mod remote_database;
 mod remote_factory;
 mod remote_table;
+mod remote_table_do_read;
 mod store_client_provider;
 
 pub use remote_database::RemoteDatabase;
 pub use remote_factory::RemoteFactory;
+pub use remote_table::RemoteTable;
+pub use store_client_provider::StoreClientProvider;

--- a/fusequery/query/src/datasources/remote/remote_table.rs
+++ b/fusequery/query/src/datasources/remote/remote_table.rs
@@ -3,30 +3,34 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 use std::any::Any;
+use std::sync::mpsc::channel;
+use std::sync::Arc;
 
 use common_datavalues::DataSchemaRef;
 use common_exception::ErrorCodes;
 use common_exception::Result;
+use common_flights::ScanPartitionResult;
 use common_planners::InsertIntoPlan;
+use common_planners::Partition;
 use common_planners::ReadDataSourcePlan;
 use common_planners::ScanPlan;
+use common_planners::Statistics;
 use common_planners::TableOptions;
 use common_streams::SendableDataBlockStream;
 
-use crate::datasources::remote::store_client_provider::StoreClientProvider;
+use crate::datasources::remote::StoreClientProvider;
 use crate::datasources::ITable;
 use crate::sessions::FuseQueryContextRef;
 
 #[allow(dead_code)]
 pub struct RemoteTable {
     pub(crate) db: String,
-    name: String,
-    schema: DataSchemaRef,
-    store_client_provider: StoreClientProvider,
+    pub(crate) name: String,
+    pub(crate) schema: DataSchemaRef,
+    pub(crate) store_client_provider: StoreClientProvider,
 }
 
 impl RemoteTable {
-    #[allow(dead_code)]
     pub fn try_create(
         db: String,
         name: String,
@@ -68,23 +72,43 @@ impl ITable for RemoteTable {
 
     fn read_plan(
         &self,
-        _ctx: FuseQueryContextRef,
-        _scan: &ScanPlan,
+        ctx: FuseQueryContextRef,
+        scan: &ScanPlan,
         _partitions: usize,
     ) -> Result<ReadDataSourcePlan> {
-        Result::Err(ErrorCodes::UnImplement(
-            "RemoteTable read_plan not yet implemented",
-        ))
+        // Change this method to async at current stage might be harsh
+        let (tx, rx) = channel();
+        let cli_provider = self.store_client_provider.clone();
+        let db_name = self.db.clone();
+        let tbl_name = self.name.clone();
+        {
+            let scan = scan.clone();
+            ctx.execute_task(async move {
+                match cli_provider.try_get_client().await {
+                    Ok(mut client) => {
+                        let parts_info = client
+                            .scan_partition(db_name, tbl_name, &scan)
+                            .await
+                            .map_err(ErrorCodes::from);
+                        let _ = tx.send(parts_info);
+                    }
+                    Err(e) => {
+                        let _ = tx.send(Err(e));
+                    }
+                }
+            });
+        }
+
+        rx.recv()
+            .map_err(ErrorCodes::from_std_error)?
+            .map(|v| self.partitions_to_plan(v, scan.clone()))
     }
 
-    async fn read(&self, _ctx: FuseQueryContextRef) -> Result<SendableDataBlockStream> {
-        Result::Err(ErrorCodes::UnImplement(
-            "RemoteTable read not yet implemented",
-        ))
+    async fn read(&self, ctx: FuseQueryContextRef) -> Result<SendableDataBlockStream> {
+        self.do_read(ctx).await
     }
 
     async fn append_data(&self, _ctx: FuseQueryContextRef, plan: InsertIntoPlan) -> Result<()> {
-        // goes like this
         let opt_stream = {
             let mut inner = plan.input_stream.lock().unwrap();
             (*inner).take()
@@ -94,7 +118,7 @@ impl ITable for RemoteTable {
             let block_stream =
                 opt_stream.ok_or_else(|| ErrorCodes::EmptyData("input stream consumed"))?;
             let mut client = self.store_client_provider.try_get_client().await?;
-            (client)
+            client
                 .append_data(
                     plan.db_name.clone(),
                     plan.tbl_name.clone(),
@@ -105,5 +129,41 @@ impl ITable for RemoteTable {
         }
 
         Ok(())
+    }
+}
+
+impl RemoteTable {
+    fn partitions_to_plan(
+        &self,
+        res: ScanPartitionResult,
+        scan_plan: ScanPlan,
+    ) -> ReadDataSourcePlan {
+        let mut partitions = vec![];
+        let mut statistics = Statistics {
+            read_rows: 0,
+            read_bytes: 0,
+        };
+
+        if let Some(parts) = res {
+            for part in parts {
+                partitions.push(Partition {
+                    name: part.partition.name,
+                    version: 0,
+                });
+                statistics.read_rows += part.stats.read_rows;
+                statistics.read_bytes += part.stats.read_bytes;
+            }
+        }
+
+        ReadDataSourcePlan {
+            db: self.db.clone(),
+            table: self.name.clone(),
+            schema: self.schema.clone(),
+            partitions,
+            statistics,
+            description: "".to_string(),
+            scan_plan: Arc::new(scan_plan),
+            remote: true,
+        }
     }
 }

--- a/fusequery/query/src/datasources/remote/remote_table_do_read.rs
+++ b/fusequery/query/src/datasources/remote/remote_table_do_read.rs
@@ -1,0 +1,65 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use common_exception::ErrorCodes;
+use common_exception::Result;
+use common_flights::ReadAction;
+use common_planners::PlanNode;
+use common_planners::ReadDataSourcePlan;
+use common_streams::ProgressStream;
+use common_streams::SendableDataBlockStream;
+use futures::StreamExt;
+
+use crate::datasources::remote::remote_table::RemoteTable;
+use crate::sessions::FuseQueryContextRef;
+
+impl RemoteTable {
+    #[inline]
+    pub(super) async fn do_read(
+        &self,
+        ctx: FuseQueryContextRef,
+    ) -> Result<SendableDataBlockStream> {
+        let client = self.store_client_provider.try_get_client().await?;
+        let schema = self.schema.clone();
+        let db = self.db.to_string();
+        let tbl = self.name.to_string();
+        let progress_callback = ctx.progress_callback();
+
+        let iter = std::iter::from_fn(move || match ctx.try_get_partitions(1) {
+            Err(_) => None,
+            Ok(parts) if parts.is_empty() => None,
+            Ok(parts) => Some(ReadAction {
+                partition: parts[0].clone(),
+                push_down: PlanNode::ReadSource(ReadDataSourcePlan {
+                    db: db.clone(),
+                    table: tbl.clone(),
+                    schema: schema.clone(),
+                    remote: true,
+                    ..ReadDataSourcePlan::empty()
+                }),
+            }),
+        });
+
+        let schema = self.schema.clone();
+        let parts = futures::stream::iter(iter);
+        let streams = parts.then(move |parts| {
+            let mut client = client.clone();
+            let schema = schema.clone();
+            async move {
+                let r = client.read_partition(schema, &parts).await;
+                r.unwrap_or_else(|e| {
+                    Box::pin(futures::stream::once(async move {
+                        Err(ErrorCodes::CannotReadFile(format!(
+                            "get partition failure. partition [{:?}], error {}",
+                            &parts, e
+                        )))
+                    }))
+                })
+            }
+        });
+
+        let stream = ProgressStream::try_create(Box::pin(streams.flatten()), progress_callback?)?;
+        Ok(Box::pin(stream))
+    }
+}

--- a/fusequery/query/src/datasources/system/clusters_table.rs
+++ b/fusequery/query/src/datasources/system/clusters_table.rs
@@ -80,6 +80,7 @@ impl ITable for ClustersTable {
             statistics: Statistics::default(),
             description: "(Read from system.clusters table)".to_string(),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/datasources/system/contributors_table.rs
+++ b/fusequery/query/src/datasources/system/contributors_table.rs
@@ -73,6 +73,7 @@ impl ITable for ContributorsTable {
             statistics: Statistics::default(),
             description: "(Read from system.contributors table)".to_string(),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/datasources/system/databases_table.rs
+++ b/fusequery/query/src/datasources/system/databases_table.rs
@@ -73,6 +73,7 @@ impl ITable for DatabasesTable {
             statistics: Statistics::default(),
             description: "(Read from system.databases table)".to_string(),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/datasources/system/functions_table.rs
+++ b/fusequery/query/src/datasources/system/functions_table.rs
@@ -74,6 +74,7 @@ impl ITable for FunctionsTable {
             statistics: Statistics::default(),
             description: "(Read from system.functions table)".to_string(),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/datasources/system/numbers_table.rs
+++ b/fusequery/query/src/datasources/system/numbers_table.rs
@@ -113,6 +113,7 @@ impl ITable for NumbersTable {
                 self.table, statistics.read_rows, statistics.read_bytes
             ),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/datasources/system/one_table.rs
+++ b/fusequery/query/src/datasources/system/one_table.rs
@@ -73,6 +73,7 @@ impl ITable for OneTable {
             statistics: Statistics::default(),
             description: "(Read from system.one table)".to_string(),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/datasources/system/settings_table.rs
+++ b/fusequery/query/src/datasources/system/settings_table.rs
@@ -79,6 +79,7 @@ impl ITable for SettingsTable {
             statistics: Statistics::default(),
             description: "(Read from system.settings table)".to_string(),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/datasources/system/tables_table.rs
+++ b/fusequery/query/src/datasources/system/tables_table.rs
@@ -77,6 +77,7 @@ impl ITable for TablesTable {
             statistics: Statistics::default(),
             description: "(Read from system.functions table)".to_string(),
             scan_plan: Arc::new(scan.clone()),
+            remote: false,
         })
     }
 

--- a/fusequery/query/src/interpreters/plan_scheduler.rs
+++ b/fusequery/query/src/interpreters/plan_scheduler.rs
@@ -217,6 +217,7 @@ impl GetNodePlan for RemoteReadSourceGetNodePlan {
             statistics: self.0.statistics.clone(),
             description: self.0.description.clone(),
             scan_plan: self.0.scan_plan.clone(),
+            remote: self.0.remote,
         }))
     }
 }

--- a/fusequery/query/src/optimizers/optimizer_constant_folding_test.rs
+++ b/fusequery/query/src/optimizers/optimizer_constant_folding_test.rs
@@ -41,6 +41,7 @@ mod tests {
                 statistics.read_bytes
             ),
             scan_plan: Arc::new(ScanPlan::empty()),
+            remote: false,
         });
 
         let filter_plan = PlanBuilder::from(&source_plan)

--- a/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
@@ -83,6 +83,7 @@ impl<'plan> PlanRewriter<'plan> for ProjectionPushDownImpl {
                     statistics: plan.statistics.clone(),
                     description: plan.description.to_string(),
                     scan_plan: plan.scan_plan.clone(),
+                    remote: plan.remote,
                 })
             })
     }

--- a/fusequery/query/src/optimizers/optimizer_projection_push_down_test.rs
+++ b/fusequery/query/src/optimizers/optimizer_projection_push_down_test.rs
@@ -96,6 +96,7 @@ fn test_projection_push_down_optimizer_2() -> anyhow::Result<()> {
             statistics.read_bytes
         ),
         scan_plan: Arc::new(ScanPlan::empty()),
+        remote: false,
     });
 
     let filter_plan = PlanBuilder::from(&source_plan)
@@ -152,6 +153,7 @@ fn test_projection_push_down_optimizer_3() -> anyhow::Result<()> {
             statistics.read_bytes
         ),
         scan_plan: Arc::new(ScanPlan::empty()),
+        remote: false,
     });
 
     let group_exprs = &[col("a"), col("c")];

--- a/fusequery/query/src/pipelines/processors/pipeline_builder.rs
+++ b/fusequery/query/src/pipelines/processors/pipeline_builder.rs
@@ -273,6 +273,7 @@ impl PipelineBuilder {
                 self.ctx.clone(),
                 plan.db.as_str(),
                 plan.table.as_str(),
+                plan.remote,
             )?;
             pipeline.add_source(Arc::new(source))?;
         }

--- a/fusequery/query/src/pipelines/transforms/transform_source.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_source.rs
@@ -17,14 +17,21 @@ pub struct SourceTransform {
     ctx: FuseQueryContextRef,
     db: String,
     table: String,
+    remote: bool,
 }
 
 impl SourceTransform {
-    pub fn try_create(ctx: FuseQueryContextRef, db: &str, table: &str) -> Result<Self> {
+    pub fn try_create(
+        ctx: FuseQueryContextRef,
+        db: &str,
+        table: &str,
+        remote: bool,
+    ) -> Result<Self> {
         Ok(SourceTransform {
             ctx,
             db: db.to_string(),
             table: table.to_string(),
+            remote,
         })
     }
 }
@@ -50,7 +57,14 @@ impl IProcessor for SourceTransform {
     }
 
     async fn execute(&self) -> Result<SendableDataBlockStream> {
-        let table = self.ctx.get_table(self.db.as_str(), self.table.as_str())?;
+        let table = if self.remote {
+            self.ctx
+                .get_remote_table(self.db.as_str(), self.table.as_str())
+                .await?
+        } else {
+            self.ctx.get_table(self.db.as_str(), self.table.as_str())?
+        };
+
         table.read(self.ctx.clone()).await
     }
 }

--- a/fusequery/query/src/sessions/context.rs
+++ b/fusequery/query/src/sessions/context.rs
@@ -166,6 +166,19 @@ impl FuseQueryContext {
         self.datasource.get_table(db_name, table_name)
     }
 
+    // This is an adhoc solution for the metadata syncing problem, far from elegant. let's tweak this later.
+    //
+    // The reason of not extending IDataSource::get_table (e.g. by adding a remote_hint parameter):
+    // Implementation of fetching remote table involves async operations which is not
+    // straight forward (but not infeasible) to do in a non-async method.
+    pub async fn get_remote_table(
+        &self,
+        db_name: &str,
+        table_name: &str,
+    ) -> Result<Arc<dyn ITable>> {
+        self.datasource.get_remote_table(db_name, table_name).await
+    }
+
     pub fn get_table_function(&self, function_name: &str) -> Result<Arc<dyn ITableFunction>> {
         self.datasource.get_table_function(function_name)
     }

--- a/fusequery/query/src/tests/number.rs
+++ b/fusequery/query/src/tests/number.rs
@@ -58,6 +58,6 @@ impl NumberTestData {
     pub fn number_source_transform_for_test(&self, numbers: i64) -> Result<SourceTransform> {
         let plan = self.number_read_source_plan_for_test(numbers)?;
         self.ctx.try_set_partitions(plan.partitions)?;
-        SourceTransform::try_create(self.ctx.clone(), self.db, self.table)
+        SourceTransform::try_create(self.ctx.clone(), self.db, self.table, false)
     }
 }

--- a/fusestore/store/src/api/rpc/flight_service_test.rs
+++ b/fusestore/store/src/api/rpc/flight_service_test.rs
@@ -4,8 +4,10 @@
 
 use common_arrow::arrow::array::ArrayRef;
 use common_datablocks::DataBlock;
+use common_datavalues::DataColumnarValue;
 use common_flights::GetTableActionResult;
 use common_flights::StoreClient;
+use common_planners::ScanPlan;
 use log::info;
 use pretty_assertions::assert_eq;
 use test_env_log::test;
@@ -243,5 +245,91 @@ async fn test_do_append() -> anyhow::Result<()> {
         assert_eq!(p.rows, expected_rows / num_batch);
         assert_eq!(p.cols, expected_cols);
     });
+    Ok(())
+}
+#[test(tokio::test)]
+async fn test_scan_partition() -> anyhow::Result<()> {
+    use std::sync::Arc;
+
+    use common_arrow::arrow::datatypes::DataType;
+    use common_datavalues::DataField;
+    use common_datavalues::DataSchema;
+    use common_datavalues::Int64Array;
+    use common_datavalues::StringArray;
+    use common_flights::StoreClient;
+    use common_planners::CreateDatabasePlan;
+    use common_planners::CreateTablePlan;
+    use common_planners::DatabaseEngineType;
+    use common_planners::TableEngineType;
+
+    let addr = crate::tests::start_store_server().await?;
+
+    let schema = Arc::new(DataSchema::new(vec![
+        DataField::new("col_i", DataType::Int64, false),
+        DataField::new("col_s", DataType::Utf8, false),
+    ]));
+    let db_name = "test_db";
+    let tbl_name = "test_tbl";
+
+    let col0: ArrayRef = Arc::new(Int64Array::from(vec![0, 1, 2]));
+    let col1: ArrayRef = Arc::new(StringArray::from(vec!["str1", "str2", "str3"]));
+
+    let expected_rows = col0.data().len() * 2;
+    let expected_cols = 2;
+
+    let block = DataBlock::create(schema.clone(), vec![
+        DataColumnarValue::Array(col0),
+        DataColumnarValue::Array(col1),
+    ]);
+    let batches = vec![block.clone(), block];
+    let num_batch = batches.len();
+    let stream = futures::stream::iter(batches);
+
+    let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
+    {
+        let plan = CreateDatabasePlan {
+            if_not_exists: false,
+            db: db_name.to_string(),
+            engine: DatabaseEngineType::Local,
+            options: Default::default(),
+        };
+        client.create_database(plan.clone()).await?;
+        let plan = CreateTablePlan {
+            if_not_exists: false,
+            db: db_name.to_string(),
+            table: tbl_name.to_string(),
+            schema: schema.clone(),
+            options: maplit::hashmap! {"opt‐1".into() => "val-1".into()},
+            engine: TableEngineType::Parquet,
+        };
+        client.create_table(plan.clone()).await?;
+    }
+    let res = client
+        .append_data(
+            db_name.to_string(),
+            tbl_name.to_string(),
+            schema,
+            Box::pin(stream),
+        )
+        .await?;
+    log::info!("append res is {:?}", res);
+    let summary = res.summary;
+    assert_eq!(summary.rows, expected_rows);
+    assert_eq!(res.parts.len(), num_batch);
+    res.parts.iter().for_each(|p| {
+        assert_eq!(p.rows, expected_rows / num_batch);
+        assert_eq!(p.cols, expected_cols);
+    });
+
+    let plan = ScanPlan {
+        schema_name: tbl_name.to_string(),
+        ..ScanPlan::empty()
+    };
+    let res = client
+        .scan_partition(db_name.to_string(), tbl_name.to_string(), &plan)
+        .await;
+    // TODO d assertions, de-duplicated codes
+    println!("scan res is {:?}", res);
+
     Ok(())
 }

--- a/fusestore/store/src/executor/action_handler.rs
+++ b/fusestore/store/src/executor/action_handler.rs
@@ -4,12 +4,19 @@
 
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use common_arrow::arrow::datatypes::Schema;
+use common_arrow::arrow::ipc::writer::IpcWriteOptions;
 use common_arrow::arrow_flight;
+use common_arrow::arrow_flight::utils::flight_data_from_arrow_batch;
 use common_arrow::arrow_flight::FlightData;
+use common_arrow::parquet::arrow::ArrowReader;
+use common_arrow::parquet::arrow::ParquetFileArrowReader;
+use common_arrow::parquet::file::reader::SerializedFileReader;
+use common_arrow::parquet::file::serialized_reader::SliceableCursor;
 use common_flights::CreateDatabaseAction;
 use common_flights::CreateDatabaseActionResult;
 use common_flights::CreateTableAction;
@@ -20,11 +27,12 @@ use common_flights::DropTableAction;
 use common_flights::DropTableActionResult;
 use common_flights::GetTableAction;
 use common_flights::GetTableActionResult;
+use common_flights::ReadAction;
+use common_flights::ScanPartitionAction;
 use common_flights::StoreDoAction;
 use common_flights::StoreDoActionResult;
-#[allow(unused_imports)]
-use log::error;
-#[allow(unused_imports)]
+use common_planners::PlanNode;
+use futures::Stream;
 use log::info;
 use tokio::sync::mpsc::Sender;
 use tokio_stream::StreamExt;
@@ -43,6 +51,9 @@ pub struct ActionHandler {
     meta: Arc<Mutex<MemEngine>>,
     fs: Arc<dyn IFileSystem>,
 }
+
+type DoGetStream =
+    Pin<Box<dyn Stream<Item = Result<FlightData, tonic::Status>> + Send + Sync + 'static>>;
 
 impl ActionHandler {
     pub fn create(fs: Arc<dyn IFileSystem>) -> Self {
@@ -82,6 +93,7 @@ impl ActionHandler {
             StoreDoAction::CreateTable(a) => self.create_table(a).await,
             StoreDoAction::DropTable(act) => self.drop_table(act).await,
             StoreDoAction::GetTable(a) => self.get_table(a).await,
+            StoreDoAction::ScanPartition(act) => self.scan_partitions(&act),
         }
     }
 
@@ -185,16 +197,13 @@ impl ActionHandler {
         let _ = meta.drop_table(&act.plan.db, &act.plan.table, act.plan.if_exists)?;
         Ok(StoreDoActionResult::DropTable(DropTableActionResult {}))
     }
-}
 
-impl ActionHandler {
     pub(crate) async fn do_put(
         &self,
         db_name: String,
         table_name: String,
         parts: Streaming<FlightData>,
     ) -> anyhow::Result<common_flights::AppendResult> {
-        log::info!("calling do_put");
         {
             let mut meta = self.meta.lock().unwrap();
             let _tbl_meta = meta.get_table(db_name.clone(), table_name.clone())?;
@@ -209,12 +218,75 @@ impl ActionHandler {
             .take_while(|item| item.is_ok())
             .map(|item| item.unwrap());
 
-        info!("calling appender");
         let res = appender
-            .append_data(db_name + "/" + &table_name, Box::pin(parts))
-            .await;
+            .append_data(format!("{}/{}", &db_name, &table_name), Box::pin(parts))
+            .await?;
 
-        info!("leaving with {:?}", res);
-        res
+        let mut meta = self.meta.lock().unwrap();
+        meta.append_data_parts(&db_name, &table_name, &res);
+        Ok(res)
+    }
+
+    fn scan_partitions(&self, cmd: &ScanPartitionAction) -> Result<StoreDoActionResult, Status> {
+        let schema = &cmd.scan_plan.schema_name;
+        let splits: Vec<&str> = schema.split('/').collect();
+        // TODO error handling
+        println!("schema {}, splits {:?}", schema, splits);
+        let db_name = splits[0];
+        let tbl_name = splits[1];
+
+        let meta = self.meta.lock().unwrap();
+        Ok(StoreDoActionResult::ScanPartition(
+            meta.get_data_parts(db_name, tbl_name),
+        ))
+    }
+
+    pub async fn read_partition(&self, action: ReadAction) -> anyhow::Result<DoGetStream> {
+        log::info!("entering read");
+        let part_file = action.partition.name;
+
+        let plan = if let PlanNode::ReadSource(read_source_plan) = action.push_down {
+            read_source_plan
+        } else {
+            anyhow::bail!("invalid PlanNode passed in")
+        };
+
+        let content = self.fs.read_all(part_file.to_string()).await?;
+        let cursor = SliceableCursor::new(content);
+
+        let file_reader = SerializedFileReader::new(cursor)?;
+        let mut arrow_reader = ParquetFileArrowReader::new(Arc::new(file_reader));
+
+        // before push_down is passed in, we returns all the columns
+        let schema = plan.schema;
+        let projection = (0..schema.fields().len()).collect::<Vec<_>>();
+
+        // TODO config
+        let batch_size = 2048;
+
+        let batch_reader = arrow_reader.get_record_reader_by_columns(projection, batch_size)?;
+
+        // For simplicity, we do the conversion in-memory, to be optimized later
+        // TODO consider using `parquet_table` and `stream_parquet`
+        let write_opt = IpcWriteOptions::default();
+        let flights =
+            batch_reader
+                .into_iter()
+                .map(|batch| {
+                    batch.map(
+                    |b| flight_data_from_arrow_batch(&b, &write_opt).1, /*dictionary ignored*/
+                ).map_err(|arrow_err| Status::internal(arrow_err.to_string()))
+                })
+                .collect::<Vec<_>>();
+        let stream = futures::stream::iter(flights);
+
+        // This is not gonna work, cause `ParquetFileArrowReader` and `ParquetFileArrowReader` are neither Send nor Sync
+        //
+        // # let stream = futures::stream::iter(reader.into_iter());
+        // # let stream =
+        // #     stream.map(move |batch| flight_data_from_arrow_batch(&batch.unwrap(), &write_opt).1);
+        // # let stream = stream.map(|v| Ok(v));
+
+        Ok(Box::pin(stream))
     }
 }

--- a/fusestore/store/src/fs/ifs.rs
+++ b/fusestore/store/src/fs/ifs.rs
@@ -19,7 +19,7 @@ where Self: Sync + Send
     async fn read_all<'a>(&'a self, path: String) -> anyhow::Result<Vec<u8>>;
 
     /// List dir and returns directories and files.
-    async fn list<'a>(&'a self, path: String) -> anyhow::Result<ListResult>;
+    async fn list(&self, path: String) -> anyhow::Result<ListResult>;
 
     // async fn read(
     //     path: &str,

--- a/tests/suites/0_stateless/09_0001_remote_insert.result
+++ b/tests/suites/0_stateless/09_0001_remote_insert.result
@@ -3,18 +3,23 @@ CREATE DATABASE IF NOT EXISTS db1
 --------------
 
 --------------
-CREATE TABLE IF NOT EXISTS t1(a int, b varchar)
+CREATE TABLE IF NOT EXISTS t1(a varchar, b varchar)
 --------------
 
 --------------
-INSERT INTO t1 VALUES(1, 'v1'),(2,'v2')
+INSERT INTO t1(a,b) VALUES('1', 'v1'),('2','v2')
 --------------
 
 --------------
 SELECT * FROM t1
 --------------
 
-ERROR 1105 (HY000) at line 6: Code: 2, displayText = RemoteTable read_plan not yet implemented.
++------+------+
+| a    | b    |
++------+------+
+| '1'  | 'v1' |
+| '2'  | 'v2' |
++------+------+
 --------------
 DROP TABLE t1
 --------------

--- a/tests/suites/0_stateless/09_0001_remote_insert.sql
+++ b/tests/suites/0_stateless/09_0001_remote_insert.sql
@@ -1,8 +1,8 @@
 CREATE DATABASE IF NOT EXISTS db1;
 USE db1;
 
-CREATE TABLE IF NOT EXISTS t1(a int, b varchar);
-INSERT INTO t1 VALUES(1, 'v1'),(2,'v2');
+CREATE TABLE IF NOT EXISTS t1(a varchar, b varchar);
+INSERT INTO t1(a,b) VALUES('1', 'v1'),('2','v2');
 SELECT * FROM t1;
 
 DROP TABLE t1;


### PR DESCRIPTION
## Summary

It's a baby step of integrating Store with Query, which implements

- update metadata after appending data parts to the table 
- remote table read_plan
- remote table read 

Basic statements like `insert into ... ` and `select .. from ...` could be executed now. (and lots of interesting things are left to do) 

## Changelog


- Store: implementions for ITable read_plan and read a5c42b2e5d14d042f3c3d928a35c625ca32f4410

 
- Query: implements RemoteTalbe's read_plan & read b55eacf912bc7985765b870ecd658d505eb75a56

 
- Adds remote flag to ReadDataSourcePlan deaea8ea29b4a6d4afb1390cdd3e0d3540b2597c

 
- Tweaks stateless test cases ed69c92fc37c01650f17478f4d6e446f828f74ad

 
The following issues might be worthy of your concern: 

- Remove trait bound Sync from SendableDataBlockStream ed69c92fc37c01650f17478f4d6e446f828f74ad
   
   Turns out, at least for now, we do not need this trait bound, and without `Sync` constraint, SendableDataBlockStream is more stream-combinator friendly.

-  Keep `ITable::read_plan` as a non-async method

   By using runtime of ctx (and channel). 
   IMHO, change `ITable::read_plan` to async fn may be too harsh at this stage.

-  Add an extra flag to `ReadDataSourcePlan` and `SourceTransform`

   So that we could be aware of operating a remote table(and fetch remote table accordingly). It is a temp workaround, let's postpone it until the `Catalog` API is ready. 
   `SourceTransform::execute` and `FuseQueryContext` are tweaked accordingly. pls see deaea8ea29b4a6d4afb1390cdd3e0d3540b2597c

## Related Issues

resolves #630 

## Test Plan

- UT & Stateless Testes

### Progress

- [x]  Update meta 
- [x]  Flight Service
- [x]  Store Client
- [x]  Remote table - read_plan
- [x]  Remote table - read (read partition)
- [x]  Unit tests & integration tests
- [x]  Multi-Node integration tests
- [x]  Code GC
- [x]  Squash commits
 
 

