### PR TITLE
Add pr-not-for-changelog label

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,8 @@ Summary about this PR
 - Build/Testing/CI
 - Documentation
 - Website
-- Other
+- Other 
+- Not for changelog (changelog entry is not required)
 
 ## Related Issues
 
@@ -20,5 +21,6 @@ Fixes #issue
 ## Test Plan
 
 Unit Tests
+
 Stateless Tests
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,6 +47,10 @@ labels:
       - '\bDocumentation?\b'
       - '\bWebsite?\b'
     exclude: []
+  'pr-not-for-changelog':
+    include:
+      - '\bNot for changelog (changelog entry is not required)\b'
+    exclude: []
   'pr-other':
     include:
       - '\bOther?\b'

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Note:
 - [x] Type coercion
 - [x] Parallel Query Execution
 - [x] Distributed Query Execution
-- [x] Hash GroupBy
+- [x] Shuffle Hash GroupBy
 - [x] Merge-Sort OrderBy
 - [ ] Joins (WIP)
 


### PR DESCRIPTION
## Summary

Add not for changelog label, fusebots will not show in the release CHNAGELOG.

## Changelog

- Build/Testing/CI

## Related Issues

Fixes #708 

## Test Plan

Unit Tests
Stateless Tests

