### PR TITLE
[building] refine: fix dep and clean useless code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/drmingdrmer/async-raft?rev=cf40344f66fdcb6cde160b3e5671ff87c88f2af8#cf40344f66fdcb6cde160b3e5671ff87c88f2af8"
+source = "git+https://github.com/drmingdrmer/async-raft?branch=master#377312cd6c0c7a804730b6f950df241c28740f19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/common/flights/src/dns_resolver_test.rs
+++ b/common/flights/src/dns_resolver_test.rs
@@ -4,7 +4,6 @@
 //
 
 use common_exception::Result;
-use trust_dns_resolver::TokioAsyncResolver;
 
 use crate::DNSResolver;
 

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -27,7 +27,7 @@ common-planners = {path = "../../common/planners"}
 # Crates.io dependencies
 anyhow = "1.0.40"
 # track self maintained branch with hot fixes
-async-raft = { git = "https://github.com/drmingdrmer/async-raft", rev = "cf40344f66fdcb6cde160b3e5671ff87c88f2af8" }
+async-raft = { git = "https://github.com/drmingdrmer/async-raft", branch = "master" }
 async-trait = "0.1"
 env_logger = "0.8"
 futures = "0.3"


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

## Summary

- Use the master branch to ensure that at least it is available - https://github.com/drmingdrmer/async-raft
- Clean up warnings during testing - unused import

## Changelog

- Build/Testing/CI

## Related Issues

Fixes #688 

## Test Plan

No test plan.

