### PR TITLE
standalone docker for testing

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,4 +7,7 @@ RUN make build
 
 FROM debian:buster
 COPY --from=builder /app/target/release/fuse-query /fuse-query
-ENTRYPOINT ["/fuse-query"]
+COPY --from=builder /app/target/release/fuse-store /fuse-store
+COPY --from=builder /app/scripts/deploy/config/fusequery-node-1.toml /fuse-query.toml
+COPY --from=builder /app/docker/bootstrap.sh /bootstrap.sh
+ENTRYPOINT ["/bootstrap.sh"]

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,0 +1,5 @@
+/fuse-store &
+P1=$!
+/fuse-query -c fuse-query.toml &
+P2=$!
+wait $P1 $P2


### PR DESCRIPTION
## Summary

Summary about this PR
integrate fusestore into current docker container, supposed to use for testing only because eventually, query and store should be deployed in seperate containers

## Changelog

- Build/Testing/CI


## Related Issues

Fixes #issue
resolve https://github.com/datafuselabs/datafuse/issues/639
## Test Plan

Unit Tests
Stateless Tests

