### PR TITLE
Fix unexpected recompile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,8 +91,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow"
 version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cdf087304d5cdd743abd621b4b1b388848d29491932dae6f676ec89ebda0ae"
+source = "git+https://github.com/apache/arrow-rs?tag=4.1.0#a5dd428f57e62db20a945e8b1895de91405958c4"
 dependencies = [
  "cfg_aliases",
  "chrono",
@@ -114,8 +113,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be523cfd3669eee90aac4223cbc6fa8c4fd4cecf3281f061e5421e3e8aa91148"
+source = "git+https://github.com/apache/arrow-rs?tag=4.1.0#a5dd428f57e62db20a945e8b1895de91405958c4"
 dependencies = [
  "arrow",
  "bytes 1.0.1",
@@ -2486,8 +2484,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193b8db290021fa28a6447df8f433e39b3caab20ee08b874d0a5c1c34aef68de"
+source = "git+https://github.com/apache/arrow-rs?tag=4.1.0#a5dd428f57e62db20a945e8b1895de91405958c4"
 dependencies = [
  "arrow",
  "base64 0.13.0",

--- a/common/arrow/Cargo.toml
+++ b/common/arrow/Cargo.toml
@@ -10,9 +10,14 @@ edition = "2018"
 # Workspace dependencies
 
 # Github dependencies
-arrow = { version = "4.0" }
-arrow-flight = { version = "4.0" }
-parquet = { version = "4.0", features = ["arrow"] }
+
+# arrow = { version = "4.0" }
+# arrow-flight = { version = "4.0" }
+# parquet = { version = "4.0", features = ["arrow"] }
+
+arrow = { git="https://github.com/apache/arrow-rs", tag = "4.1.0" }
+arrow-flight = { git="https://github.com/apache/arrow-rs", tag = "4.1.0" }
+parquet = { git="https://github.com/apache/arrow-rs", tag = "4.1.0", features = ["arrow"] }
 
 # Crates.io dependencies
 


### PR DESCRIPTION
## Summary

fix: corgo recompiles every crate no matter file changes
`arrow-flight/build.rs` depends on an absent file, in a standalone crate:

>    println!("cargo:rerun-if-changed=../format/Flight.proto");

which causes this crate(and other crates depend on it, i.e., every crate in datafuse!) to be re-built every single time no matter whether a file changed.

See https://github.com/rust-lang/cargo/pull/8927/files#diff-197a732275c32bdbdb079bdd92ac8a4ba585ee556ea978e9e661804eb76ce9eeR229-R232

>  * A build script prints `cargo:rerun-if-changed=foo` where `foo` is a file that
>    doesn't exist and nothing generates it. In this case Cargo will keep running
>    the build script thinking it will generate the file but nothing ever does. The
>    fix is to avoid printing `rerun-if-changed` in this scenario.

In a packaged crate there is no such file `../format/Flight.proto`.

This problem is solved by referring to the git repo as the crate
source.

## Changelog


- Bug Fix



