### PR TITLE
[common/exception] add a trait `ToErrorCode` to let a user easily convert Result::Err to ErrorCodes error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ dependencies = [
  "common-building",
  "common-datablocks",
  "common-datavalues",
+ "common-exception",
  "common-flights",
  "common-functions",
  "common-infallible",

--- a/common/datavalues/src/data_array_scatter.rs
+++ b/common/datavalues/src/data_array_scatter.rs
@@ -105,26 +105,29 @@ impl DataArrayScatter {
             let mut scattered_data_res = Vec::with_capacity(nums);
 
             for res_index in 0..nums {
-                match res_index {
-                    res_index if res_index == index => scattered_data_res.push(data.clone()),
-                    _ => scattered_data_res.push(data.clone_empty()),
+                if res_index == index {
+                    scattered_data_res.push(data.clone());
+                } else {
+                    scattered_data_res.push(data.clone_empty());
                 }
             }
 
             Ok(scattered_data_res)
         };
 
-        match indices {
-            DataValue::Int8(Some(v)) => scatter_data(*v as usize),
-            DataValue::Int16(Some(v)) => scatter_data(*v as usize),
-            DataValue::Int32(Some(v)) => scatter_data(*v as usize),
-            DataValue::Int64(Some(v)) => scatter_data(*v as usize),
-            DataValue::UInt8(Some(v)) => scatter_data(*v as usize),
-            DataValue::UInt16(Some(v)) => scatter_data(*v as usize),
-            DataValue::UInt32(Some(v)) => scatter_data(*v as usize),
-            DataValue::UInt64(Some(v)) => scatter_data(*v as usize),
-            _ => Err(ErrorCodes::BadDataValueType("")),
-        }
+        let v = match indices {
+            DataValue::Int8(Some(v)) => *v as usize,
+            DataValue::Int16(Some(v)) => *v as usize,
+            DataValue::Int32(Some(v)) => *v as usize,
+            DataValue::Int64(Some(v)) => *v as usize,
+            DataValue::UInt8(Some(v)) => *v as usize,
+            DataValue::UInt16(Some(v)) => *v as usize,
+            DataValue::UInt32(Some(v)) => *v as usize,
+            DataValue::UInt64(Some(v)) => *v as usize,
+            _ => return Err(ErrorCodes::BadDataValueType("")),
+        };
+
+        scatter_data(v)
     }
 
     fn scatter_data(

--- a/common/exception/src/exception_test.rs
+++ b/common/exception/src/exception_test.rs
@@ -24,3 +24,18 @@ fn test_format_with_error_codes() {
         "Code: 1000, displayText = test message 2."
     );
 }
+
+#[test]
+fn test_derive_from_std_error() {
+    use crate::exception::ErrorCodes;
+    use crate::exception::ToErrorCodes;
+
+    let x: std::result::Result<(), std::fmt::Error> = Err(std::fmt::Error {});
+    let y: crate::exception::Result<()> =
+        x.map_err_to_code(ErrorCodes::UnknownException, || format!("{}", 123));
+
+    assert_eq!(
+        "Code: 1000, displayText = Error.",
+        format!("{}", y.unwrap_err())
+    );
+}

--- a/common/exception/src/lib.rs
+++ b/common/exception/src/lib.rs
@@ -9,3 +9,4 @@ pub mod exception;
 
 pub use exception::ErrorCodes;
 pub use exception::Result;
+pub use exception::ToErrorCodes;

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/bin/fuse-store.rs"
 common-arrow = {path = "../../common/arrow"}
 common-datablocks = {path = "../../common/datablocks"}
 common-datavalues = {path = "../../common/datavalues"}
+common-exception = {path = "../../common/exception"}
 common-flights = {path = "../../common/flights"}
 common-functions = {path = "../../common/functions"}
 common-infallible = {path = "../../common/infallible"}
@@ -58,9 +59,9 @@ tracing-subscriber = "0.2.18"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
+env_logger = "*"
 pretty_assertions = "0.7"
 test-env-log = "0.2.7"
-env_logger = "*"
 tracing = {version = "0.1", default-features = false}
 tracing-subscriber = {version = "0.2.17", default-features = false, features = ["env-filter", "fmt"]}
 

--- a/fusestore/store/src/api/rpc_service.rs
+++ b/fusestore/store/src/api/rpc_service.rs
@@ -5,13 +5,14 @@
 use std::sync::Arc;
 
 use anyhow::anyhow;
-use anyhow::Result;
 use common_arrow::arrow_flight::flight_service_server::FlightServiceServer;
 use tonic::transport::Server;
 
 use crate::api::rpc::StoreFlightImpl;
 use crate::configs::Config;
+use crate::dfs::Dfs;
 use crate::localfs::LocalFS;
+use crate::meta_service::MetaNode;
 
 pub struct StoreServer {
     conf: Config,
@@ -22,17 +23,29 @@ impl StoreServer {
         Self { conf }
     }
 
-    pub async fn serve(&self) -> Result<()> {
+    pub async fn serve(&self) -> anyhow::Result<()> {
         let addr = self
             .conf
             .flight_api_address
             .parse::<std::net::SocketAddr>()?;
 
+        // TODO(xp): add local fs dir to config and use it.
         let p = tempfile::tempdir()?;
         let fs = LocalFS::try_create(p.path().to_str().unwrap().into())?;
 
-        // Flight service:
-        let flight_impl = StoreFlightImpl::create(self.conf.clone(), Arc::new(fs));
+        let meta_addr = format!("{}:{}", self.conf.meta_api_host, self.conf.meta_api_port);
+
+        // TODO(xp): support non-boot mode.
+        //           for now it can only be run in single-node cluster mode.
+        // if !self.conf.boot {
+        //     todo!("non-boot mode is not impl yet")
+        // }
+
+        let mn = MetaNode::boot(0, meta_addr.clone()).await?;
+
+        let dfs = Dfs::create(fs, mn);
+
+        let flight_impl = StoreFlightImpl::create(self.conf.clone(), Arc::new(dfs));
         let flight_srv = FlightServiceServer::new(flight_impl);
 
         Server::builder()

--- a/fusestore/store/src/configs/config.rs
+++ b/fusestore/store/src/configs/config.rs
@@ -25,4 +25,27 @@ pub struct Config {
         default_value = "127.0.0.1:9191"
     )]
     pub flight_api_address: String,
+
+    #[structopt(
+        long,
+        env = "FUSE_STORE_META_API_HOST",
+        default_value = "127.0.0.1",
+        help = "The listening host for metadata communication"
+    )]
+    pub meta_api_host: String,
+
+    #[structopt(
+        long,
+        env = "FUSE_STORE_META_API_PORT",
+        default_value = "9291",
+        help = "The listening port for metadata communication"
+    )]
+    pub meta_api_port: u32,
+
+    #[structopt(
+        long,
+        env = "FUSE_STORE_BOOT",
+        help = "Whether to boot up a new cluster. If already booted, it is ignored"
+    )]
+    pub boot: bool,
 }


### PR DESCRIPTION

## Summary

### [common/exception] add a trait `ToErrorCode` to let a user easily convert Result::Err to ErrorCodes error
Usage:

```
use common_exception::ToErrorCodes;

let x = Err(std::fmt::Error {}).map_err_to_code(ErrorCodes::UnknownException, ||"");
assert_eq!( "Code: 1000, displayText = Error.", format!("{}", x.unwrap_err()));
```


### [common/datavalues] minor refinement

### [store] store server adopts dfs

## Changelog






## Related Issues

#271