### PR TITLE
[store/meta] refine: the same test cases should be applied to both state-machine and the meta server

### DIFF
--- a/fusestore/store/src/meta_service/meta_service_impl_test.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl_test.rs
@@ -6,6 +6,7 @@
 use log::info;
 use pretty_assertions::assert_eq;
 
+use crate::meta_service::raftmeta_test::assert_connection;
 use crate::meta_service::ClientRequest;
 use crate::meta_service::ClientResponse;
 use crate::meta_service::Cmd;
@@ -19,6 +20,7 @@ async fn test_meta_server_add_file() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
     let _mn = MetaNode::boot(0, addr.clone()).await?;
+    assert_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
 
@@ -53,6 +55,7 @@ async fn test_meta_server_sed_file() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
     let _mn = MetaNode::boot(0, addr.clone()).await?;
+    assert_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
 
@@ -88,9 +91,9 @@ async fn test_meta_server_add_set_get() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
     let _mn = MetaNode::boot(0, addr.clone()).await?;
-    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+    assert_connection(&addr).await?;
 
-    let cases = crate::meta_service::raftmeta_test::cases_add_file();
+    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
 
     {
         // add: ok
@@ -174,6 +177,7 @@ async fn test_meta_server_incr_seq() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
     let _mn = MetaNode::boot(0, addr.clone()).await?;
+    assert_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
 

--- a/fusestore/store/src/meta_service/meta_service_impl_test.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl_test.rs
@@ -15,12 +15,82 @@ use crate::meta_service::MetaServiceClient;
 use crate::tests::rand_local_addr;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_meta_server_set_get() -> anyhow::Result<()> {
+async fn test_meta_server_add_file() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
     let _mn = MetaNode::boot(0, addr.clone()).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+
+    let cases = crate::meta_service::raftmeta_test::cases_add_file();
+
+    for (name, txid, k, v, want_prev, want_rst) in cases.iter() {
+        let req = ClientRequest {
+            txid: txid.clone(),
+            cmd: Cmd::AddFile {
+                key: k.to_string(),
+                value: v.to_string(),
+            },
+        };
+        let rst = client.write(req).await?.into_inner();
+        let resp: ClientResponse = rst.into();
+        match resp {
+            ClientResponse::String { prev, result } => {
+                assert_eq!(*want_prev, prev, "{}", name);
+                assert_eq!(*want_rst, result, "{}", name);
+            }
+            _ => {
+                panic!("not String")
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_server_sed_file() -> anyhow::Result<()> {
+    let addr = rand_local_addr();
+
+    let _mn = MetaNode::boot(0, addr.clone()).await?;
+
+    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+
+    let cases = crate::meta_service::raftmeta_test::cases_set_file();
+
+    for (name, txid, k, v, want_prev, want_rst) in cases.iter() {
+        let req = ClientRequest {
+            txid: txid.clone(),
+            cmd: Cmd::SetFile {
+                key: k.to_string(),
+                value: v.to_string(),
+            },
+        };
+        let rst = client.write(req).await?.into_inner();
+        let resp: ClientResponse = rst.into();
+        match resp {
+            ClientResponse::String { prev, result } => {
+                assert_eq!(*want_prev, prev, "{}", name);
+                assert_eq!(*want_rst, result, "{}", name);
+            }
+            _ => {
+                panic!("not String")
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_server_add_set_get() -> anyhow::Result<()> {
+    // Test Cmd::AddFile, Cmd::SetFile, Cma::GetFile
+    let addr = rand_local_addr();
+
+    let _mn = MetaNode::boot(0, addr.clone()).await?;
+    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+
+    let cases = crate::meta_service::raftmeta_test::cases_add_file();
 
     {
         // add: ok

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -38,3 +38,5 @@ mod meta_test;
 mod placement_test;
 #[cfg(test)]
 mod raftmeta_test;
+#[cfg(test)]
+mod state_machine_test;

--- a/fusestore/store/src/meta_service/raftmeta_test.rs
+++ b/fusestore/store/src/meta_service/raftmeta_test.rs
@@ -15,7 +15,6 @@ use crate::meta_service::ClientRequest;
 use crate::meta_service::ClientResponse;
 use crate::meta_service::Cmd;
 use crate::meta_service::GetReq;
-use crate::meta_service::MemStoreStateMachine;
 use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
 use crate::meta_service::NodeId;
@@ -390,7 +389,7 @@ async fn assert_get_file(
     Ok(())
 }
 
-async fn assert_connection(addr: &str) -> anyhow::Result<()> {
+pub async fn assert_connection(addr: &str) -> anyhow::Result<()> {
     tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
     let req = tonic::Request::new(GetReq { key: "foo".into() });

--- a/fusestore/store/src/meta_service/raftmeta_test.rs
+++ b/fusestore/store/src/meta_service/raftmeta_test.rs
@@ -44,19 +44,17 @@ pub fn cases_incr_seq() -> Vec<(&'static str, Option<RaftTxId>, &'static str, u6
     ]
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {
-    crate::tests::init_tracing();
-
-    let mut sm = MemStoreStateMachine::default();
-    let cases: Vec<(
-        &str,
-        Option<RaftTxId>,
-        &str,
-        &str,
-        Option<String>,
-        Option<String>,
-    )> = vec![
+// test cases for Cmd::AddFile
+// case_name, txid, key, value, want_prev, want_result
+pub fn cases_add_file() -> Vec<(
+    &'static str,
+    Option<RaftTxId>,
+    &'static str,
+    &'static str,
+    Option<String>,
+    Option<String>,
+)> {
+    vec![
         (
             "add on none",
             Some(RaftTxId::new("foo", 1)),
@@ -90,42 +88,20 @@ async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {
             Some("v3".to_string()),
         ),
         ("no txid", None, "k3", "v4", None, Some("v4".to_string())),
-    ];
-    for (name, txid, k, v, want_prev, want_result) in cases.iter() {
-        let resp = sm.apply(5, &ClientRequest {
-            txid: txid.clone(),
-            cmd: Cmd::AddFile {
-                key: k.to_string(),
-                value: v.to_string(),
-            },
-        });
-        assert_eq!(
-            ClientResponse::String {
-                prev: want_prev.clone(),
-                result: want_result.clone()
-            },
-            resp.unwrap(),
-            "{}",
-            name
-        );
-    }
-
-    Ok(())
+    ]
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_state_machine_apply_set_file() -> anyhow::Result<()> {
-    crate::tests::init_tracing();
-
-    let mut sm = MemStoreStateMachine::default();
-    let cases: Vec<(
-        &str,
-        Option<RaftTxId>,
-        &str,
-        &str,
-        Option<String>,
-        Option<String>,
-    )> = vec![
+// test cases for Cmd::SetFile
+// case_name, txid, key, value, want_prev, want_result
+pub fn cases_set_file() -> Vec<(
+    &'static str,
+    Option<RaftTxId>,
+    &'static str,
+    &'static str,
+    Option<String>,
+    Option<String>,
+)> {
+    vec![
         (
             "set on none",
             Some(RaftTxId::new("foo", 1)),
@@ -166,50 +142,7 @@ async fn test_state_machine_apply_set_file() -> anyhow::Result<()> {
             Some("v3".to_string()),
             Some("v4".to_string()),
         ),
-    ];
-    for (name, txid, k, v, want_prev, want_result) in cases.iter() {
-        let resp = sm.apply(5, &ClientRequest {
-            txid: txid.clone(),
-            cmd: Cmd::SetFile {
-                key: k.to_string(),
-                value: v.to_string(),
-            },
-        });
-        assert_eq!(
-            ClientResponse::String {
-                prev: want_prev.clone(),
-                result: want_result.clone()
-            },
-            resp.unwrap(),
-            "{}",
-            name
-        );
-    }
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
-    crate::tests::init_tracing();
-
-    let cases = cases_incr_seq();
-
-    let mut sm = MemStoreStateMachine::default();
-    for (name, txid, k, want) in cases.iter() {
-        let resp = sm.apply(5, &ClientRequest {
-            txid: txid.clone(),
-            cmd: Cmd::IncrSeq { key: k.to_string() },
-        });
-        assert_eq!(
-            ClientResponse::Seq { seq: *want },
-            resp.unwrap(),
-            "{}",
-            name
-        );
-    }
-
-    Ok(())
+    ]
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/fusestore/store/src/meta_service/state_machine_test.rs
+++ b/fusestore/store/src/meta_service/state_machine_test.rs
@@ -1,0 +1,106 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+use std::sync::Arc;
+
+use async_raft::RaftMetrics;
+use async_raft::State;
+use maplit::hashset;
+use pretty_assertions::assert_eq;
+use tokio::sync::watch::Receiver;
+use tokio::time::Duration;
+
+use crate::meta_service::ClientRequest;
+use crate::meta_service::ClientResponse;
+use crate::meta_service::Cmd;
+use crate::meta_service::GetReq;
+use crate::meta_service::MemStoreStateMachine;
+use crate::meta_service::MetaNode;
+use crate::meta_service::MetaServiceClient;
+use crate::meta_service::NodeId;
+use crate::meta_service::RaftTxId;
+use crate::tests::Seq;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {
+    crate::tests::init_tracing();
+
+    let mut sm = MemStoreStateMachine::default();
+
+    let cases = crate::meta_service::raftmeta_test::cases_add_file();
+
+    for (name, txid, k, v, want_prev, want_result) in cases.iter() {
+        let resp = sm.apply(5, &ClientRequest {
+            txid: txid.clone(),
+            cmd: Cmd::AddFile {
+                key: k.to_string(),
+                value: v.to_string(),
+            },
+        });
+        assert_eq!(
+            ClientResponse::String {
+                prev: want_prev.clone(),
+                result: want_result.clone()
+            },
+            resp.unwrap(),
+            "{}",
+            name
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_state_machine_apply_set_file() -> anyhow::Result<()> {
+    crate::tests::init_tracing();
+
+    let mut sm = MemStoreStateMachine::default();
+
+    let cases = crate::meta_service::raftmeta_test::cases_set_file();
+
+    for (name, txid, k, v, want_prev, want_result) in cases.iter() {
+        let resp = sm.apply(5, &ClientRequest {
+            txid: txid.clone(),
+            cmd: Cmd::SetFile {
+                key: k.to_string(),
+                value: v.to_string(),
+            },
+        });
+        assert_eq!(
+            ClientResponse::String {
+                prev: want_prev.clone(),
+                result: want_result.clone()
+            },
+            resp.unwrap(),
+            "{}",
+            name
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
+    crate::tests::init_tracing();
+
+    let mut sm = MemStoreStateMachine::default();
+
+    let cases = crate::meta_service::raftmeta_test::cases_incr_seq();
+
+    for (name, txid, k, want) in cases.iter() {
+        let resp = sm.apply(5, &ClientRequest {
+            txid: txid.clone(),
+            cmd: Cmd::IncrSeq { key: k.to_string() },
+        });
+        assert_eq!(
+            ClientResponse::Seq { seq: *want },
+            resp.unwrap(),
+            "{}",
+            name
+        );
+    }
+
+    Ok(())
+}

--- a/fusestore/store/src/meta_service/state_machine_test.rs
+++ b/fusestore/store/src/meta_service/state_machine_test.rs
@@ -1,25 +1,13 @@
 // Copyright 2020-2021 The Datafuse Authors.
 //
 // SPDX-License-Identifier: Apache-2.0.
-use std::sync::Arc;
 
-use async_raft::RaftMetrics;
-use async_raft::State;
-use maplit::hashset;
 use pretty_assertions::assert_eq;
-use tokio::sync::watch::Receiver;
-use tokio::time::Duration;
 
 use crate::meta_service::ClientRequest;
 use crate::meta_service::ClientResponse;
 use crate::meta_service::Cmd;
-use crate::meta_service::GetReq;
 use crate::meta_service::MemStoreStateMachine;
-use crate::meta_service::MetaNode;
-use crate::meta_service::MetaServiceClient;
-use crate::meta_service::NodeId;
-use crate::meta_service::RaftTxId;
-use crate::tests::Seq;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary

##### [store/meta] refine: the same test cases should be applied to both state-machine and the meta server

The meta server is no more than a state machine with log management.
Thus the command sequence that applies to the state-machine should also apply
to the meta server and both result in the same state.

The common test cases are extracted and are shared by both sets of
tests.

## Changelog


- Improvement



## Related Issues

#271