### PR TITLE
[store/meta] feature: generate unique auto-incr number

### DIFF
--- a/fusestore/store/src/meta_service/meta_test.rs
+++ b/fusestore/store/src/meta_service/meta_test.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 use crate::meta_service::meta::Replication;
+use crate::meta_service::ClientRequest;
+use crate::meta_service::ClientResponse;
+use crate::meta_service::Cmd;
 use crate::meta_service::Meta;
 use crate::meta_service::Node;
 use crate::meta_service::Slot;
@@ -88,5 +91,36 @@ fn test_meta_builder() -> anyhow::Result<()> {
         Replication::Mirror(x) => x,
     };
     assert_eq!(8, n);
+    Ok(())
+}
+
+// TODO test apply:AddFile,SetFile,AddNode
+
+#[test]
+fn test_meta_apply_incr_seq() -> anyhow::Result<()> {
+    let mut m = Meta::builder().build()?;
+
+    for i in 0..3 {
+        // incr "foo"
+
+        let resp = m.apply(&ClientRequest {
+            txid: None,
+            cmd: Cmd::IncrSeq {
+                key: "foo".to_string(),
+            },
+        })?;
+        assert_eq!(ClientResponse::Seq { seq: i + 1 }, resp);
+
+        // incr "bar"
+
+        let resp = m.apply(&ClientRequest {
+            txid: None,
+            cmd: Cmd::IncrSeq {
+                key: "bar".to_string(),
+            },
+        })?;
+        assert_eq!(ClientResponse::Seq { seq: i + 1 }, resp);
+    }
+
     Ok(())
 }

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -31,20 +31,3 @@ pub fn rand_local_addr() -> String {
     let addr = format!("127.0.0.1:{}", port);
     return addr;
 }
-
-macro_rules! serve_grpc {
-    ($addr:expr, $srv:expr) => {
-        let addr = $addr.parse::<std::net::SocketAddr>()?;
-
-        let srv = tonic::transport::Server::builder().add_service($srv);
-
-        tokio::spawn(async move {
-            srv.serve(addr)
-                .await
-                .map_err(|e| anyhow::anyhow!("Flight service error: {:?}", e))?;
-            Ok::<(), anyhow::Error>(())
-        });
-
-        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-    };
-}


### PR DESCRIPTION

## Summary

##### [store/meta] feature: generate unique auto-incr number
- Add new storage `sequences` to Meta. Introduce a corresponding new
  command `Cmd::IncrSeq`, to generate mono-incr sequence numbers.
  This feature enables Store to generate a globally unique u64 number,
  for a unique block/partition name.

  `test_meta_server_incr_seq` shows how to use this feature.

- Simplify meta test cases by letting the state-machine test and the
  meta service test share a common test case set.

- Remove unused codes etc.

## Changelog

- New Feature




## Related Issues

#271