### PR TITLE
[common/planners] simplify Statistics with Default

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -133,6 +133,13 @@ build_exceptions! {
     TokioError(1001)
 }
 
+// Store errors
+build_exceptions! {
+
+    FileMetaNotFound(2001),
+    FileDamaged(2002)
+}
+
 pub type Result<T> = std::result::Result<T, ErrorCodes>;
 
 impl Debug for ErrorCodes {

--- a/common/planners/src/plan_statistics.rs
+++ b/common/planners/src/plan_statistics.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Debug)]
+#[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq, Clone, Debug, Default)]
 pub struct Statistics {
     /// Total rows of the query read.
     pub read_rows: usize,
@@ -11,15 +11,7 @@ pub struct Statistics {
 }
 
 impl Statistics {
-    pub fn default() -> Self {
-        Statistics {
-            read_rows: 0,
-            read_bytes: 0,
-        }
-    }
-
     pub fn clear(&mut self) {
-        self.read_rows = 0;
-        self.read_bytes = 0;
+        *self = Self::default();
     }
 }

--- a/fusestore/store/src/dfs/distributed_fs.rs
+++ b/fusestore/store/src/dfs/distributed_fs.rs
@@ -5,6 +5,8 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use common_exception::exception;
+use common_exception::ErrorCodes;
 
 use crate::fs::IFileSystem;
 use crate::fs::ListResult;
@@ -57,9 +59,16 @@ impl IFileSystem for Dfs {
         Ok(())
     }
 
-    async fn read_all(&self, path: String) -> anyhow::Result<Vec<u8>> {
-        // TODO read local cached meta first
-        self.local_fs.read_all(path).await
+    async fn read_all(&self, key: String) -> exception::Result<Vec<u8>> {
+        // TODO read from remove if file is not in local fs
+        // TODO(xp): week consistency, meta may not have been replicated to this node.
+
+        // meanwhile, file meta is empty string
+        let _file_meta = self.meta_node.get_file(&key).await.ok_or_else(|| {
+            ErrorCodes::FileMetaNotFound(format!("dfs/meta: key not found: {:?}", key))
+        })?;
+
+        self.local_fs.read_all(key).await
     }
 
     async fn list(&self, path: String) -> anyhow::Result<ListResult> {

--- a/fusestore/store/src/dfs/distributed_fs_test.rs
+++ b/fusestore/store/src/dfs/distributed_fs_test.rs
@@ -14,7 +14,12 @@ use crate::meta_service::MetaServiceClient;
 use crate::tests::rand_local_addr;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_distributed_fs() -> anyhow::Result<()> {
+async fn test_distributed_fs_single_node() -> anyhow::Result<()> {
+    // - Brings a single node dfs online.
+    // - Write a file.
+    // - Test read_all()
+    // - Test reading an absent file.
+
     let dir = tempdir()?;
     let root = dir.path();
 
@@ -30,6 +35,7 @@ async fn test_distributed_fs() -> anyhow::Result<()> {
     {
         let rst = dfs.add("foo".into(), "bar".as_bytes()).await;
         rst.unwrap();
+
         // check meta changes
 
         let mut client = MetaServiceClient::connect(format!("http://{}", meta_addr)).await?;
@@ -37,7 +43,19 @@ async fn test_distributed_fs() -> anyhow::Result<()> {
         let rst = client.get(req).await?.into_inner();
         assert_eq!("", rst.value);
 
-        // TODO read file data and check result.
+        // read file and check
+
+        let got = dfs.read_all("foo".into()).await?;
+        assert_eq!("bar".to_string().as_bytes(), got);
+
+        let got = dfs.read_all("absent".into()).await;
+        assert!(got.is_err());
+        assert_eq!(
+            "dfs/meta: key not found: \"absent\"",
+            got.unwrap_err().message()
+        );
+
+        // TODO: test a file presents in meta but not found on local fs.
     }
     Ok(())
 }

--- a/fusestore/store/src/executor/action_handler_test.rs
+++ b/fusestore/store/src/executor/action_handler_test.rs
@@ -23,15 +23,13 @@ async fn test_action_handler_do_pull_file() -> anyhow::Result<()> {
     let root = dir.path();
 
     let fs = LocalFS::try_create(root.to_str().unwrap().to_string())?;
-    fs.add("foo".into(), "bar".as_bytes()).await?;
 
     let meta_addr = rand_local_addr();
-
-    let rst = MetaNode::boot(0, meta_addr.clone()).await;
-    assert!(rst.is_ok());
-    let mn = rst.unwrap();
+    let mn = MetaNode::boot(0, meta_addr.clone()).await?;
 
     let dfs = Dfs::create(fs, mn);
+    dfs.add("foo".into(), "bar".as_bytes()).await?;
+
     let hdlr = ActionHandler::create(Arc::new(dfs));
     {
         // pull file

--- a/fusestore/store/src/fs/ifs.rs
+++ b/fusestore/store/src/fs/ifs.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 use async_trait::async_trait;
+use common_exception::exception;
 
 use crate::fs::ListResult;
 
@@ -13,10 +14,10 @@ where Self: Sync + Send
 {
     /// Add file atomically.
     /// AKA put_if_absent
-    async fn add<'a>(&'a self, path: String, data: &[u8]) -> anyhow::Result<()>;
+    async fn add(&self, path: String, data: &[u8]) -> anyhow::Result<()>;
 
     /// read all bytes from a file
-    async fn read_all<'a>(&'a self, path: String) -> anyhow::Result<Vec<u8>>;
+    async fn read_all(&self, path: String) -> exception::Result<Vec<u8>>;
 
     /// List dir and returns directories and files.
     async fn list(&self, path: String) -> anyhow::Result<ListResult>;
@@ -27,5 +28,4 @@ where Self: Sync + Send
     //     length: usize,
     //     buf: &mut [u8],
     // ) -> anyhow::Result<usize>;
-    // async fn list(path: &str) -> anyhow::Result<Vec<String>>;
 }

--- a/fusestore/store/src/localfs/local_fs.rs
+++ b/fusestore/store/src/localfs/local_fs.rs
@@ -8,6 +8,9 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 use async_trait::async_trait;
+use common_exception::exception;
+use common_exception::ErrorCodes;
+use common_exception::ToErrorCodes;
 
 use crate::fs::IFileSystem;
 use crate::fs::ListResult;
@@ -28,7 +31,7 @@ impl LocalFS {
 
 #[async_trait]
 impl IFileSystem for LocalFS {
-    async fn add<'a>(&'a self, path: String, data: &[u8]) -> anyhow::Result<()> {
+    async fn add(&self, path: String, data: &[u8]) -> anyhow::Result<()> {
         // TODO: test atomicity: write temp file and rename it
         let p = Path::new(self.root.as_path()).join(&path);
         let mut an = p.ancestors();
@@ -54,14 +57,15 @@ impl IFileSystem for LocalFS {
         Ok(())
     }
 
-    async fn read_all<'a>(&'a self, path: String) -> anyhow::Result<Vec<u8>> {
+    async fn read_all(&self, path: String) -> exception::Result<Vec<u8>> {
         let p = Path::new(self.root.as_path()).join(&path);
-        let data = std::fs::read(p.as_path())
-            .with_context(|| format!("LocalFS: fail to read {}", path))?;
+        let data = std::fs::read(p.as_path()).map_err_to_code(ErrorCodes::FileDamaged, || {
+            format!("localfs: fail to read: {:?}", path)
+        })?;
         Ok(data)
     }
 
-    async fn list<'a>(&'a self, path: String) -> anyhow::Result<ListResult> {
+    async fn list(&self, path: String) -> anyhow::Result<ListResult> {
         let p = Path::new(self.root.as_path()).join(&path);
         let entries = std::fs::read_dir(p.as_path())
             .with_context(|| format!("LocalFS: fail to list {}", path))?;

--- a/fusestore/store/src/localfs/local_fs_test.rs
+++ b/fusestore/store/src/localfs/local_fs_test.rs
@@ -18,8 +18,8 @@ async fn test_localfs_read_all() -> anyhow::Result<()> {
         // read absent file
         let got = f.read_all("foo.txt".into()).await;
         assert_eq!(
-            "No such file or directory (os error 2)",
-            got.err().unwrap().root_cause().to_string()
+            "localfs: fail to read: \"foo.txt\", cause: No such file or directory (os error 2)",
+            got.err().unwrap().message()
         );
     }
     {


### PR DESCRIPTION
## Summary

##### [common/planners] simplify Statistics with Default

##### [store] dfs checks meta data first when reading.
- [common/exceptions] add 2 store errors.
- [store] `read_all()` returns ErrorCodes instead of anyhow::Error.
- [store] `read_all()` check file meta before returning file content.

## Changelog

- Improvement




## Related Issues

#271