### PR TITLE
[building] refine: building helper crate: common/building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "common-building"
+version = "0.1.0"
+dependencies = [
+ "run_script",
+ "vergen",
+]
+
+[[package]]
 name = "common-datablocks"
 version = "0.1.0"
 dependencies = [
@@ -1349,6 +1357,7 @@ dependencies = [
  "clickhouse-srv",
  "common-aggregate-functions",
  "common-arrow",
+ "common-building",
  "common-datablocks",
  "common-datavalues",
  "common-exception",
@@ -1380,7 +1389,6 @@ dependencies = [
  "prost",
  "quantiles",
  "rand 0.8.3",
- "run_script",
  "serde",
  "serde_json",
  "sqlparser",
@@ -1392,7 +1400,6 @@ dependencies = [
  "toml",
  "tonic",
  "uuid",
- "vergen",
  "warp",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     # Common
     "common/arrow",
+    "common/building",
     "common/datablocks",
     "common/datavalues",
     "common/flights",

--- a/common/building/Cargo.toml
+++ b/common/building/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "common-building"
+version = "0.1.0"
+authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+vergen = "5.1.8"
+run_script = "^0.8.0"

--- a/common/building/src/lib.rs
+++ b/common/building/src/lib.rs
@@ -1,0 +1,61 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::path::Path;
+
+use vergen::vergen;
+use vergen::Config;
+use vergen::ShaKind;
+
+/// Setup building environment:
+/// - Watch git HEAD to trigger a rebuild;
+/// - Generate vergen instruction to setup environment variables for building Fuse components. See: https://docs.rs/vergen/5.1.8/vergen/ ;
+/// - Generate Fuse environment variables, e.g., version and authors.
+pub fn setup() {
+    if Path::new(".git/HEAD").exists() {
+        println!("cargo:rerun-if-changed=.git/HEAD");
+    }
+    add_building_env_vars();
+}
+
+pub fn add_building_env_vars() {
+    add_env_vergen();
+    add_env_commit_authors();
+    add_env_commit_version();
+}
+
+pub fn add_env_vergen() {
+    let mut config = Config::default();
+    *config.git_mut().sha_kind_mut() = ShaKind::Short;
+
+    if let Err(e) = vergen(config) {
+        eprintln!("{}", e);
+    }
+}
+
+pub fn add_env_commit_authors() {
+    let r = run_script::run_script!(
+        r#"git shortlog HEAD --summary | perl -lnE 's/^\s+\d+\s+(.+)/  "$1",/; next unless $1; say $_' | sort | xargs"#
+    );
+    let authors = match r {
+        Ok((_, output, _)) => output,
+        Err(e) => e.to_string(),
+    };
+    println!("cargo:rustc-env=FUSE_COMMIT_AUTHORS={}", authors);
+}
+
+/// Generate Fuse style commit-version and keep it in environment variable FUSE_COMMIT_VERSION.
+pub fn add_env_commit_version() {
+    let build_semver = option_env!("VERGEN_BUILD_SEMVER");
+    let git_sha = option_env!("VERGEN_GIT_SHA_SHORT");
+    let rustc_semver = option_env!("VERGEN_RUSTC_SEMVER");
+    let timestamp = option_env!("VERGEN_BUILD_TIMESTAMP");
+
+    let ver = match (build_semver, git_sha, rustc_semver, timestamp) {
+        (Some(v1), Some(v2), Some(v3), Some(v4)) => format!("{}-{}({}-{})", v1, v2, v3, v4),
+        _ => String::new(),
+    };
+
+    println!("cargo:rustc-env=FUSE_COMMIT_VERSION={}", ver);
+}

--- a/fusequery/query/Cargo.toml
+++ b/fusequery/query/Cargo.toml
@@ -75,8 +75,7 @@ pretty_assertions = "0.7"
 criterion = "0.3"
 
 [build-dependencies]
-vergen = "5.1.8"
-run_script = "^0.8.0"
+common-building = {path = "../../common/building"}
 
 [[bench]]
 name = "bench_main"

--- a/fusequery/query/build.rs
+++ b/fusequery/query/build.rs
@@ -2,37 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use std::path::Path;
-
-use vergen::vergen;
-use vergen::Config;
-use vergen::ShaKind;
-
 fn main() {
-    if Path::new(".git/HEAD").exists() {
-        println!("cargo:rerun-if-changed=.git/HEAD");
-    }
-
-    commit_version();
-    commit_authors();
-}
-
-fn commit_version() {
-    let mut config = Config::default();
-    *config.git_mut().sha_kind_mut() = ShaKind::Short;
-
-    if let Err(e) = vergen(config) {
-        eprintln!("{}", e);
-    }
-}
-
-fn commit_authors() {
-    let r = run_script::run_script!(
-        r#"git shortlog HEAD --summary | perl -lnE 's/^\s+\d+\s+(.+)/  "$1",/; next unless $1; say $_' | sort | xargs"#
-    );
-    let authors = match r {
-        Ok((_, output, _)) => output,
-        Err(e) => e.to_string(),
-    };
-    println!("cargo:rustc-env=COMMIT_AUTHORS={}", authors);
+    common_building::setup();
 }

--- a/fusequery/query/src/configs/config.rs
+++ b/fusequery/query/src/configs/config.rs
@@ -120,7 +120,7 @@ impl Config {
         if cfg.num_cpus == 0 {
             cfg.num_cpus = num_cpus::get() as u64;
         }
-        cfg.version = Self::commit_version();
+        cfg.version = env!("FUSE_COMMIT_VERSION").to_string();
 
         cfg
     }
@@ -134,19 +134,7 @@ impl Config {
         if cfg.num_cpus == 0 {
             cfg.num_cpus = num_cpus::get() as u64;
         }
-        cfg.version = Self::commit_version();
+        cfg.version = env!("FUSE_COMMIT_VERSION").to_string();
         Ok(cfg)
-    }
-
-    fn commit_version() -> String {
-        let build_semver = option_env!("VERGEN_BUILD_SEMVER");
-        let git_sha = option_env!("VERGEN_GIT_SHA_SHORT");
-        let rustc_semver = option_env!("VERGEN_RUSTC_SEMVER");
-        let timestamp = option_env!("VERGEN_BUILD_TIMESTAMP");
-
-        match (build_semver, git_sha, rustc_semver, timestamp) {
-            (Some(v1), Some(v2), Some(v3), Some(v4)) => format!("{}-{}({}-{})", v1, v2, v3, v4),
-            _ => String::new(),
-        }
     }
 }

--- a/fusequery/query/src/datasources/system/contributors_table.rs
+++ b/fusequery/query/src/datasources/system/contributors_table.rs
@@ -77,7 +77,7 @@ impl ITable for ContributorsTable {
     }
 
     async fn read(&self, _ctx: FuseQueryContextRef) -> Result<SendableDataBlockStream> {
-        let contributors: Vec<&str> = env!("COMMIT_AUTHORS")
+        let contributors: Vec<&str> = env!("FUSE_COMMIT_AUTHORS")
             .split_terminator(',')
             .map(|x| x.trim())
             .collect();

--- a/fusestore/store/src/bin/fuse-store.rs
+++ b/fusestore/store/src/bin/fuse-store.rs
@@ -9,7 +9,7 @@ use log::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let conf = Config::create_from_args();
+    let conf = Config::load_from_args();
     env_logger::Builder::from_env(
         env_logger::Env::default().default_filter_or(conf.log_level.to_lowercase().as_str()),
     )

--- a/fusestore/store/src/configs/config.rs
+++ b/fusestore/store/src/configs/config.rs
@@ -39,7 +39,7 @@ impl Config {
     }
 
     /// Create configs from args.
-    pub fn create_from_args() -> Self {
+    pub fn load_from_args() -> Self {
         let mut cfg = Config::from_args();
         cfg.version = include_str!(concat!(env!("OUT_DIR"), "/version-info.txt")).to_string();
         cfg


### PR DESCRIPTION
## Summary

### [building] refine: building helper crate: common/building
- `common/building` setup common building environment for both Query and Store.
- Generate the commit version in building phase, not in config parsing
  phase any more.
- Add prefix `FUSE_` to our own env vars.

## Changelog

- Improvement

## Related Issues

#271 



