### PR TITLE
[store] refine: add tracing to FS-related API

### DIFF
--- a/fusestore/store/src/dfs/distributed_fs.rs
+++ b/fusestore/store/src/dfs/distributed_fs.rs
@@ -41,6 +41,7 @@ impl Dfs {}
 
 #[async_trait]
 impl IFileSystem for Dfs {
+    #[tracing::instrument(level = "debug", skip(self, data))]
     async fn add(&self, path: String, data: &[u8]) -> anyhow::Result<()> {
         // add the file to local fs
 
@@ -59,6 +60,7 @@ impl IFileSystem for Dfs {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn read_all(&self, key: String) -> exception::Result<Vec<u8>> {
         // TODO read from remove if file is not in local fs
         // TODO(xp): week consistency, meta may not have been replicated to this node.
@@ -71,6 +73,7 @@ impl IFileSystem for Dfs {
         self.local_fs.read_all(key).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn list(&self, path: String) -> anyhow::Result<ListResult> {
         let _key = path;
 

--- a/fusestore/store/src/executor/action_handler_test.rs
+++ b/fusestore/store/src/executor/action_handler_test.rs
@@ -2,9 +2,12 @@
 //
 // SPDX-Lise-Identifier: Apache-2.0.
 
+use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Arc;
 
 use common_arrow::arrow_flight::FlightData;
+use maplit::hashmap;
 use pretty_assertions::assert_eq;
 use tempfile::tempdir;
 use tokio::sync::mpsc::Receiver;
@@ -19,18 +22,16 @@ use crate::tests::rand_local_addr;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_action_handler_do_pull_file() -> anyhow::Result<()> {
+    crate::tests::init_tracing();
+
     let dir = tempdir()?;
     let root = dir.path();
 
-    let fs = LocalFS::try_create(root.to_str().unwrap().to_string())?;
+    let hdlr = bring_up_dfs_action_handler(root, hashmap! {
+        "foo" => "bar",
+    })
+    .await?;
 
-    let meta_addr = rand_local_addr();
-    let mn = MetaNode::boot(0, meta_addr.clone()).await?;
-
-    let dfs = Dfs::create(fs, mn);
-    dfs.add("foo".into(), "bar".as_bytes()).await?;
-
-    let hdlr = ActionHandler::create(Arc::new(dfs));
     {
         // pull file
         let (tx, mut rx): (
@@ -39,18 +40,35 @@ async fn test_action_handler_do_pull_file() -> anyhow::Result<()> {
         ) = tokio::sync::mpsc::channel(2);
 
         hdlr.do_pull_file("foo".into(), tx).await?;
-        let rst = rx.recv().await;
-        match rst {
-            Some(r) => {
-                //
-                let r = r?;
-                let body = r.data_body;
-                assert_eq!("bar", std::str::from_utf8(&body)?);
-            }
-            None => {
-                panic!("should not be None");
-            }
-        }
+        let rst = rx
+            .recv()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("should not be None"))?;
+        let rst = rst?;
+        let body = rst.data_body;
+        assert_eq!("bar", std::str::from_utf8(&body)?);
     }
     Ok(())
+}
+
+// Start an ActionHandler backed with a dfs.
+// And feed files into dfs.
+async fn bring_up_dfs_action_handler(
+    root: &Path,
+    files: HashMap<&str, &str>,
+) -> anyhow::Result<ActionHandler> {
+    let fs = LocalFS::try_create(root.to_str().unwrap().to_string())?;
+
+    let meta_addr = rand_local_addr();
+    let mn = MetaNode::boot(0, meta_addr.clone()).await?;
+
+    let dfs = Dfs::create(fs, mn);
+    for (key, content) in files.iter() {
+        dfs.add((*key).into(), (*content).as_bytes()).await?;
+        tracing::debug!("added file: {} {:?}", *key, *content);
+    }
+
+    let ah = ActionHandler::create(Arc::new(dfs));
+
+    Ok(ah)
 }

--- a/fusestore/store/src/localfs/local_fs.rs
+++ b/fusestore/store/src/localfs/local_fs.rs
@@ -31,6 +31,7 @@ impl LocalFS {
 
 #[async_trait]
 impl IFileSystem for LocalFS {
+    #[tracing::instrument(level = "debug", skip(self, data))]
     async fn add(&self, path: String, data: &[u8]) -> anyhow::Result<()> {
         // TODO: test atomicity: write temp file and rename it
         let p = Path::new(self.root.as_path()).join(&path);
@@ -57,14 +58,18 @@ impl IFileSystem for LocalFS {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn read_all(&self, path: String) -> exception::Result<Vec<u8>> {
         let p = Path::new(self.root.as_path()).join(&path);
+        tracing::info!("read: {}", p.as_path().display());
+
         let data = std::fs::read(p.as_path()).map_err_to_code(ErrorCodes::FileDamaged, || {
             format!("localfs: fail to read: {:?}", path)
         })?;
         Ok(data)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn list(&self, path: String) -> anyhow::Result<ListResult> {
         let p = Path::new(self.root.as_path()).join(&path);
         let entries = std::fs::read_dir(p.as_path())


### PR DESCRIPTION

## Summary

##### [store] refine: add tracing to FS-related API
- trace LocalFS and Dfs API at debug level.
- extract common code setting up a dfs to standalone function.

## Changelog


- Improvement



## Related Issues

#271