### PR TITLE
Rename trait type names from I$Name to $Name

### DIFF
--- a/common/aggregate_functions/src/aggregate_arg_max.rs
+++ b/common/aggregate_functions/src/aggregate_arg_max.rs
@@ -13,7 +13,7 @@ use common_exception::ErrorCodes;
 use common_exception::Result;
 
 use crate::aggregator_common::assert_binary_arguments;
-use crate::IAggregateFunction;
+use crate::AggregateFunction;
 
 #[derive(Clone)]
 pub struct AggregateArgMaxFunction {
@@ -26,7 +26,7 @@ impl AggregateArgMaxFunction {
     pub fn try_create(
         display_name: &str,
         arguments: Vec<DataField>,
-    ) -> Result<Box<dyn IAggregateFunction>> {
+    ) -> Result<Box<dyn AggregateFunction>> {
         assert_binary_arguments(display_name, arguments.len())?;
 
         Ok(Box::new(AggregateArgMaxFunction {
@@ -40,7 +40,7 @@ impl AggregateArgMaxFunction {
     }
 }
 
-impl IAggregateFunction for AggregateArgMaxFunction {
+impl AggregateFunction for AggregateArgMaxFunction {
     fn name(&self) -> &str {
         "AggregateArgMaxFunction"
     }

--- a/common/aggregate_functions/src/aggregate_arg_min.rs
+++ b/common/aggregate_functions/src/aggregate_arg_min.rs
@@ -13,7 +13,7 @@ use common_exception::ErrorCodes;
 use common_exception::Result;
 
 use crate::aggregator_common::assert_binary_arguments;
-use crate::IAggregateFunction;
+use crate::AggregateFunction;
 
 #[derive(Clone)]
 pub struct AggregateArgMinFunction {
@@ -26,7 +26,7 @@ impl AggregateArgMinFunction {
     pub fn try_create(
         display_name: &str,
         arguments: Vec<DataField>,
-    ) -> Result<Box<dyn IAggregateFunction>> {
+    ) -> Result<Box<dyn AggregateFunction>> {
         assert_binary_arguments(display_name, arguments.len())?;
 
         Ok(Box::new(AggregateArgMinFunction {
@@ -40,7 +40,7 @@ impl AggregateArgMinFunction {
     }
 }
 
-impl IAggregateFunction for AggregateArgMinFunction {
+impl AggregateFunction for AggregateArgMinFunction {
     fn name(&self) -> &str {
         "AggregateArgMinFunction"
     }

--- a/common/aggregate_functions/src/aggregate_avg.rs
+++ b/common/aggregate_functions/src/aggregate_avg.rs
@@ -14,8 +14,8 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::Result;
 
 use crate::aggregator_common::assert_unary_arguments;
+use crate::AggregateFunction;
 use crate::AggregateSumFunction;
-use crate::IAggregateFunction;
 
 #[derive(Clone)]
 pub struct AggregateAvgFunction {
@@ -28,7 +28,7 @@ impl AggregateAvgFunction {
     pub fn try_create(
         display_name: &str,
         arguments: Vec<DataField>,
-    ) -> Result<Box<dyn IAggregateFunction>> {
+    ) -> Result<Box<dyn AggregateFunction>> {
         assert_unary_arguments(display_name, arguments.len())?;
 
         Ok(Box::new(AggregateAvgFunction {
@@ -39,7 +39,7 @@ impl AggregateAvgFunction {
     }
 }
 
-impl IAggregateFunction for AggregateAvgFunction {
+impl AggregateFunction for AggregateAvgFunction {
     fn name(&self) -> &str {
         "AggregateAvgFunction"
     }

--- a/common/aggregate_functions/src/aggregate_count.rs
+++ b/common/aggregate_functions/src/aggregate_count.rs
@@ -14,7 +14,7 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::Result;
 
 use crate::aggregator_common::assert_variadic_arguments;
-use crate::IAggregateFunction;
+use crate::AggregateFunction;
 
 #[derive(Clone)]
 pub struct AggregateCountFunction {
@@ -27,7 +27,7 @@ impl AggregateCountFunction {
     pub fn try_create(
         display_name: &str,
         arguments: Vec<DataField>,
-    ) -> Result<Box<dyn IAggregateFunction>> {
+    ) -> Result<Box<dyn AggregateFunction>> {
         assert_variadic_arguments(display_name, arguments.len(), (0, 1))?;
 
         Ok(Box::new(AggregateCountFunction {
@@ -38,7 +38,7 @@ impl AggregateCountFunction {
     }
 }
 
-impl IAggregateFunction for AggregateCountFunction {
+impl AggregateFunction for AggregateCountFunction {
     fn name(&self) -> &str {
         "AggregateCountFunction"
     }

--- a/common/aggregate_functions/src/aggregate_function.rs
+++ b/common/aggregate_functions/src/aggregate_function.rs
@@ -11,7 +11,7 @@ use common_datavalues::DataValue;
 use common_exception::Result;
 use dyn_clone::DynClone;
 
-pub trait IAggregateFunction: fmt::Display + Sync + Send + DynClone {
+pub trait AggregateFunction: fmt::Display + Sync + Send + DynClone {
     fn name(&self) -> &str;
     fn return_type(&self) -> Result<DataType>;
     fn nullable(&self, _input_schema: &DataSchema) -> Result<bool>;
@@ -22,4 +22,4 @@ pub trait IAggregateFunction: fmt::Display + Sync + Send + DynClone {
     fn merge_result(&self) -> Result<DataValue>;
 }
 
-dyn_clone::clone_trait_object!(IAggregateFunction);
+dyn_clone::clone_trait_object!(AggregateFunction);

--- a/common/aggregate_functions/src/aggregate_function_factory.rs
+++ b/common/aggregate_functions/src/aggregate_function_factory.rs
@@ -12,11 +12,11 @@ use indexmap::IndexMap;
 use lazy_static::lazy_static;
 
 use crate::aggregator::AggregatorFunction;
-use crate::IAggregateFunction;
+use crate::AggregateFunction;
 
 pub struct AggregateFunctionFactory;
 pub type FactoryFunc =
-    fn(name: &str, arguments: Vec<DataField>) -> Result<Box<dyn IAggregateFunction>>;
+    fn(name: &str, arguments: Vec<DataField>) -> Result<Box<dyn AggregateFunction>>;
 
 pub type FactoryFuncRef = Arc<RwLock<IndexMap<&'static str, FactoryFunc>>>;
 
@@ -30,7 +30,7 @@ lazy_static! {
 }
 
 impl AggregateFunctionFactory {
-    pub fn get(name: &str, arguments: Vec<DataField>) -> Result<Box<dyn IAggregateFunction>> {
+    pub fn get(name: &str, arguments: Vec<DataField>) -> Result<Box<dyn AggregateFunction>> {
         let map = FACTORY.read();
         let creator = map.get(&*name.to_lowercase()).ok_or_else(|| {
             ErrorCodes::UnknownAggregateFunction(format!("Unsupported AggregateFunction: {}", name))

--- a/common/aggregate_functions/src/aggregate_max.rs
+++ b/common/aggregate_functions/src/aggregate_max.rs
@@ -9,7 +9,7 @@ use common_exception::ErrorCodes;
 use common_exception::Result;
 
 use crate::aggregator_common::assert_unary_arguments;
-use crate::IAggregateFunction;
+use crate::AggregateFunction;
 
 #[derive(Clone)]
 pub struct AggregateMaxFunction {
@@ -22,7 +22,7 @@ impl AggregateMaxFunction {
     pub fn try_create(
         display_name: &str,
         arguments: Vec<DataField>,
-    ) -> Result<Box<dyn IAggregateFunction>> {
+    ) -> Result<Box<dyn AggregateFunction>> {
         assert_unary_arguments(display_name, arguments.len())?;
 
         Ok(Box::new(AggregateMaxFunction {
@@ -33,7 +33,7 @@ impl AggregateMaxFunction {
     }
 }
 
-impl IAggregateFunction for AggregateMaxFunction {
+impl AggregateFunction for AggregateMaxFunction {
     fn name(&self) -> &str {
         "AggregateMaxFunction"
     }

--- a/common/aggregate_functions/src/aggregate_min.rs
+++ b/common/aggregate_functions/src/aggregate_min.rs
@@ -9,7 +9,7 @@ use common_exception::ErrorCodes;
 use common_exception::Result;
 
 use crate::aggregator_common::assert_unary_arguments;
-use crate::IAggregateFunction;
+use crate::AggregateFunction;
 
 #[derive(Clone)]
 pub struct AggregateMinFunction {
@@ -22,7 +22,7 @@ impl AggregateMinFunction {
     pub fn try_create(
         display_name: &str,
         arguments: Vec<DataField>,
-    ) -> Result<Box<dyn IAggregateFunction>> {
+    ) -> Result<Box<dyn AggregateFunction>> {
         assert_unary_arguments(display_name, arguments.len())?;
 
         Ok(Box::new(AggregateMinFunction {
@@ -33,7 +33,7 @@ impl AggregateMinFunction {
     }
 }
 
-impl IAggregateFunction for AggregateMinFunction {
+impl AggregateFunction for AggregateMinFunction {
     fn name(&self) -> &str {
         "AggregateMinFunction"
     }

--- a/common/aggregate_functions/src/aggregate_sum.rs
+++ b/common/aggregate_functions/src/aggregate_sum.rs
@@ -10,7 +10,7 @@ use common_exception::ErrorCodes;
 use common_exception::Result;
 
 use crate::aggregator_common::assert_unary_arguments;
-use crate::IAggregateFunction;
+use crate::AggregateFunction;
 
 #[derive(Clone)]
 pub struct AggregateSumFunction {
@@ -23,7 +23,7 @@ impl AggregateSumFunction {
     pub fn try_create(
         display_name: &str,
         arguments: Vec<DataField>,
-    ) -> Result<Box<dyn IAggregateFunction>> {
+    ) -> Result<Box<dyn AggregateFunction>> {
         assert_unary_arguments(display_name, arguments.len())?;
 
         let return_type = Self::sum_return_type(arguments[0].data_type())?;
@@ -35,7 +35,7 @@ impl AggregateSumFunction {
     }
 }
 
-impl IAggregateFunction for AggregateSumFunction {
+impl AggregateFunction for AggregateSumFunction {
     fn name(&self) -> &str {
         "AggregateSumFunction"
     }

--- a/common/aggregate_functions/src/lib.rs
+++ b/common/aggregate_functions/src/lib.rs
@@ -24,7 +24,7 @@ pub use aggregate_arg_max::AggregateArgMaxFunction;
 pub use aggregate_arg_min::AggregateArgMinFunction;
 pub use aggregate_avg::AggregateAvgFunction;
 pub use aggregate_count::AggregateCountFunction;
-pub use aggregate_function::IAggregateFunction;
+pub use aggregate_function::AggregateFunction;
 pub use aggregate_function_factory::AggregateFunctionFactory;
 pub use aggregate_max::AggregateMaxFunction;
 pub use aggregate_min::AggregateMinFunction;

--- a/common/functions/src/arithmetics/arithmetic.rs
+++ b/common/functions/src/arithmetics/arithmetic.rs
@@ -18,7 +18,7 @@ use crate::arithmetics::ArithmeticModuloFunction;
 use crate::arithmetics::ArithmeticMulFunction;
 use crate::arithmetics::ArithmeticPlusFunction;
 use crate::FactoryFuncRef;
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone)]
 pub struct ArithmeticFunction {
@@ -41,12 +41,12 @@ impl ArithmeticFunction {
         Ok(())
     }
 
-    pub fn try_create_func(op: DataValueArithmeticOperator) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(op: DataValueArithmeticOperator) -> Result<Box<dyn Function>> {
         Ok(Box::new(ArithmeticFunction { op }))
     }
 }
 
-impl IFunction for ArithmeticFunction {
+impl Function for ArithmeticFunction {
     fn name(&self) -> &str {
         "ArithmeticFunction"
     }

--- a/common/functions/src/arithmetics/arithmetic_div.rs
+++ b/common/functions/src/arithmetics/arithmetic_div.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::Result;
 
 use crate::arithmetics::ArithmeticFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ArithmeticDivFunction;
 
 impl ArithmeticDivFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Div)
     }
 }

--- a/common/functions/src/arithmetics/arithmetic_minus.rs
+++ b/common/functions/src/arithmetics/arithmetic_minus.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::Result;
 
 use crate::arithmetics::ArithmeticFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ArithmeticMinusFunction;
 
 impl ArithmeticMinusFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Minus)
     }
 }

--- a/common/functions/src/arithmetics/arithmetic_modulo.rs
+++ b/common/functions/src/arithmetics/arithmetic_modulo.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::Result;
 
 use crate::arithmetics::ArithmeticFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ArithmeticModuloFunction;
 
 impl ArithmeticModuloFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Modulo)
     }
 }

--- a/common/functions/src/arithmetics/arithmetic_mul.rs
+++ b/common/functions/src/arithmetics/arithmetic_mul.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::Result;
 
 use crate::arithmetics::ArithmeticFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ArithmeticMulFunction;
 
 impl ArithmeticMulFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Mul)
     }
 }

--- a/common/functions/src/arithmetics/arithmetic_plus.rs
+++ b/common/functions/src/arithmetics/arithmetic_plus.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueArithmeticOperator;
 use common_exception::Result;
 
 use crate::arithmetics::ArithmeticFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ArithmeticPlusFunction;
 
 impl ArithmeticPlusFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ArithmeticFunction::try_create_func(DataValueArithmeticOperator::Plus)
     }
 }

--- a/common/functions/src/arithmetics/arithmetic_test.rs
+++ b/common/functions/src/arithmetics/arithmetic_test.rs
@@ -29,7 +29,7 @@ fn test_arithmetic_function() -> Result<()> {
         columns: Vec<DataColumnarValue>,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>,
+        func: Box<dyn Function>,
     }
 
     let schema = DataSchemaRefExt::create(vec![

--- a/common/functions/src/comparisons/comparison.rs
+++ b/common/functions/src/comparisons/comparison.rs
@@ -18,7 +18,7 @@ use crate::comparisons::ComparisonLtEqFunction;
 use crate::comparisons::ComparisonLtFunction;
 use crate::comparisons::ComparisonNotEqFunction;
 use crate::FactoryFuncRef;
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone)]
 pub struct ComparisonFunction {
@@ -39,12 +39,12 @@ impl ComparisonFunction {
         Ok(())
     }
 
-    pub fn try_create_func(op: DataValueComparisonOperator) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(op: DataValueComparisonOperator) -> Result<Box<dyn Function>> {
         Ok(Box::new(ComparisonFunction { op }))
     }
 }
 
-impl IFunction for ComparisonFunction {
+impl Function for ComparisonFunction {
     fn name(&self) -> &str {
         "ComparisonFunction"
     }

--- a/common/functions/src/comparisons/comparison_eq.rs
+++ b/common/functions/src/comparisons/comparison_eq.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueComparisonOperator;
 use common_exception::Result;
 
 use crate::comparisons::ComparisonFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ComparisonEqFunction;
 
 impl ComparisonEqFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::Eq)
     }
 }

--- a/common/functions/src/comparisons/comparison_gt.rs
+++ b/common/functions/src/comparisons/comparison_gt.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueComparisonOperator;
 use common_exception::Result;
 
 use crate::comparisons::ComparisonFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ComparisonGtFunction;
 
 impl ComparisonGtFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::Gt)
     }
 }

--- a/common/functions/src/comparisons/comparison_gt_eq.rs
+++ b/common/functions/src/comparisons/comparison_gt_eq.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueComparisonOperator;
 use common_exception::Result;
 
 use crate::comparisons::ComparisonFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ComparisonGtEqFunction;
 
 impl ComparisonGtEqFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::GtEq)
     }
 }

--- a/common/functions/src/comparisons/comparison_lt.rs
+++ b/common/functions/src/comparisons/comparison_lt.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueComparisonOperator;
 use common_exception::Result;
 
 use crate::comparisons::ComparisonFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ComparisonLtFunction;
 
 impl ComparisonLtFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::Lt)
     }
 }

--- a/common/functions/src/comparisons/comparison_lt_eq.rs
+++ b/common/functions/src/comparisons/comparison_lt_eq.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueComparisonOperator;
 use common_exception::Result;
 
 use crate::comparisons::ComparisonFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ComparisonLtEqFunction;
 
 impl ComparisonLtEqFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::LtEq)
     }
 }

--- a/common/functions/src/comparisons/comparison_not_eq.rs
+++ b/common/functions/src/comparisons/comparison_not_eq.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueComparisonOperator;
 use common_exception::Result;
 
 use crate::comparisons::ComparisonFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct ComparisonNotEqFunction;
 
 impl ComparisonNotEqFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         ComparisonFunction::try_create_func(DataValueComparisonOperator::NotEq)
     }
 }

--- a/common/functions/src/comparisons/comparison_test.rs
+++ b/common/functions/src/comparisons/comparison_test.rs
@@ -22,7 +22,7 @@ fn test_comparison_function() -> Result<()> {
         columns: Vec<DataColumnarValue>,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>,
+        func: Box<dyn Function>,
     }
 
     let schema = DataSchemaRefExt::create(vec![

--- a/common/functions/src/expressions/cast.rs
+++ b/common/functions/src/expressions/cast.rs
@@ -11,7 +11,7 @@ use common_datavalues::DataSchema;
 use common_datavalues::DataType;
 use common_exception::Result;
 
-use crate::function::IFunction;
+use crate::function::Function;
 
 /// provide Datafuse default cast options
 pub const DEFAULT_DATAFUSE_CAST_OPTIONS: CastOptions = CastOptions { safe: false };
@@ -23,12 +23,12 @@ pub struct CastFunction {
 }
 
 impl CastFunction {
-    pub fn create(cast_type: DataType) -> Box<dyn IFunction> {
+    pub fn create(cast_type: DataType) -> Box<dyn Function> {
         Box::new(Self { cast_type })
     }
 }
 
-impl IFunction for CastFunction {
+impl Function for CastFunction {
     fn name(&self) -> &str {
         "CastFunction"
     }

--- a/common/functions/src/expressions/cast_test.rs
+++ b/common/functions/src/expressions/cast_test.rs
@@ -21,7 +21,7 @@ fn test_cast_function() -> Result<()> {
         cast_type: DataType,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>,
+        func: Box<dyn Function>,
     }
 
     let tests = vec![

--- a/common/functions/src/function.rs
+++ b/common/functions/src/function.rs
@@ -10,7 +10,7 @@ use common_datavalues::DataType;
 use common_exception::Result;
 use dyn_clone::DynClone;
 
-pub trait IFunction: fmt::Display + Sync + Send + DynClone {
+pub trait Function: fmt::Display + Sync + Send + DynClone {
     fn name(&self) -> &str;
 
     fn num_arguments(&self) -> usize {

--- a/common/functions/src/function_alias.rs
+++ b/common/functions/src/function_alias.rs
@@ -9,7 +9,7 @@ use common_datavalues::DataSchema;
 use common_datavalues::DataType;
 use common_exception::Result;
 
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone)]
 pub struct AliasFunction {
@@ -17,12 +17,12 @@ pub struct AliasFunction {
 }
 
 impl AliasFunction {
-    pub fn try_create(alias: String) -> Result<Box<dyn IFunction>> {
+    pub fn try_create(alias: String) -> Result<Box<dyn Function>> {
         Ok(Box::new(AliasFunction { alias }))
     }
 }
 
-impl IFunction for AliasFunction {
+impl Function for AliasFunction {
     fn name(&self) -> &str {
         "AliasFunction"
     }

--- a/common/functions/src/function_column.rs
+++ b/common/functions/src/function_column.rs
@@ -10,7 +10,7 @@ use common_datavalues::DataType;
 use common_datavalues::DataValue;
 use common_exception::Result;
 
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone, Debug)]
 pub struct ColumnFunction {
@@ -19,7 +19,7 @@ pub struct ColumnFunction {
 }
 
 impl ColumnFunction {
-    pub fn try_create(value: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create(value: &str) -> Result<Box<dyn Function>> {
         Ok(Box::new(ColumnFunction {
             value: value.to_string(),
             saved: None,
@@ -27,7 +27,7 @@ impl ColumnFunction {
     }
 }
 
-impl IFunction for ColumnFunction {
+impl Function for ColumnFunction {
     fn name(&self) -> &str {
         "ColumnFunction"
     }

--- a/common/functions/src/function_factory.rs
+++ b/common/functions/src/function_factory.rs
@@ -16,10 +16,10 @@ use crate::hashes::HashesFunction;
 use crate::logics::LogicFunction;
 use crate::strings::StringFunction;
 use crate::udfs::UdfFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct FunctionFactory;
-pub type FactoryFunc = fn(name: &str) -> Result<Box<dyn IFunction>>;
+pub type FactoryFunc = fn(name: &str) -> Result<Box<dyn Function>>;
 
 pub type FactoryFuncRef = Arc<RwLock<IndexMap<&'static str, FactoryFunc>>>;
 
@@ -37,7 +37,7 @@ lazy_static! {
 }
 
 impl FunctionFactory {
-    pub fn get(name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn get(name: &str) -> Result<Box<dyn Function>> {
         let map = FACTORY.read();
         let creator = map.get(&*name.to_lowercase()).ok_or_else(|| {
             ErrorCodes::UnknownFunction(format!("Unsupported Function: {}", name))

--- a/common/functions/src/function_literal.rs
+++ b/common/functions/src/function_literal.rs
@@ -10,7 +10,7 @@ use common_datavalues::DataType;
 use common_datavalues::DataValue;
 use common_exception::Result;
 
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone, Debug)]
 pub struct LiteralFunction {
@@ -18,12 +18,12 @@ pub struct LiteralFunction {
 }
 
 impl LiteralFunction {
-    pub fn try_create(value: DataValue) -> Result<Box<dyn IFunction>> {
+    pub fn try_create(value: DataValue) -> Result<Box<dyn Function>> {
         Ok(Box::new(LiteralFunction { value }))
     }
 }
 
-impl IFunction for LiteralFunction {
+impl Function for LiteralFunction {
     fn name(&self) -> &str {
         "LiteralFunction"
     }

--- a/common/functions/src/hashes/siphash.rs
+++ b/common/functions/src/hashes/siphash.rs
@@ -14,7 +14,7 @@ use common_datavalues::FuseDataHasher;
 use common_exception::ErrorCodes;
 use common_exception::Result;
 
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone)]
 pub struct SipHashFunction {
@@ -24,14 +24,14 @@ pub struct SipHashFunction {
 struct SipHasher;
 
 impl SipHashFunction {
-    pub fn try_create(display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create(display_name: &str) -> Result<Box<dyn Function>> {
         Ok(Box::new(SipHashFunction {
             display_name: display_name.to_string(),
         }))
     }
 }
 
-impl IFunction for SipHashFunction {
+impl Function for SipHashFunction {
     fn name(&self) -> &str {
         "siphash"
     }

--- a/common/functions/src/lib.rs
+++ b/common/functions/src/lib.rs
@@ -19,7 +19,7 @@ mod strings;
 mod udfs;
 
 pub use expressions::CastFunction;
-pub use function::IFunction;
+pub use function::Function;
 pub use function_alias::AliasFunction;
 pub use function_column::ColumnFunction;
 pub use function_factory::FactoryFuncRef;

--- a/common/functions/src/logics/logic.rs
+++ b/common/functions/src/logics/logic.rs
@@ -15,7 +15,7 @@ use crate::logics::LogicAndFunction;
 use crate::logics::LogicNotFunction;
 use crate::logics::LogicOrFunction;
 use crate::FactoryFuncRef;
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone)]
 pub struct LogicFunction {
@@ -31,12 +31,12 @@ impl LogicFunction {
         Ok(())
     }
 
-    pub fn try_create_func(op: DataValueLogicOperator) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(op: DataValueLogicOperator) -> Result<Box<dyn Function>> {
         Ok(Box::new(LogicFunction { op }))
     }
 }
 
-impl IFunction for LogicFunction {
+impl Function for LogicFunction {
     fn name(&self) -> &str {
         "LogicFunction"
     }

--- a/common/functions/src/logics/logic_and.rs
+++ b/common/functions/src/logics/logic_and.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueLogicOperator;
 use common_exception::Result;
 
 use crate::logics::LogicFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct LogicAndFunction;
 
 impl LogicAndFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         LogicFunction::try_create_func(DataValueLogicOperator::And)
     }
 }

--- a/common/functions/src/logics/logic_not.rs
+++ b/common/functions/src/logics/logic_not.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueLogicOperator;
 use common_exception::Result;
 
 use crate::logics::LogicFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct LogicNotFunction;
 
 impl LogicNotFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         LogicFunction::try_create_func(DataValueLogicOperator::Not)
     }
 }

--- a/common/functions/src/logics/logic_or.rs
+++ b/common/functions/src/logics/logic_or.rs
@@ -6,12 +6,12 @@ use common_datavalues::DataValueLogicOperator;
 use common_exception::Result;
 
 use crate::logics::LogicFunction;
-use crate::IFunction;
+use crate::Function;
 
 pub struct LogicOrFunction;
 
 impl LogicOrFunction {
-    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create_func(_display_name: &str) -> Result<Box<dyn Function>> {
         LogicFunction::try_create_func(DataValueLogicOperator::Or)
     }
 }

--- a/common/functions/src/logics/logic_test.rs
+++ b/common/functions/src/logics/logic_test.rs
@@ -24,7 +24,7 @@ fn test_logic_function() -> Result<()> {
         columns: Vec<DataColumnarValue>,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>,
+        func: Box<dyn Function>,
     }
 
     let schema = DataSchemaRefExt::create(vec![

--- a/common/functions/src/strings/substring.rs
+++ b/common/functions/src/strings/substring.rs
@@ -13,7 +13,7 @@ use common_datavalues::UInt64Array;
 use common_exception::ErrorCodes;
 use common_exception::Result;
 
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone)]
 pub struct SubstringFunction {
@@ -21,14 +21,14 @@ pub struct SubstringFunction {
 }
 
 impl SubstringFunction {
-    pub fn try_create(display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create(display_name: &str) -> Result<Box<dyn Function>> {
         Ok(Box::new(SubstringFunction {
             display_name: display_name.to_string(),
         }))
     }
 }
 
-impl IFunction for SubstringFunction {
+impl Function for SubstringFunction {
     fn name(&self) -> &str {
         "substring"
     }

--- a/common/functions/src/strings/substring_test.rs
+++ b/common/functions/src/strings/substring_test.rs
@@ -9,7 +9,7 @@ use common_exception::Result;
 use pretty_assertions::assert_eq;
 
 use crate::strings::SubstringFunction;
-use crate::IFunction;
+use crate::Function;
 
 #[test]
 fn test_substring_function() -> Result<()> {
@@ -22,7 +22,7 @@ fn test_substring_function() -> Result<()> {
         columns: Vec<DataColumnarValue>,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>,
+        func: Box<dyn Function>,
     }
 
     let schema = DataSchemaRefExt::create(vec![

--- a/common/functions/src/udfs/database.rs
+++ b/common/functions/src/udfs/database.rs
@@ -9,19 +9,19 @@ use common_datavalues::DataSchema;
 use common_datavalues::DataType;
 use common_exception::Result;
 
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone)]
 pub struct DatabaseFunction {}
 
 // we bind database as first argument in eval
 impl DatabaseFunction {
-    pub fn try_create(_display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create(_display_name: &str) -> Result<Box<dyn Function>> {
         Ok(Box::new(DatabaseFunction {}))
     }
 }
 
-impl IFunction for DatabaseFunction {
+impl Function for DatabaseFunction {
     fn name(&self) -> &str {
         "DatabaseFunction"
     }

--- a/common/functions/src/udfs/database_test.rs
+++ b/common/functions/src/udfs/database_test.rs
@@ -20,7 +20,7 @@ fn test_database_function() -> anyhow::Result<()> {
         columns: Vec<DataColumnarValue>,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>,
+        func: Box<dyn Function>,
     }
 
     let tests = vec![Test {

--- a/common/functions/src/udfs/to_type_name.rs
+++ b/common/functions/src/udfs/to_type_name.rs
@@ -10,7 +10,7 @@ use common_datavalues::DataType;
 use common_datavalues::DataValue;
 use common_exception::Result;
 
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone)]
 pub struct ToTypeNameFunction {
@@ -18,14 +18,14 @@ pub struct ToTypeNameFunction {
 }
 
 impl ToTypeNameFunction {
-    pub fn try_create(display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create(display_name: &str) -> Result<Box<dyn Function>> {
         Ok(Box::new(ToTypeNameFunction {
             display_name: display_name.to_string(),
         }))
     }
 }
 
-impl IFunction for ToTypeNameFunction {
+impl Function for ToTypeNameFunction {
     fn name(&self) -> &str {
         "ToTypeNameFunction"
     }

--- a/common/functions/src/udfs/to_type_name_test.rs
+++ b/common/functions/src/udfs/to_type_name_test.rs
@@ -22,7 +22,7 @@ fn test_to_type_name_function() -> Result<()> {
         columns: Vec<DataColumnarValue>,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>,
+        func: Box<dyn Function>,
     }
 
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Boolean, false)]);

--- a/common/functions/src/udfs/udf_example.rs
+++ b/common/functions/src/udfs/udf_example.rs
@@ -10,7 +10,7 @@ use common_datavalues::DataType;
 use common_datavalues::DataValue;
 use common_exception::Result;
 
-use crate::IFunction;
+use crate::Function;
 
 #[derive(Clone)]
 pub struct UdfExampleFunction {
@@ -18,14 +18,14 @@ pub struct UdfExampleFunction {
 }
 
 impl UdfExampleFunction {
-    pub fn try_create(display_name: &str) -> Result<Box<dyn IFunction>> {
+    pub fn try_create(display_name: &str) -> Result<Box<dyn Function>> {
         Ok(Box::new(UdfExampleFunction {
             display_name: display_name.to_string(),
         }))
     }
 }
 
-impl IFunction for UdfExampleFunction {
+impl Function for UdfExampleFunction {
     fn name(&self) -> &str {
         "UdfExampleFunction"
     }

--- a/common/functions/src/udfs/udf_example_test.rs
+++ b/common/functions/src/udfs/udf_example_test.rs
@@ -24,7 +24,7 @@ fn test_udf_example_function() -> anyhow::Result<()> {
         columns: Vec<DataColumnarValue>,
         expect: DataArrayRef,
         error: &'static str,
-        func: Box<dyn IFunction>,
+        func: Box<dyn Function>,
     }
 
     let schema = DataSchemaRefExt::create(vec![

--- a/common/planners/src/plan_expression.rs
+++ b/common/planners/src/plan_expression.rs
@@ -5,8 +5,8 @@
 use std::fmt;
 use std::sync::Arc;
 
+use common_aggregate_functions::AggregateFunction;
 use common_aggregate_functions::AggregateFunctionFactory;
-use common_aggregate_functions::IAggregateFunction;
 use common_datavalues::DataField;
 use common_datavalues::DataSchemaRef;
 use common_datavalues::DataType;
@@ -150,7 +150,7 @@ impl Expression {
     pub fn to_aggregate_function(
         &self,
         schema: &DataSchemaRef,
-    ) -> Result<Box<dyn IAggregateFunction>> {
+    ) -> Result<Box<dyn AggregateFunction>> {
         match self {
             Expression::AggregateFunction { op, args } => {
                 let mut fields = Vec::with_capacity(args.len());

--- a/common/planners/src/plan_expression_chain.rs
+++ b/common/planners/src/plan_expression_chain.rs
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use common_aggregate_functions::AggregateFunction;
 use common_aggregate_functions::AggregateFunctionFactory;
-use common_aggregate_functions::IAggregateFunction;
 use common_datavalues::DataField;
 use common_datavalues::DataSchemaRef;
 use common_datavalues::DataType;
@@ -11,8 +11,8 @@ use common_datavalues::DataValue;
 use common_exception::ErrorCodes;
 use common_exception::Result;
 use common_functions::CastFunction;
+use common_functions::Function;
 use common_functions::FunctionFactory;
-use common_functions::IFunction;
 
 use crate::Expression;
 
@@ -246,7 +246,7 @@ impl ExpressionAction {
 }
 
 impl ActionFunction {
-    pub fn to_function(&self) -> Result<Box<dyn IFunction>> {
+    pub fn to_function(&self) -> Result<Box<dyn Function>> {
         if self.is_aggregated {
             return Err(ErrorCodes::LogicalError(
                 "Action must be non-aggregated function",
@@ -259,7 +259,7 @@ impl ActionFunction {
         }
     }
 
-    pub fn to_aggregate_function(&self) -> Result<Box<dyn IAggregateFunction>> {
+    pub fn to_aggregate_function(&self) -> Result<Box<dyn AggregateFunction>> {
         if !self.is_aggregated {
             return Err(ErrorCodes::LogicalError(
                 "Action must be aggregated function",

--- a/common/planners/src/plan_expression_literal.rs
+++ b/common/planners/src/plan_expression_literal.rs
@@ -6,17 +6,17 @@ use common_datavalues::DataValue;
 
 use crate::Expression;
 
-pub trait ILiteral {
+pub trait Literal {
     fn to_literal(&self) -> Expression;
 }
 
-impl ILiteral for &str {
+impl Literal for &str {
     fn to_literal(&self) -> Expression {
         Expression::Literal(DataValue::Utf8(Some(self.to_string())))
     }
 }
 
-impl ILiteral for String {
+impl Literal for String {
     fn to_literal(&self) -> Expression {
         Expression::Literal(DataValue::Utf8(Some(self.clone())))
     }
@@ -25,7 +25,7 @@ impl ILiteral for String {
 macro_rules! make_literal {
     ($TYPE:ty, $SCALAR:ident) => {
         #[allow(missing_docs)]
-        impl ILiteral for $TYPE {
+        impl Literal for $TYPE {
             fn to_literal(&self) -> Expression {
                 Expression::Literal(DataValue::$SCALAR(Some(self.clone())))
             }
@@ -45,6 +45,6 @@ make_literal!(u16, UInt16);
 make_literal!(u32, UInt32);
 make_literal!(u64, UInt64);
 
-pub fn lit<T: ILiteral>(n: T) -> Expression {
+pub fn lit<T: Literal>(n: T) -> Expression {
     n.to_literal()
 }

--- a/common/planners/src/plan_expression_validator.rs
+++ b/common/planners/src/plan_expression_validator.rs
@@ -4,8 +4,8 @@
 
 use common_exception::ErrorCodes;
 use common_exception::Result;
+use common_functions::Function;
 use common_functions::FunctionFactory;
-use common_functions::IFunction;
 
 use crate::Expression;
 use crate::ExpressionVisitor;
@@ -45,7 +45,7 @@ where F: Fn(&Expression) -> Result<()>
     }
 }
 
-fn validate_function_arg(func: Box<dyn IFunction>, args: &[Expression]) -> Result<()> {
+fn validate_function_arg(func: Box<dyn Function>, args: &[Expression]) -> Result<()> {
     match func.variadic_arguments() {
         Some((start, end)) => {
             return if args.len() < start || args.len() > end {

--- a/fusequery/benchmarks/nyctaxi/src/bin/nyctaxi.rs
+++ b/fusequery/benchmarks/nyctaxi/src/bin/nyctaxi.rs
@@ -14,7 +14,7 @@ use common_planners::CreateTablePlan;
 use common_planners::TableEngineType;
 use common_planners::TableOptions;
 use fuse_query::interpreters::InterpreterFactory;
-use fuse_query::optimizers::Optimizer;
+use fuse_query::optimizers::Optimizers;
 use fuse_query::sessions::FuseQueryContext;
 use fuse_query::sql::PlanParser;
 use futures::TryStreamExt;
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         for i in 0..opt.iterations {
             let start = Instant::now();
             let plan = PlanParser::create(ctx.clone()).build_from_sql(sql)?;
-            let plan = Optimizer::create(ctx.clone()).optimize(&plan)?;
+            let plan = Optimizers::create(ctx.clone()).optimize(&plan)?;
             let executor = InterpreterFactory::get(ctx.clone(), plan)?;
             let stream = executor.execute().await?;
 

--- a/fusequery/query/src/datasources/database.rs
+++ b/fusequery/query/src/datasources/database.rs
@@ -8,24 +8,24 @@ use common_exception::Result;
 use common_planners::CreateTablePlan;
 use common_planners::DropTablePlan;
 
-use crate::datasources::ITable;
-use crate::datasources::ITableFunction;
+use crate::datasources::Table;
+use crate::datasources::TableFunction;
 
 #[async_trait::async_trait]
-pub trait IDatabase: Sync + Send {
+pub trait Database: Sync + Send {
     /// Database name.
     fn name(&self) -> &str;
     fn engine(&self) -> &str;
     fn is_local(&self) -> bool;
 
     /// Get one table by name.
-    fn get_table(&self, table_name: &str) -> Result<Arc<dyn ITable>>;
+    fn get_table(&self, table_name: &str) -> Result<Arc<dyn Table>>;
 
     /// Get all tables.
-    fn get_tables(&self) -> Result<Vec<Arc<dyn ITable>>>;
+    fn get_tables(&self) -> Result<Vec<Arc<dyn Table>>>;
 
     /// Get database table functions.
-    fn get_table_functions(&self) -> Result<Vec<Arc<dyn ITableFunction>>>;
+    fn get_table_functions(&self) -> Result<Vec<Arc<dyn TableFunction>>>;
 
     /// DDL
     async fn create_table(&self, plan: CreateTablePlan) -> Result<()>;

--- a/fusequery/query/src/datasources/local/csv_table.rs
+++ b/fusequery/query/src/datasources/local/csv_table.rs
@@ -18,7 +18,7 @@ use common_streams::SendableDataBlockStream;
 
 use crate::datasources::local::CsvTableStream;
 use crate::datasources::Common;
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct CsvTable {
@@ -35,7 +35,7 @@ impl CsvTable {
         name: String,
         schema: DataSchemaRef,
         options: TableOptions,
-    ) -> Result<Box<dyn ITable>> {
+    ) -> Result<Box<dyn Table>> {
         let has_header = options.get("has_header").is_some();
         let file = match options.get("location") {
             None => {
@@ -57,7 +57,7 @@ impl CsvTable {
 }
 
 #[async_trait::async_trait]
-impl ITable for CsvTable {
+impl Table for CsvTable {
     fn name(&self) -> &str {
         &self.name
     }

--- a/fusequery/query/src/datasources/local/local_database.rs
+++ b/fusequery/query/src/datasources/local/local_database.rs
@@ -15,12 +15,12 @@ use common_planners::TableEngineType;
 use crate::datasources::local::CsvTable;
 use crate::datasources::local::NullTable;
 use crate::datasources::local::ParquetTable;
-use crate::datasources::IDatabase;
-use crate::datasources::ITable;
-use crate::datasources::ITableFunction;
+use crate::datasources::Database;
+use crate::datasources::Table;
+use crate::datasources::TableFunction;
 
 pub struct LocalDatabase {
-    tables: RwLock<HashMap<String, Arc<dyn ITable>>>,
+    tables: RwLock<HashMap<String, Arc<dyn Table>>>,
 }
 
 impl LocalDatabase {
@@ -32,7 +32,7 @@ impl LocalDatabase {
 }
 
 #[async_trait::async_trait]
-impl IDatabase for LocalDatabase {
+impl Database for LocalDatabase {
     fn name(&self) -> &str {
         "local"
     }
@@ -45,7 +45,7 @@ impl IDatabase for LocalDatabase {
         true
     }
 
-    fn get_table(&self, table_name: &str) -> Result<Arc<dyn ITable>> {
+    fn get_table(&self, table_name: &str) -> Result<Arc<dyn Table>> {
         let table_lock = self.tables.read();
         let table = table_lock
             .get(table_name)
@@ -53,11 +53,11 @@ impl IDatabase for LocalDatabase {
         Ok(table.clone())
     }
 
-    fn get_tables(&self) -> Result<Vec<Arc<dyn ITable>>> {
+    fn get_tables(&self) -> Result<Vec<Arc<dyn Table>>> {
         Ok(self.tables.read().values().cloned().collect())
     }
 
-    fn get_table_functions(&self) -> Result<Vec<Arc<dyn ITableFunction>>> {
+    fn get_table_functions(&self) -> Result<Vec<Arc<dyn TableFunction>>> {
         Ok(vec![])
     }
 

--- a/fusequery/query/src/datasources/local/local_factory.rs
+++ b/fusequery/query/src/datasources/local/local_factory.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use common_exception::Result;
 
 use crate::datasources::local::LocalDatabase;
-use crate::datasources::IDatabase;
+use crate::datasources::Database;
 
 pub struct LocalFactory;
 
@@ -16,8 +16,8 @@ impl LocalFactory {
         Self
     }
 
-    pub fn load_databases(&self) -> Result<Vec<Arc<dyn IDatabase>>> {
-        let databases: Vec<Arc<dyn IDatabase>> = vec![Arc::new(LocalDatabase::create())];
+    pub fn load_databases(&self) -> Result<Vec<Arc<dyn Database>>> {
+        let databases: Vec<Arc<dyn Database>> = vec![Arc::new(LocalDatabase::create())];
         Ok(databases)
     }
 }

--- a/fusequery/query/src/datasources/local/null_table.rs
+++ b/fusequery/query/src/datasources/local/null_table.rs
@@ -16,7 +16,7 @@ use common_planners::TableOptions;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct NullTable {
@@ -31,14 +31,14 @@ impl NullTable {
         name: String,
         schema: DataSchemaRef,
         _options: TableOptions,
-    ) -> Result<Box<dyn ITable>> {
+    ) -> Result<Box<dyn Table>> {
         let table = Self { db, name, schema };
         Ok(Box::new(table))
     }
 }
 
 #[async_trait::async_trait]
-impl ITable for NullTable {
+impl Table for NullTable {
     fn name(&self) -> &str {
         &self.name
     }

--- a/fusequery/query/src/datasources/local/parquet_table.rs
+++ b/fusequery/query/src/datasources/local/parquet_table.rs
@@ -26,7 +26,7 @@ use crossbeam::channel::Receiver;
 use crossbeam::channel::Sender;
 use tokio::task;
 
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct ParquetTable {
@@ -42,7 +42,7 @@ impl ParquetTable {
         name: String,
         schema: DataSchemaRef,
         options: TableOptions,
-    ) -> Result<Box<dyn ITable>> {
+    ) -> Result<Box<dyn Table>> {
         let file = options.get("location");
         return match file {
             Some(file) => {
@@ -102,7 +102,7 @@ fn read_file(
 }
 
 #[async_trait::async_trait]
-impl ITable for ParquetTable {
+impl Table for ParquetTable {
     fn name(&self) -> &str {
         &self.name
     }

--- a/fusequery/query/src/datasources/mod.rs
+++ b/fusequery/query/src/datasources/mod.rs
@@ -17,8 +17,7 @@ mod table;
 mod table_function;
 
 pub use common::Common;
-pub use database::IDatabase;
+pub use database::Database;
 pub use datasource::DataSource;
-pub use datasource::IDataSource;
-pub use table::ITable;
-pub use table_function::ITableFunction;
+pub use table::Table;
+pub use table_function::TableFunction;

--- a/fusequery/query/src/datasources/remote/remote_database.rs
+++ b/fusequery/query/src/datasources/remote/remote_database.rs
@@ -13,14 +13,14 @@ use common_planners::DropTablePlan;
 
 use crate::datasources::remote::remote_table::RemoteTable;
 use crate::datasources::remote::store_client_provider::StoreClientProvider;
-use crate::datasources::IDatabase;
-use crate::datasources::ITable;
-use crate::datasources::ITableFunction;
+use crate::datasources::Database;
+use crate::datasources::Table;
+use crate::datasources::TableFunction;
 
 pub struct RemoteDatabase {
     name: String,
     store_client_provider: StoreClientProvider,
-    tables: RwLock<HashMap<String, Arc<dyn ITable>>>,
+    tables: RwLock<HashMap<String, Arc<dyn Table>>>,
 }
 
 impl RemoteDatabase {
@@ -34,7 +34,7 @@ impl RemoteDatabase {
 }
 
 #[async_trait::async_trait]
-impl IDatabase for RemoteDatabase {
+impl Database for RemoteDatabase {
     fn name(&self) -> &str {
         self.name.as_str()
     }
@@ -47,7 +47,7 @@ impl IDatabase for RemoteDatabase {
         false
     }
 
-    fn get_table(&self, _table_name: &str) -> Result<Arc<dyn ITable>> {
+    fn get_table(&self, _table_name: &str) -> Result<Arc<dyn Table>> {
         match self.tables.read().get(_table_name) {
             Some(tbl) => Ok(tbl.clone()),
             None =>
@@ -58,11 +58,11 @@ impl IDatabase for RemoteDatabase {
         }
     }
 
-    fn get_tables(&self) -> Result<Vec<Arc<dyn ITable>>> {
+    fn get_tables(&self) -> Result<Vec<Arc<dyn Table>>> {
         Ok(self.tables.read().values().cloned().collect())
     }
 
-    fn get_table_functions(&self) -> Result<Vec<Arc<dyn ITableFunction>>> {
+    fn get_table_functions(&self) -> Result<Vec<Arc<dyn TableFunction>>> {
         Ok(vec![])
     }
 

--- a/fusequery/query/src/datasources/remote/remote_factory.rs
+++ b/fusequery/query/src/datasources/remote/remote_factory.rs
@@ -9,10 +9,10 @@ use common_exception::Result;
 use common_flights::StoreClient;
 
 use crate::configs::Config;
-use crate::datasources::remote::store_client_provider::IStoreClientProvider;
 use crate::datasources::remote::store_client_provider::StoreClientProvider;
+use crate::datasources::remote::store_client_provider::TryGetStoreClient;
 use crate::datasources::remote::RemoteDatabase;
-use crate::datasources::IDatabase;
+use crate::datasources::Database;
 
 pub struct RemoteFactory {
     store_client_provider: StoreClientProvider,
@@ -25,9 +25,9 @@ impl RemoteFactory {
         }
     }
 
-    pub fn load_databases(&self) -> Result<Vec<Arc<dyn IDatabase>>> {
+    pub fn load_databases(&self) -> Result<Vec<Arc<dyn Database>>> {
         // Load databases from remote.
-        let databases: Vec<Arc<dyn IDatabase>> = vec![Arc::new(RemoteDatabase::create(
+        let databases: Vec<Arc<dyn Database>> = vec![Arc::new(RemoteDatabase::create(
             self.store_client_provider.clone(),
             "for_test".to_string(),
         ))];
@@ -49,7 +49,7 @@ impl ClientProvider {
 }
 
 #[async_trait::async_trait]
-impl IStoreClientProvider for ClientProvider {
+impl TryGetStoreClient for ClientProvider {
     async fn try_get_client(&self) -> Result<StoreClient> {
         let client = StoreClient::try_create(
             &self.conf.store_api_address,

--- a/fusequery/query/src/datasources/remote/remote_table.rs
+++ b/fusequery/query/src/datasources/remote/remote_table.rs
@@ -19,7 +19,7 @@ use common_planners::TableOptions;
 use common_streams::SendableDataBlockStream;
 
 use crate::datasources::remote::StoreClientProvider;
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 #[allow(dead_code)]
@@ -37,7 +37,7 @@ impl RemoteTable {
         schema: DataSchemaRef,
         store_client_provider: StoreClientProvider,
         _options: TableOptions,
-    ) -> Result<Box<dyn ITable>> {
+    ) -> Result<Box<dyn Table>> {
         let table = Self {
             db,
             name,
@@ -49,7 +49,7 @@ impl RemoteTable {
 }
 
 #[async_trait::async_trait]
-impl ITable for RemoteTable {
+impl Table for RemoteTable {
     fn name(&self) -> &str {
         &self.name
     }

--- a/fusequery/query/src/datasources/remote/store_client_provider.rs
+++ b/fusequery/query/src/datasources/remote/store_client_provider.rs
@@ -9,8 +9,8 @@ use common_exception::Result;
 use common_flights::StoreClient;
 
 #[async_trait::async_trait]
-pub trait IStoreClientProvider {
+pub trait TryGetStoreClient {
     async fn try_get_client(&self) -> Result<StoreClient>;
 }
 
-pub type StoreClientProvider = Arc<dyn IStoreClientProvider + Send + Sync>;
+pub type StoreClientProvider = Arc<dyn TryGetStoreClient + Send + Sync>;

--- a/fusequery/query/src/datasources/system/clusters_table.rs
+++ b/fusequery/query/src/datasources/system/clusters_table.rs
@@ -21,7 +21,7 @@ use common_planners::Statistics;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct ClustersTable {
@@ -42,7 +42,7 @@ impl ClustersTable {
 }
 
 #[async_trait::async_trait]
-impl ITable for ClustersTable {
+impl Table for ClustersTable {
     fn name(&self) -> &str {
         "clusters"
     }

--- a/fusequery/query/src/datasources/system/contributors_table.rs
+++ b/fusequery/query/src/datasources/system/contributors_table.rs
@@ -19,7 +19,7 @@ use common_planners::Statistics;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct ContributorsTable {
@@ -35,7 +35,7 @@ impl ContributorsTable {
 }
 
 #[async_trait::async_trait]
-impl ITable for ContributorsTable {
+impl Table for ContributorsTable {
     fn name(&self) -> &str {
         "contributors"
     }

--- a/fusequery/query/src/datasources/system/databases_table.rs
+++ b/fusequery/query/src/datasources/system/databases_table.rs
@@ -19,7 +19,7 @@ use common_planners::Statistics;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct DatabasesTable {
@@ -35,7 +35,7 @@ impl DatabasesTable {
 }
 
 #[async_trait::async_trait]
-impl ITable for DatabasesTable {
+impl Table for DatabasesTable {
     fn name(&self) -> &str {
         "databases"
     }

--- a/fusequery/query/src/datasources/system/functions_table.rs
+++ b/fusequery/query/src/datasources/system/functions_table.rs
@@ -22,7 +22,7 @@ use common_planners::Statistics;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct FunctionsTable {
@@ -41,7 +41,7 @@ impl FunctionsTable {
 }
 
 #[async_trait::async_trait]
-impl ITable for FunctionsTable {
+impl Table for FunctionsTable {
     fn name(&self) -> &str {
         "functions"
     }

--- a/fusequery/query/src/datasources/system/numbers_table.rs
+++ b/fusequery/query/src/datasources/system/numbers_table.rs
@@ -21,8 +21,8 @@ use common_streams::SendableDataBlockStream;
 
 use crate::datasources::system::NumbersStream;
 use crate::datasources::Common;
-use crate::datasources::ITable;
-use crate::datasources::ITableFunction;
+use crate::datasources::Table;
+use crate::datasources::TableFunction;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct NumbersTable {
@@ -44,7 +44,7 @@ impl NumbersTable {
 }
 
 #[async_trait::async_trait]
-impl ITable for NumbersTable {
+impl Table for NumbersTable {
     fn name(&self) -> &str {
         self.table
     }
@@ -125,7 +125,7 @@ impl ITable for NumbersTable {
     }
 }
 
-impl ITableFunction for NumbersTable {
+impl TableFunction for NumbersTable {
     fn function_name(&self) -> &str {
         self.table
     }
@@ -134,7 +134,7 @@ impl ITableFunction for NumbersTable {
         "system"
     }
 
-    fn as_table<'a>(self: Arc<Self>) -> Arc<dyn ITable + 'a>
+    fn as_table<'a>(self: Arc<Self>) -> Arc<dyn Table + 'a>
     where Self: 'a {
         self
     }

--- a/fusequery/query/src/datasources/system/one_table.rs
+++ b/fusequery/query/src/datasources/system/one_table.rs
@@ -19,7 +19,7 @@ use common_planners::Statistics;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct OneTable {
@@ -35,7 +35,7 @@ impl OneTable {
 }
 
 #[async_trait::async_trait]
-impl ITable for OneTable {
+impl Table for OneTable {
     fn name(&self) -> &str {
         "one"
     }

--- a/fusequery/query/src/datasources/system/settings_table.rs
+++ b/fusequery/query/src/datasources/system/settings_table.rs
@@ -20,7 +20,7 @@ use common_planners::Statistics;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct SettingsTable {
@@ -41,7 +41,7 @@ impl SettingsTable {
 }
 
 #[async_trait::async_trait]
-impl ITable for SettingsTable {
+impl Table for SettingsTable {
     fn name(&self) -> &str {
         "settings"
     }

--- a/fusequery/query/src/datasources/system/system_database.rs
+++ b/fusequery/query/src/datasources/system/system_database.rs
@@ -11,19 +11,19 @@ use common_planners::CreateTablePlan;
 use common_planners::DropTablePlan;
 
 use crate::datasources::system;
-use crate::datasources::IDatabase;
-use crate::datasources::ITable;
-use crate::datasources::ITableFunction;
+use crate::datasources::Database;
+use crate::datasources::Table;
+use crate::datasources::TableFunction;
 
 pub struct SystemDatabase {
-    tables: HashMap<String, Arc<dyn ITable>>,
-    table_functions: HashMap<String, Arc<dyn ITableFunction>>,
+    tables: HashMap<String, Arc<dyn Table>>,
+    table_functions: HashMap<String, Arc<dyn TableFunction>>,
 }
 
 impl SystemDatabase {
     pub fn create() -> Self {
         // Table list.
-        let table_list: Vec<Arc<dyn ITable>> = vec![
+        let table_list: Vec<Arc<dyn Table>> = vec![
             Arc::new(system::OneTable::create()),
             Arc::new(system::FunctionsTable::create()),
             Arc::new(system::ContributorsTable::create()),
@@ -35,18 +35,18 @@ impl SystemDatabase {
             Arc::new(system::ClustersTable::create()),
             Arc::new(system::DatabasesTable::create()),
         ];
-        let mut tables: HashMap<String, Arc<dyn ITable>> = HashMap::default();
+        let mut tables: HashMap<String, Arc<dyn Table>> = HashMap::default();
         for tbl in table_list.iter() {
             tables.insert(tbl.name().to_string(), tbl.clone());
         }
 
         // Table function list.
-        let table_function_list: Vec<Arc<dyn ITableFunction>> = vec![
+        let table_function_list: Vec<Arc<dyn TableFunction>> = vec![
             Arc::new(system::NumbersTable::create("numbers")),
             Arc::new(system::NumbersTable::create("numbers_mt")),
             Arc::new(system::NumbersTable::create("numbers_local")),
         ];
-        let mut table_functions: HashMap<String, Arc<dyn ITableFunction>> = HashMap::default();
+        let mut table_functions: HashMap<String, Arc<dyn TableFunction>> = HashMap::default();
         for tbl_func in table_function_list.iter() {
             table_functions.insert(tbl_func.name().to_string(), tbl_func.clone());
         }
@@ -59,7 +59,7 @@ impl SystemDatabase {
 }
 
 #[async_trait::async_trait]
-impl IDatabase for SystemDatabase {
+impl Database for SystemDatabase {
     fn name(&self) -> &str {
         "system"
     }
@@ -72,7 +72,7 @@ impl IDatabase for SystemDatabase {
         true
     }
 
-    fn get_table(&self, table_name: &str) -> Result<Arc<dyn ITable>> {
+    fn get_table(&self, table_name: &str) -> Result<Arc<dyn Table>> {
         let table = self
             .tables
             .get(table_name)
@@ -80,11 +80,11 @@ impl IDatabase for SystemDatabase {
         Ok(table.clone())
     }
 
-    fn get_tables(&self) -> Result<Vec<Arc<dyn ITable>>> {
+    fn get_tables(&self) -> Result<Vec<Arc<dyn Table>>> {
         Ok(self.tables.values().cloned().collect())
     }
 
-    fn get_table_functions(&self) -> Result<Vec<Arc<dyn ITableFunction>>> {
+    fn get_table_functions(&self) -> Result<Vec<Arc<dyn TableFunction>>> {
         Ok(self.table_functions.values().cloned().collect())
     }
 

--- a/fusequery/query/src/datasources/system/system_factory.rs
+++ b/fusequery/query/src/datasources/system/system_factory.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use common_exception::Result;
 
 use crate::datasources::system::SystemDatabase;
-use crate::datasources::IDatabase;
+use crate::datasources::Database;
 
 pub struct SystemFactory;
 
@@ -16,8 +16,8 @@ impl SystemFactory {
         Self
     }
 
-    pub fn load_databases(&self) -> Result<Vec<Arc<dyn IDatabase>>> {
-        let databases: Vec<Arc<dyn IDatabase>> = vec![Arc::new(SystemDatabase::create())];
+    pub fn load_databases(&self) -> Result<Vec<Arc<dyn Database>>> {
+        let databases: Vec<Arc<dyn Database>> = vec![Arc::new(SystemDatabase::create())];
         Ok(databases)
     }
 }

--- a/fusequery/query/src/datasources/system/tables_table.rs
+++ b/fusequery/query/src/datasources/system/tables_table.rs
@@ -19,7 +19,7 @@ use common_planners::Statistics;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct TablesTable {
@@ -39,7 +39,7 @@ impl TablesTable {
 }
 
 #[async_trait::async_trait]
-impl ITable for TablesTable {
+impl Table for TablesTable {
     fn name(&self) -> &str {
         "tables"
     }

--- a/fusequery/query/src/datasources/table.rs
+++ b/fusequery/query/src/datasources/table.rs
@@ -15,7 +15,7 @@ use common_streams::SendableDataBlockStream;
 use crate::sessions::FuseQueryContextRef;
 
 #[async_trait::async_trait]
-pub trait ITable: Sync + Send {
+pub trait Table: Sync + Send {
     fn name(&self) -> &str;
     fn engine(&self) -> &str;
     fn as_any(&self) -> &dyn Any;

--- a/fusequery/query/src/datasources/table_function.rs
+++ b/fusequery/query/src/datasources/table_function.rs
@@ -4,12 +4,12 @@
 
 use std::sync::Arc;
 
-use crate::datasources::ITable;
+use crate::datasources::Table;
 
-pub trait ITableFunction: Sync + Send + ITable {
+pub trait TableFunction: Sync + Send + Table {
     fn function_name(&self) -> &str;
     fn db(&self) -> &str;
 
-    fn as_table<'a>(self: Arc<Self>) -> Arc<dyn ITable + 'a>
+    fn as_table<'a>(self: Arc<Self>) -> Arc<dyn Table + 'a>
     where Self: 'a;
 }

--- a/fusequery/query/src/datasources/tests.rs
+++ b/fusequery/query/src/datasources/tests.rs
@@ -7,8 +7,7 @@ async fn test_datasource() -> anyhow::Result<()> {
     use common_planners::*;
     use pretty_assertions::assert_eq;
 
-    use crate::datasources::IDataSource;
-    use crate::datasources::*;
+    use crate::datasources::DataSource;
 
     let datasource = DataSource::try_create()?;
 

--- a/fusequery/query/src/interpreters/interpreter.rs
+++ b/fusequery/query/src/interpreters/interpreter.rs
@@ -8,7 +8,7 @@ use common_exception::Result;
 use common_streams::SendableDataBlockStream;
 
 #[async_trait::async_trait]
-pub trait IInterpreter: Sync + Send {
+pub trait Interpreter: Sync + Send {
     fn name(&self) -> &str;
     async fn execute(&self) -> Result<SendableDataBlockStream>;
 
@@ -17,4 +17,4 @@ pub trait IInterpreter: Sync + Send {
     }
 }
 
-pub type InterpreterPtr = std::sync::Arc<dyn IInterpreter>;
+pub type InterpreterPtr = std::sync::Arc<dyn Interpreter>;

--- a/fusequery/query/src/interpreters/interpreter_database_create.rs
+++ b/fusequery/query/src/interpreters/interpreter_database_create.rs
@@ -9,7 +9,7 @@ use common_planners::CreateDatabasePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::interpreters::IInterpreter;
+use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::sessions::FuseQueryContextRef;
 
@@ -28,7 +28,7 @@ impl CreateDatabaseInterpreter {
 }
 
 #[async_trait::async_trait]
-impl IInterpreter for CreateDatabaseInterpreter {
+impl Interpreter for CreateDatabaseInterpreter {
     fn name(&self) -> &str {
         "CreateDatabaseInterpreter"
     }

--- a/fusequery/query/src/interpreters/interpreter_database_drop.rs
+++ b/fusequery/query/src/interpreters/interpreter_database_drop.rs
@@ -9,7 +9,7 @@ use common_planners::DropDatabasePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::interpreters::IInterpreter;
+use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::sessions::FuseQueryContextRef;
 
@@ -25,7 +25,7 @@ impl DropDatabaseInterpreter {
 }
 
 #[async_trait::async_trait]
-impl IInterpreter for DropDatabaseInterpreter {
+impl Interpreter for DropDatabaseInterpreter {
     fn name(&self) -> &str {
         "DropDatabaseInterpreter"
     }

--- a/fusequery/query/src/interpreters/interpreter_explain.rs
+++ b/fusequery/query/src/interpreters/interpreter_explain.rs
@@ -17,9 +17,9 @@ use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 use log::debug;
 
-use crate::interpreters::IInterpreter;
+use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::optimizers::Optimizer;
+use crate::optimizers::Optimizers;
 use crate::pipelines::processors::PipelineBuilder;
 use crate::sessions::FuseQueryContextRef;
 
@@ -35,7 +35,7 @@ impl ExplainInterpreter {
 }
 
 #[async_trait::async_trait]
-impl IInterpreter for ExplainInterpreter {
+impl Interpreter for ExplainInterpreter {
     fn name(&self) -> &str {
         "ExplainInterpreter"
     }
@@ -44,7 +44,7 @@ impl IInterpreter for ExplainInterpreter {
         let schema =
             DataSchemaRefExt::create(vec![DataField::new("explain", DataType::Utf8, false)]);
 
-        let plan = Optimizer::create(self.ctx.clone()).optimize(&self.explain.input)?;
+        let plan = Optimizers::create(self.ctx.clone()).optimize(&self.explain.input)?;
         let result = match self.explain.typ {
             ExplainType::Graph => {
                 format!("{}", plan.display_graphviz())

--- a/fusequery/query/src/interpreters/interpreter_factory.rs
+++ b/fusequery/query/src/interpreters/interpreter_factory.rs
@@ -13,8 +13,8 @@ use crate::interpreters::CreateTableInterpreter;
 use crate::interpreters::DropDatabaseInterpreter;
 use crate::interpreters::DropTableInterpreter;
 use crate::interpreters::ExplainInterpreter;
-use crate::interpreters::IInterpreter;
 use crate::interpreters::InsertIntoInterpreter;
+use crate::interpreters::Interpreter;
 use crate::interpreters::SelectInterpreter;
 use crate::interpreters::SettingInterpreter;
 use crate::interpreters::UseDatabaseInterpreter;
@@ -23,7 +23,7 @@ use crate::sessions::FuseQueryContextRef;
 pub struct InterpreterFactory;
 
 impl InterpreterFactory {
-    pub fn get(ctx: FuseQueryContextRef, plan: PlanNode) -> Result<Arc<dyn IInterpreter>> {
+    pub fn get(ctx: FuseQueryContextRef, plan: PlanNode) -> Result<Arc<dyn Interpreter>> {
         match plan {
             PlanNode::Select(v) => SelectInterpreter::try_create(ctx, v),
             PlanNode::Explain(v) => ExplainInterpreter::try_create(ctx, v),

--- a/fusequery/query/src/interpreters/interpreter_insert_into.rs
+++ b/fusequery/query/src/interpreters/interpreter_insert_into.rs
@@ -9,7 +9,7 @@ use common_planners::InsertIntoPlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::interpreters::IInterpreter;
+use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::sessions::FuseQueryContextRef;
 
@@ -25,7 +25,7 @@ impl InsertIntoInterpreter {
 }
 
 #[async_trait::async_trait]
-impl IInterpreter for InsertIntoInterpreter {
+impl Interpreter for InsertIntoInterpreter {
     fn name(&self) -> &str {
         "InsertIntoInterpreter"
     }

--- a/fusequery/query/src/interpreters/interpreter_select.rs
+++ b/fusequery/query/src/interpreters/interpreter_select.rs
@@ -12,9 +12,9 @@ use common_planners::SelectPlan;
 use common_streams::SendableDataBlockStream;
 
 use crate::interpreters::plan_scheduler::PlanScheduler;
-use crate::interpreters::IInterpreter;
+use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
-use crate::optimizers::Optimizer;
+use crate::optimizers::Optimizers;
 use crate::pipelines::processors::PipelineBuilder;
 use crate::sessions::FuseQueryContextRef;
 
@@ -30,7 +30,7 @@ impl SelectInterpreter {
 }
 
 #[async_trait::async_trait]
-impl IInterpreter for SelectInterpreter {
+impl Interpreter for SelectInterpreter {
     fn name(&self) -> &str {
         "SelectInterpreter"
     }
@@ -40,7 +40,7 @@ impl IInterpreter for SelectInterpreter {
     }
 
     async fn execute(&self) -> Result<SendableDataBlockStream> {
-        let plan = Optimizer::create(self.ctx.clone()).optimize(&self.select.input)?;
+        let plan = Optimizers::create(self.ctx.clone()).optimize(&self.select.input)?;
 
         let scheduled_actions = PlanScheduler::reschedule(self.ctx.clone(), &plan)?;
 

--- a/fusequery/query/src/interpreters/interpreter_setting.rs
+++ b/fusequery/query/src/interpreters/interpreter_setting.rs
@@ -12,7 +12,7 @@ use common_planners::SettingPlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::interpreters::IInterpreter;
+use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::sessions::FuseQueryContextRef;
 
@@ -28,7 +28,7 @@ impl SettingInterpreter {
 }
 
 #[async_trait::async_trait]
-impl IInterpreter for SettingInterpreter {
+impl Interpreter for SettingInterpreter {
     fn name(&self) -> &str {
         "SettingInterpreter"
     }

--- a/fusequery/query/src/interpreters/interpreter_table_create.rs
+++ b/fusequery/query/src/interpreters/interpreter_table_create.rs
@@ -9,7 +9,7 @@ use common_planners::CreateTablePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::interpreters::IInterpreter;
+use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::sessions::FuseQueryContextRef;
 
@@ -25,7 +25,7 @@ impl CreateTableInterpreter {
 }
 
 #[async_trait::async_trait]
-impl IInterpreter for CreateTableInterpreter {
+impl Interpreter for CreateTableInterpreter {
     fn name(&self) -> &str {
         "CreateTableInterpreter"
     }

--- a/fusequery/query/src/interpreters/interpreter_table_drop.rs
+++ b/fusequery/query/src/interpreters/interpreter_table_drop.rs
@@ -9,7 +9,7 @@ use common_planners::DropTablePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::interpreters::IInterpreter;
+use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::sessions::FuseQueryContextRef;
 
@@ -25,7 +25,7 @@ impl DropTableInterpreter {
 }
 
 #[async_trait::async_trait]
-impl IInterpreter for DropTableInterpreter {
+impl Interpreter for DropTableInterpreter {
     fn name(&self) -> &str {
         "DropTableInterpreter"
     }

--- a/fusequery/query/src/interpreters/interpreter_use_database.rs
+++ b/fusequery/query/src/interpreters/interpreter_use_database.rs
@@ -10,7 +10,7 @@ use common_planners::UseDatabasePlan;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::interpreters::IInterpreter;
+use crate::interpreters::Interpreter;
 use crate::interpreters::InterpreterPtr;
 use crate::sessions::FuseQueryContextRef;
 
@@ -26,7 +26,7 @@ impl UseDatabaseInterpreter {
 }
 
 #[async_trait::async_trait]
-impl IInterpreter for UseDatabaseInterpreter {
+impl Interpreter for UseDatabaseInterpreter {
     fn name(&self) -> &str {
         "UseDatabaseInterpreter"
     }

--- a/fusequery/query/src/interpreters/mod.rs
+++ b/fusequery/query/src/interpreters/mod.rs
@@ -34,7 +34,7 @@ mod interpreter_table_drop;
 mod interpreter_use_database;
 mod plan_scheduler;
 
-pub use interpreter::IInterpreter;
+pub use interpreter::Interpreter;
 pub use interpreter::InterpreterPtr;
 pub use interpreter_database_create::CreateDatabaseInterpreter;
 pub use interpreter_database_drop::DropDatabaseInterpreter;

--- a/fusequery/query/src/optimizers/mod.rs
+++ b/fusequery/query/src/optimizers/mod.rs
@@ -16,8 +16,8 @@ mod optimizer_constant_folding;
 mod optimizer_projection_push_down;
 mod optimizer_scatters;
 
-pub use optimizer::IOptimizer;
 pub use optimizer::Optimizer;
+pub use optimizer::Optimizers;
 pub use optimizer_constant_folding::ConstantFoldingOptimizer;
 pub use optimizer_projection_push_down::ProjectionPushDownOptimizer;
 pub use optimizer_scatters::ScattersOptimizer;

--- a/fusequery/query/src/optimizers/optimizer.rs
+++ b/fusequery/query/src/optimizers/optimizer.rs
@@ -9,27 +9,27 @@ use crate::optimizers::optimizer_scatters::ScattersOptimizer;
 use crate::optimizers::ProjectionPushDownOptimizer;
 use crate::sessions::FuseQueryContextRef;
 
-pub trait IOptimizer {
+pub trait Optimizer {
     fn name(&self) -> &str;
     fn optimize(&mut self, plan: &PlanNode) -> Result<PlanNode>;
 }
 
-pub struct Optimizer {
-    optimizers: Vec<Box<dyn IOptimizer>>,
+pub struct Optimizers {
+    inner: Vec<Box<dyn Optimizer>>,
 }
 
-impl Optimizer {
+impl Optimizers {
     pub fn create(ctx: FuseQueryContextRef) -> Self {
-        let optimizers: Vec<Box<dyn IOptimizer>> = vec![
+        let optimizers: Vec<Box<dyn Optimizer>> = vec![
             Box::new(ProjectionPushDownOptimizer::create(ctx.clone())),
             Box::new(ScattersOptimizer::create(ctx)),
         ];
-        Optimizer { optimizers }
+        Optimizers { inner: optimizers }
     }
 
     pub fn optimize(&mut self, plan: &PlanNode) -> Result<PlanNode> {
         let mut plan = plan.clone();
-        for optimizer in self.optimizers.iter_mut() {
+        for optimizer in self.inner.iter_mut() {
             plan = optimizer.optimize(&plan)?;
         }
         Ok(plan)

--- a/fusequery/query/src/optimizers/optimizer_constant_folding.rs
+++ b/fusequery/query/src/optimizers/optimizer_constant_folding.rs
@@ -14,7 +14,7 @@ use common_planners::FilterPlan;
 use common_planners::PlanNode;
 use common_planners::PlanRewriter;
 
-use crate::optimizers::IOptimizer;
+use crate::optimizers::Optimizer;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct ConstantFoldingOptimizer {}
@@ -136,7 +136,7 @@ impl ConstantFoldingImpl {
     }
 }
 
-impl IOptimizer for ConstantFoldingOptimizer {
+impl Optimizer for ConstantFoldingOptimizer {
     fn name(&self) -> &str {
         "ConstantFolding"
     }

--- a/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
+++ b/fusequery/query/src/optimizers/optimizer_projection_push_down.rs
@@ -23,7 +23,7 @@ use common_planners::ReadDataSourcePlan;
 use common_planners::RewriteHelper;
 use common_planners::SortPlan;
 
-use crate::optimizers::IOptimizer;
+use crate::optimizers::Optimizer;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct ProjectionPushDownOptimizer {}
@@ -159,7 +159,7 @@ impl ProjectionPushDownImpl {
     }
 }
 
-impl IOptimizer for ProjectionPushDownOptimizer {
+impl Optimizer for ProjectionPushDownOptimizer {
     fn name(&self) -> &str {
         "ProjectionPushDown"
     }

--- a/fusequery/query/src/optimizers/optimizer_scatters.rs
+++ b/fusequery/query/src/optimizers/optimizer_scatters.rs
@@ -15,7 +15,7 @@ use common_planners::ReadDataSourcePlan;
 use common_planners::StageKind;
 use common_planners::StagePlan;
 
-use crate::optimizers::IOptimizer;
+use crate::optimizers::Optimizer;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct ScattersOptimizer {
@@ -155,7 +155,7 @@ impl ScattersOptimizer {
     }
 }
 
-impl IOptimizer for ScattersOptimizer {
+impl Optimizer for ScattersOptimizer {
     fn name(&self) -> &str {
         "Scatters"
     }

--- a/fusequery/query/src/optimizers/optimizer_scatters_test.rs
+++ b/fusequery/query/src/optimizers/optimizer_scatters_test.rs
@@ -7,7 +7,7 @@ use common_exception::Result;
 use crate::clusters::Cluster;
 use crate::configs::Config;
 use crate::optimizers::optimizer_scatters::ScattersOptimizer;
-use crate::optimizers::IOptimizer;
+use crate::optimizers::Optimizer;
 use crate::sql::PlanParser;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/fusequery/query/src/pipelines/processors/mod.rs
+++ b/fusequery/query/src/pipelines/processors/mod.rs
@@ -28,6 +28,6 @@ pub use pipe::Pipe;
 pub use pipeline::Pipeline;
 pub use pipeline_builder::PipelineBuilder;
 pub use processor::FormatterSettings;
-pub use processor::IProcessor;
+pub use processor::Processor;
 pub use processor_empty::EmptyProcessor;
 pub use processor_merge::MergeProcessor;

--- a/fusequery/query/src/pipelines/processors/pipe.rs
+++ b/fusequery/query/src/pipelines/processors/pipe.rs
@@ -4,11 +4,11 @@
 
 use std::sync::Arc;
 
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 
 #[derive(Clone)]
 pub struct Pipe {
-    processors: Vec<Arc<dyn IProcessor>>,
+    processors: Vec<Arc<dyn Processor>>,
 }
 
 impl Pipe {
@@ -24,20 +24,20 @@ impl Pipe {
         self.processors[0].name()
     }
 
-    pub fn processors(&self) -> Vec<Arc<dyn IProcessor>> {
+    pub fn processors(&self) -> Vec<Arc<dyn Processor>> {
         self.processors.clone()
     }
 
-    pub fn processor_by_index(&self, index: usize) -> Arc<dyn IProcessor> {
+    pub fn processor_by_index(&self, index: usize) -> Arc<dyn Processor> {
         self.processors[index].clone()
     }
 
     /// The first processor of the pipe.
-    pub fn first(&self) -> Arc<dyn IProcessor> {
+    pub fn first(&self) -> Arc<dyn Processor> {
         self.processors[0].clone()
     }
 
-    pub fn add(&mut self, processor: Arc<dyn IProcessor>) {
+    pub fn add(&mut self, processor: Arc<dyn Processor>) {
         self.processors.push(processor);
     }
 }

--- a/fusequery/query/src/pipelines/processors/pipeline.rs
+++ b/fusequery/query/src/pipelines/processors/pipeline.rs
@@ -8,9 +8,9 @@ use common_exception::ErrorCodes;
 use common_exception::Result;
 use common_streams::SendableDataBlockStream;
 
-use crate::pipelines::processors::IProcessor;
 use crate::pipelines::processors::MergeProcessor;
 use crate::pipelines::processors::Pipe;
+use crate::pipelines::processors::Processor;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct Pipeline {
@@ -51,7 +51,7 @@ impl Pipeline {
             .ok_or_else(|| ErrorCodes::IllegalPipelineState("Pipeline last pipe can not be none"))
     }
 
-    pub fn add_source(&mut self, source: Arc<dyn IProcessor>) -> Result<()> {
+    pub fn add_source(&mut self, source: Arc<dyn Processor>) -> Result<()> {
         if self.pipes.first().is_none() {
             let mut first = Pipe::create();
             first.add(source);
@@ -72,7 +72,7 @@ impl Pipeline {
     ///
     pub fn add_simple_transform(
         &mut self,
-        f: impl Fn() -> Result<Box<dyn IProcessor>>,
+        f: impl Fn() -> Result<Box<dyn Processor>>,
     ) -> Result<()> {
         let last_pipe = self.last_pipe()?;
         let mut new_pipe = Pipe::create();

--- a/fusequery/query/src/pipelines/processors/processor.rs
+++ b/fusequery/query/src/pipelines/processors/processor.rs
@@ -19,15 +19,15 @@ pub struct FormatterSettings {
 }
 
 #[async_trait::async_trait]
-pub trait IProcessor: Sync + Send {
+pub trait Processor: Sync + Send {
     /// Processor name.
     fn name(&self) -> &str;
 
     /// Connect to the input processor, add an edge on the DAG.
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()>;
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()>;
 
     /// Inputs.
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>>;
+    fn inputs(&self) -> Vec<Arc<dyn Processor>>;
 
     /// Reference used for downcast.
     fn as_any(&self) -> &dyn Any;

--- a/fusequery/query/src/pipelines/processors/processor_empty.rs
+++ b/fusequery/query/src/pipelines/processors/processor_empty.rs
@@ -11,7 +11,7 @@ use common_exception::Result;
 use common_streams::DataBlockStream;
 use common_streams::SendableDataBlockStream;
 
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 
 pub struct EmptyProcessor {}
 
@@ -22,18 +22,18 @@ impl EmptyProcessor {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for EmptyProcessor {
+impl Processor for EmptyProcessor {
     fn name(&self) -> &str {
         "EmptyProcessor"
     }
 
-    fn connect_to(&mut self, _: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, _: Arc<dyn Processor>) -> Result<()> {
         Result::Err(ErrorCodes::IllegalTransformConnectionState(
             "Cannot call EmptyProcessor connect_to",
         ))
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![Arc::new(EmptyProcessor::create())]
     }
 

--- a/fusequery/query/src/pipelines/processors/processor_merge.rs
+++ b/fusequery/query/src/pipelines/processors/processor_merge.rs
@@ -14,12 +14,12 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
 
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct MergeProcessor {
     ctx: FuseQueryContextRef,
-    inputs: Vec<Arc<dyn IProcessor>>,
+    inputs: Vec<Arc<dyn Processor>>,
 }
 
 impl MergeProcessor {
@@ -32,17 +32,17 @@ impl MergeProcessor {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for MergeProcessor {
+impl Processor for MergeProcessor {
     fn name(&self) -> &str {
         "MergeProcessor"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.inputs.push(input);
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         self.inputs.clone()
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_aggregator_final.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_aggregator_final.rs
@@ -6,7 +6,7 @@ use std::any::Any;
 use std::sync::Arc;
 use std::time::Instant;
 
-use common_aggregate_functions::IAggregateFunction;
+use common_aggregate_functions::AggregateFunction;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_datavalues::DataValue;
@@ -18,12 +18,12 @@ use futures::stream::StreamExt;
 use log::info;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 
 pub struct AggregatorFinalTransform {
-    funcs: Vec<Box<dyn IAggregateFunction>>,
+    funcs: Vec<Box<dyn AggregateFunction>>,
     schema: DataSchemaRef,
-    input: Arc<dyn IProcessor>,
+    input: Arc<dyn Processor>,
 }
 
 impl AggregatorFinalTransform {
@@ -45,17 +45,17 @@ impl AggregatorFinalTransform {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for AggregatorFinalTransform {
+impl Processor for AggregatorFinalTransform {
     fn name(&self) -> &str {
         "AggregatorFinalTransform"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.input = input;
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![self.input.clone()]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_aggregator_partial.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_aggregator_partial.rs
@@ -6,7 +6,7 @@ use std::any::Any;
 use std::sync::Arc;
 use std::time::Instant;
 
-use common_aggregate_functions::IAggregateFunction;
+use common_aggregate_functions::AggregateFunction;
 use common_datablocks::DataBlock;
 use common_datavalues::DataArrayRef;
 use common_datavalues::DataSchemaRef;
@@ -20,14 +20,14 @@ use futures::stream::StreamExt;
 use log::info;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 
 pub struct AggregatorPartialTransform {
-    funcs: Vec<Box<dyn IAggregateFunction>>,
+    funcs: Vec<Box<dyn AggregateFunction>>,
     arg_names: Vec<Vec<String>>,
 
     schema: DataSchemaRef,
-    input: Arc<dyn IProcessor>,
+    input: Arc<dyn Processor>,
 }
 
 impl AggregatorPartialTransform {
@@ -56,17 +56,17 @@ impl AggregatorPartialTransform {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for AggregatorPartialTransform {
+impl Processor for AggregatorPartialTransform {
     fn name(&self) -> &str {
         "AggregatorPartialTransform"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.input = input;
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![self.input.clone()]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_expression.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_expression.rs
@@ -13,7 +13,7 @@ use common_streams::SendableDataBlockStream;
 use tokio_stream::StreamExt;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 use crate::pipelines::transforms::ExpressionExecutor;
 /// Executes certain expressions over the block and append the result column to the new block.
 /// Aims to transform a block to another format, such as add one or more columns against the Expressions.
@@ -31,7 +31,7 @@ use crate::pipelines::transforms::ExpressionExecutor;
 /// |number|c1|c2|
 pub struct ExpressionTransform {
     // The final schema(Build by plan_builder.expression).
-    input: Arc<dyn IProcessor>,
+    input: Arc<dyn Processor>,
     executor: Arc<ExpressionExecutor>,
 }
 
@@ -52,17 +52,17 @@ impl ExpressionTransform {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for ExpressionTransform {
+impl Processor for ExpressionTransform {
     fn name(&self) -> &str {
         "ExpressionTransform"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.input = input;
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![self.input.clone()]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_filter.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_filter.rs
@@ -19,11 +19,11 @@ use common_streams::SendableDataBlockStream;
 use tokio_stream::StreamExt;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 use crate::pipelines::transforms::ExpressionExecutor;
 
 pub struct FilterTransform {
-    input: Arc<dyn IProcessor>,
+    input: Arc<dyn Processor>,
     executor: Arc<ExpressionExecutor>,
     predicate: Expression,
     having: bool,
@@ -52,7 +52,7 @@ impl FilterTransform {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for FilterTransform {
+impl Processor for FilterTransform {
     fn name(&self) -> &str {
         if self.having {
             return "HavingTransform";
@@ -60,12 +60,12 @@ impl IProcessor for FilterTransform {
         "FilterTransform"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.input = input;
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![self.input.clone()]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_groupby_final.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_groupby_final.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 
-use common_aggregate_functions::IAggregateFunction;
+use common_aggregate_functions::AggregateFunction;
 use common_datablocks::DataBlock;
 use common_datavalues::DataArrayRef;
 use common_datavalues::DataSchemaRef;
@@ -21,11 +21,10 @@ use futures::stream::StreamExt;
 use log::info;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 
 // Table for <group_key, indices>
-type GroupFuncTable =
-    RwLock<HashMap<Vec<u8>, Vec<Box<dyn IAggregateFunction>>, ahash::RandomState>>;
+type GroupFuncTable = RwLock<HashMap<Vec<u8>, Vec<Box<dyn AggregateFunction>>, ahash::RandomState>>;
 
 // Group Key ==> Group by values
 type GroupKeyTable = RwLock<HashMap<Vec<u8>, Vec<DataValue>>>;
@@ -35,7 +34,7 @@ pub struct GroupByFinalTransform {
     group_exprs: Vec<Expression>,
     schema: DataSchemaRef,
     schema_before_groupby: DataSchemaRef,
-    input: Arc<dyn IProcessor>,
+    input: Arc<dyn Processor>,
     groups: GroupFuncTable,
     keys: GroupKeyTable,
 }
@@ -60,17 +59,17 @@ impl GroupByFinalTransform {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for GroupByFinalTransform {
+impl Processor for GroupByFinalTransform {
     fn name(&self) -> &str {
         "GroupByFinalTransform"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.input = input;
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![self.input.clone()]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_limit.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_limit.rs
@@ -10,11 +10,11 @@ use common_streams::LimitStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 
 pub struct LimitTransform {
     limit: usize,
-    input: Arc<dyn IProcessor>,
+    input: Arc<dyn Processor>,
 }
 
 impl LimitTransform {
@@ -27,17 +27,17 @@ impl LimitTransform {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for LimitTransform {
+impl Processor for LimitTransform {
     fn name(&self) -> &str {
         "LimitTransform"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.input = input;
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![self.input.clone()]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_limit_by.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_limit_by.rs
@@ -11,10 +11,10 @@ use common_streams::LimitByStream;
 use common_streams::SendableDataBlockStream;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 
 pub struct LimitByTransform {
-    input: Arc<dyn IProcessor>,
+    input: Arc<dyn Processor>,
     limit_by_exprs: Vec<Expression>,
     limit: usize,
 }
@@ -30,17 +30,17 @@ impl LimitByTransform {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for LimitByTransform {
+impl Processor for LimitByTransform {
     fn name(&self) -> &str {
         "LimitByTransform"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.input = input;
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![self.input.clone()]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_projection.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_projection.rs
@@ -13,12 +13,12 @@ use common_streams::SendableDataBlockStream;
 use tokio_stream::StreamExt;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 use crate::pipelines::transforms::ExpressionExecutor;
 
 pub struct ProjectionTransform {
     executor: Arc<ExpressionExecutor>,
-    input: Arc<dyn IProcessor>,
+    input: Arc<dyn Processor>,
 }
 
 impl ProjectionTransform {
@@ -37,17 +37,17 @@ impl ProjectionTransform {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for ProjectionTransform {
+impl Processor for ProjectionTransform {
     fn name(&self) -> &str {
         "ProjectionTransform"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.input = input;
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![self.input.clone()]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_remote.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_remote.rs
@@ -11,7 +11,7 @@ use common_exception::Result;
 use common_streams::SendableDataBlockStream;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct RemoteTransform {
@@ -38,18 +38,18 @@ impl RemoteTransform {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for RemoteTransform {
+impl Processor for RemoteTransform {
     fn name(&self) -> &str {
         "RemoteTransform"
     }
 
-    fn connect_to(&mut self, _input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, _input: Arc<dyn Processor>) -> Result<()> {
         Result::Err(ErrorCodes::LogicalError(
             "Cannot call RemoteTransform connect_to",
         ))
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![Arc::new(EmptyProcessor::create())]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_sort_merge.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_sort_merge.rs
@@ -15,14 +15,14 @@ use common_streams::SendableDataBlockStream;
 use futures::StreamExt;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 use crate::pipelines::transforms::transform_sort_partial::get_sort_descriptions;
 
 pub struct SortMergeTransform {
     schema: DataSchemaRef,
     exprs: Vec<Expression>,
     limit: Option<usize>,
-    input: Arc<dyn IProcessor>,
+    input: Arc<dyn Processor>,
 }
 
 impl SortMergeTransform {
@@ -41,17 +41,17 @@ impl SortMergeTransform {
 }
 
 #[async_trait]
-impl IProcessor for SortMergeTransform {
+impl Processor for SortMergeTransform {
     fn name(&self) -> &str {
         "SortMergeTransform"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.input = input;
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![self.input.clone()]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_sort_partial.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_sort_partial.rs
@@ -15,13 +15,13 @@ use common_streams::SendableDataBlockStream;
 use common_streams::SortStream;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 
 pub struct SortPartialTransform {
     schema: DataSchemaRef,
     exprs: Vec<Expression>,
     limit: Option<usize>,
-    input: Arc<dyn IProcessor>,
+    input: Arc<dyn Processor>,
 }
 
 impl SortPartialTransform {
@@ -40,17 +40,17 @@ impl SortPartialTransform {
 }
 
 #[async_trait]
-impl IProcessor for SortPartialTransform {
+impl Processor for SortPartialTransform {
     fn name(&self) -> &str {
         "SortPartialTransform"
     }
 
-    fn connect_to(&mut self, input: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, input: Arc<dyn Processor>) -> Result<()> {
         self.input = input;
         Ok(())
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![self.input.clone()]
     }
 

--- a/fusequery/query/src/pipelines/transforms/transform_source.rs
+++ b/fusequery/query/src/pipelines/transforms/transform_source.rs
@@ -10,7 +10,7 @@ use common_exception::Result;
 use common_streams::SendableDataBlockStream;
 
 use crate::pipelines::processors::EmptyProcessor;
-use crate::pipelines::processors::IProcessor;
+use crate::pipelines::processors::Processor;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct SourceTransform {
@@ -37,18 +37,18 @@ impl SourceTransform {
 }
 
 #[async_trait::async_trait]
-impl IProcessor for SourceTransform {
+impl Processor for SourceTransform {
     fn name(&self) -> &str {
         "SourceTransform"
     }
 
-    fn connect_to(&mut self, _: Arc<dyn IProcessor>) -> Result<()> {
+    fn connect_to(&mut self, _: Arc<dyn Processor>) -> Result<()> {
         Result::Err(ErrorCodes::LogicalError(
             "Cannot call SourceTransform connect_to",
         ))
     }
 
-    fn inputs(&self) -> Vec<Arc<dyn IProcessor>> {
+    fn inputs(&self) -> Vec<Arc<dyn Processor>> {
         vec![Arc::new(EmptyProcessor::create())]
     }
 

--- a/fusequery/query/src/servers/mysql/endpoints/endpoint.rs
+++ b/fusequery/query/src/servers/mysql/endpoints/endpoint.rs
@@ -5,7 +5,7 @@
 use common_exception::ErrorCodes;
 use common_exception::Result;
 
-pub trait IMySQLEndpoint<Writer> {
+pub trait MySQLEndpoint<Writer> {
     type Input;
 
     fn ok(data: Self::Input, writer: Writer) -> Result<()>;

--- a/fusequery/query/src/servers/mysql/endpoints/endpoint_on_query.rs
+++ b/fusequery/query/src/servers/mysql/endpoints/endpoint_on_query.rs
@@ -15,11 +15,11 @@ use log::debug;
 use log::error;
 use msql_srv::*;
 
-use crate::servers::mysql::endpoints::IMySQLEndpoint;
+use crate::servers::mysql::endpoints::MySQLEndpoint;
 
 struct MySQLOnQueryEndpoint;
 
-impl<'a, T: std::io::Write> IMySQLEndpoint<QueryResultWriter<'a, T>> for MySQLOnQueryEndpoint {
+impl<'a, T: std::io::Write> MySQLEndpoint<QueryResultWriter<'a, T>> for MySQLOnQueryEndpoint {
     type Input = Vec<DataBlock>;
 
     fn ok(blocks: Self::Input, dataset_writer: QueryResultWriter<'a, T>) -> Result<()> {

--- a/fusequery/query/src/servers/mysql/endpoints/mod.rs
+++ b/fusequery/query/src/servers/mysql/endpoints/mod.rs
@@ -5,5 +5,5 @@
 mod endpoint;
 mod endpoint_on_query;
 
-pub use self::endpoint::IMySQLEndpoint;
+pub use self::endpoint::MySQLEndpoint;
 pub use self::endpoint_on_query::done as on_query_done;

--- a/fusequery/query/src/sessions/context.rs
+++ b/fusequery/query/src/sessions/context.rs
@@ -23,9 +23,8 @@ use uuid::Uuid;
 use crate::clusters::Cluster;
 use crate::clusters::ClusterRef;
 use crate::datasources::DataSource;
-use crate::datasources::IDataSource;
-use crate::datasources::ITable;
-use crate::datasources::ITableFunction;
+use crate::datasources::Table;
+use crate::datasources::TableFunction;
 use crate::sessions::Settings;
 
 #[derive(Clone)]
@@ -33,7 +32,7 @@ pub struct FuseQueryContext {
     uuid: Arc<RwLock<String>>,
     settings: Settings,
     cluster: Arc<RwLock<ClusterRef>>,
-    datasource: Arc<dyn IDataSource>,
+    datasource: Arc<DataSource>,
     statistics: Arc<RwLock<Statistics>>,
     partition_queue: Arc<RwLock<VecDeque<Partition>>>,
     current_database: Arc<RwLock<String>>,
@@ -158,11 +157,11 @@ impl FuseQueryContext {
         Ok(cluster.clone())
     }
 
-    pub fn get_datasource(&self) -> Arc<dyn IDataSource> {
+    pub fn get_datasource(&self) -> Arc<DataSource> {
         self.datasource.clone()
     }
 
-    pub fn get_table(&self, db_name: &str, table_name: &str) -> Result<Arc<dyn ITable>> {
+    pub fn get_table(&self, db_name: &str, table_name: &str) -> Result<Arc<dyn Table>> {
         self.datasource.get_table(db_name, table_name)
     }
 
@@ -175,11 +174,11 @@ impl FuseQueryContext {
         &self,
         db_name: &str,
         table_name: &str,
-    ) -> Result<Arc<dyn ITable>> {
+    ) -> Result<Arc<dyn Table>> {
         self.datasource.get_remote_table(db_name, table_name).await
     }
 
-    pub fn get_table_function(&self, function_name: &str) -> Result<Arc<dyn ITableFunction>> {
+    pub fn get_table_function(&self, function_name: &str) -> Result<Arc<dyn TableFunction>> {
         self.datasource.get_table_function(function_name)
     }
 

--- a/fusequery/query/src/sql/plan_parser.rs
+++ b/fusequery/query/src/sql/plan_parser.rs
@@ -40,7 +40,7 @@ use sqlparser::ast::Statement;
 use sqlparser::ast::TableFactor;
 
 use super::expr_common::rebase_expr_from_input;
-use crate::datasources::ITable;
+use crate::datasources::Table;
 use crate::functions::ContextFunction;
 use crate::sessions::FuseQueryContextRef;
 use crate::sql::expr_common::expand_aggregate_arg_exprs;
@@ -563,10 +563,10 @@ impl PlanParser {
     }
 
     fn create_relation(&self, relation: &sqlparser::ast::TableFactor) -> Result<PlanNode> {
-        use sqlparser::ast::TableFactor::*;
+        use sqlparser::ast::TableFactor as Ast;
 
         match relation {
-            Table { name, args, .. } => {
+            Ast::Table { name, args, .. } => {
                 let mut db_name = self.ctx.get_current_database();
                 let mut table_name = name.to_string();
                 if name.0.len() == 2 {
@@ -574,7 +574,7 @@ impl PlanParser {
                     table_name = name.0[1].to_string();
                 }
                 let mut table_args = None;
-                let table: Arc<dyn ITable>;
+                let table: Arc<dyn Table>;
 
                 // only table functions has table args
                 if !args.is_empty() {
@@ -626,9 +626,9 @@ impl PlanParser {
                     _unreachable_plan => panic!("Logical error: Cannot downcast to scan plan"),
                 })
             }
-            Derived { subquery, .. } => self.query_to_plan(subquery),
-            NestedJoin(table_with_joins) => self.plan_table_with_joins(table_with_joins),
-            TableFunction { .. } => {
+            Ast::Derived { subquery, .. } => self.query_to_plan(subquery),
+            Ast::NestedJoin(table_with_joins) => self.plan_table_with_joins(table_with_joins),
+            Ast::TableFunction { .. } => {
                 Result::Err(ErrorCodes::UnImplement("Unsupported table function"))
             }
         }

--- a/fusequery/query/src/sql/plan_parser.rs
+++ b/fusequery/query/src/sql/plan_parser.rs
@@ -563,10 +563,8 @@ impl PlanParser {
     }
 
     fn create_relation(&self, relation: &sqlparser::ast::TableFactor) -> Result<PlanNode> {
-        use sqlparser::ast::TableFactor as Ast;
-
         match relation {
-            Ast::Table { name, args, .. } => {
+            TableFactor::Table { name, args, .. } => {
                 let mut db_name = self.ctx.get_current_database();
                 let mut table_name = name.to_string();
                 if name.0.len() == 2 {
@@ -626,9 +624,11 @@ impl PlanParser {
                     _unreachable_plan => panic!("Logical error: Cannot downcast to scan plan"),
                 })
             }
-            Ast::Derived { subquery, .. } => self.query_to_plan(subquery),
-            Ast::NestedJoin(table_with_joins) => self.plan_table_with_joins(table_with_joins),
-            Ast::TableFunction { .. } => {
+            TableFactor::Derived { subquery, .. } => self.query_to_plan(subquery),
+            TableFactor::NestedJoin(table_with_joins) => {
+                self.plan_table_with_joins(table_with_joins)
+            }
+            TableFactor::TableFunction { .. } => {
                 Result::Err(ErrorCodes::UnImplement("Unsupported table function"))
             }
         }

--- a/fusequery/query/src/tests/number.rs
+++ b/fusequery/query/src/tests/number.rs
@@ -12,7 +12,6 @@ use common_planners::Expression;
 use common_planners::ReadDataSourcePlan;
 use common_planners::ScanPlan;
 
-use crate::datasources::IDataSource;
 use crate::pipelines::transforms::SourceTransform;
 use crate::sessions::FuseQueryContextRef;
 

--- a/fusestore/store/src/api/rpc/flight_service.rs
+++ b/fusestore/store/src/api/rpc/flight_service.rs
@@ -42,7 +42,7 @@ use tonic::Streaming;
 
 use crate::configs::Config;
 use crate::executor::ActionHandler;
-use crate::fs::IFileSystem;
+use crate::fs::FileSystem;
 
 pub type FlightStream<T> =
     Pin<Box<dyn Stream<Item = Result<T, tonic::Status>> + Send + Sync + 'static>>;
@@ -54,7 +54,7 @@ pub struct StoreFlightImpl {
 }
 
 impl StoreFlightImpl {
-    pub fn create(_conf: Config, fs: Arc<dyn IFileSystem>) -> Self {
+    pub fn create(_conf: Config, fs: Arc<dyn FileSystem>) -> Self {
         Self {
             token: FlightToken::create(),
             // TODO pass in action handler

--- a/fusestore/store/src/data_part/appender.rs
+++ b/fusestore/store/src/data_part/appender.rs
@@ -18,16 +18,16 @@ use common_datavalues::DataSchema;
 use futures::StreamExt;
 use uuid::Uuid;
 
-use crate::fs::IFileSystem;
+use crate::fs::FileSystem;
 
 pub(crate) struct Appender {
-    fs: Arc<dyn IFileSystem>,
+    fs: Arc<dyn FileSystem>,
 }
 
 pub type InputData = std::pin::Pin<Box<dyn futures::Stream<Item = FlightData> + Send>>;
 
 impl Appender {
-    pub fn new(fs: Arc<dyn IFileSystem>) -> Self {
+    pub fn new(fs: Arc<dyn FileSystem>) -> Self {
         Appender { fs }
     }
 

--- a/fusestore/store/src/dfs/distributed_fs.rs
+++ b/fusestore/store/src/dfs/distributed_fs.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use common_exception::exception;
 use common_exception::ErrorCodes;
 
-use crate::fs::IFileSystem;
+use crate::fs::FileSystem;
 use crate::fs::ListResult;
 use crate::localfs::LocalFS;
 use crate::meta_service::ClientRequest;
@@ -40,7 +40,7 @@ impl Dfs {
 impl Dfs {}
 
 #[async_trait]
-impl IFileSystem for Dfs {
+impl FileSystem for Dfs {
     #[tracing::instrument(level = "debug", skip(self, data))]
     async fn add(&self, path: String, data: &[u8]) -> anyhow::Result<()> {
         // add the file to local fs

--- a/fusestore/store/src/dfs/distributed_fs_test.rs
+++ b/fusestore/store/src/dfs/distributed_fs_test.rs
@@ -6,7 +6,7 @@ use pretty_assertions::assert_eq;
 use tempfile::tempdir;
 
 use crate::dfs::Dfs;
-use crate::fs::IFileSystem;
+use crate::fs::FileSystem;
 use crate::localfs::LocalFS;
 use crate::meta_service::GetReq;
 use crate::meta_service::MetaNode;

--- a/fusestore/store/src/executor/action_handler.rs
+++ b/fusestore/store/src/executor/action_handler.rs
@@ -41,7 +41,7 @@ use tonic::Streaming;
 
 use crate::data_part::appender::Appender;
 use crate::engine::MemEngine;
-use crate::fs::IFileSystem;
+use crate::fs::FileSystem;
 use crate::protobuf::CmdCreateDatabase;
 use crate::protobuf::CmdCreateTable;
 use crate::protobuf::Db;
@@ -49,14 +49,14 @@ use crate::protobuf::Table;
 
 pub struct ActionHandler {
     meta: Arc<Mutex<MemEngine>>,
-    fs: Arc<dyn IFileSystem>,
+    fs: Arc<dyn FileSystem>,
 }
 
 type DoGetStream =
     Pin<Box<dyn Stream<Item = Result<FlightData, tonic::Status>> + Send + Sync + 'static>>;
 
 impl ActionHandler {
-    pub fn create(fs: Arc<dyn IFileSystem>) -> Self {
+    pub fn create(fs: Arc<dyn FileSystem>) -> Self {
         ActionHandler {
             meta: MemEngine::create(),
             fs,

--- a/fusestore/store/src/executor/action_handler_test.rs
+++ b/fusestore/store/src/executor/action_handler_test.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc::Sender;
 
 use crate::dfs::Dfs;
 use crate::executor::ActionHandler;
-use crate::fs::IFileSystem;
+use crate::fs::FileSystem;
 use crate::localfs::LocalFS;
 use crate::meta_service::MetaNode;
 use crate::tests::rand_local_addr;

--- a/fusestore/store/src/fs/ifs.rs
+++ b/fusestore/store/src/fs/ifs.rs
@@ -9,7 +9,7 @@ use crate::fs::ListResult;
 
 /// Abstract storage layer API.
 #[async_trait]
-pub trait IFileSystem
+pub trait FileSystem
 where Self: Sync + Send
 {
     /// Add file atomically.

--- a/fusestore/store/src/fs/mod.rs
+++ b/fusestore/store/src/fs/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-pub use ifs::IFileSystem;
+pub use ifs::FileSystem;
 pub use list_result::ListResult;
 
 pub mod ifs;

--- a/fusestore/store/src/localfs/local_fs.rs
+++ b/fusestore/store/src/localfs/local_fs.rs
@@ -12,7 +12,7 @@ use common_exception::exception;
 use common_exception::ErrorCodes;
 use common_exception::ToErrorCodes;
 
-use crate::fs::IFileSystem;
+use crate::fs::FileSystem;
 use crate::fs::ListResult;
 
 pub struct LocalFS {
@@ -30,7 +30,7 @@ impl LocalFS {
 }
 
 #[async_trait]
-impl IFileSystem for LocalFS {
+impl FileSystem for LocalFS {
     #[tracing::instrument(level = "debug", skip(self, data))]
     async fn add(&self, path: String, data: &[u8]) -> anyhow::Result<()> {
         // TODO: test atomicity: write temp file and rename it

--- a/fusestore/store/src/localfs/local_fs_test.rs
+++ b/fusestore/store/src/localfs/local_fs_test.rs
@@ -4,7 +4,7 @@
 use pretty_assertions::assert_eq;
 use tempfile::tempdir;
 
-use crate::fs::IFileSystem;
+use crate::fs::FileSystem;
 use crate::fs::ListResult;
 use crate::localfs::LocalFS;
 

--- a/fusestore/store/src/meta_service/meta.rs
+++ b/fusestore/store/src/meta_service/meta.rs
@@ -15,8 +15,8 @@ use crate::meta_service::placement::rand_n_from_m;
 use crate::meta_service::ClientRequest;
 use crate::meta_service::ClientResponse;
 use crate::meta_service::Cmd;
-use crate::meta_service::IPlacement;
 use crate::meta_service::NodeId;
+use crate::meta_service::Placement;
 
 /// Replication defines the replication strategy.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -210,7 +210,7 @@ impl Display for Node {
     }
 }
 
-impl IPlacement for Meta {
+impl Placement for Meta {
     fn get_slots(&self) -> &[Slot] {
         &self.slots
     }

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -12,7 +12,7 @@ pub use meta::Meta;
 pub use meta::Node;
 pub use meta::Slot;
 pub use meta_service_impl::MetaServiceImpl;
-pub use placement::IPlacement;
+pub use placement::Placement;
 pub use raftmeta::ClientRequest;
 pub use raftmeta::ClientResponse;
 pub use raftmeta::Cmd;

--- a/fusestore/store/src/meta_service/placement.rs
+++ b/fusestore/store/src/meta_service/placement.rs
@@ -23,7 +23,7 @@ use crate::meta_service::Slot;
 ///
 /// A default consistent-hash like impl is provided for most cases.
 /// With this algo user only need to impl two methods: get_slots() and get_node().
-pub trait IPlacement {
+pub trait Placement {
     /// Returns the Node-s that are responsible to store a copy of a file.
     fn nodes_to_store_key(&self, key: &str) -> Vec<Node> {
         let slot_idx = self.slot_index_for_key(key);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Rename trait type names from I$Name to $Name

## Changelog

- Renames :
  - `ITable` to `Table`
  - `IDatabase` to `Database`

- Removes `IDataSource`, use `struct DataSource` directly

- And relevant code 



## Related Issues

Fixes #727

## Test Plan

No extra ut/stateless_test
