### PR TITLE
[store/dfs] test: add deep path test

### DIFF
--- a/fusestore/store/src/dfs/distributed_fs_test.rs
+++ b/fusestore/store/src/dfs/distributed_fs_test.rs
@@ -2,8 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::collections::HashMap;
+
+use maplit::hashmap;
 use pretty_assertions::assert_eq;
 use tempfile::tempdir;
+use tempfile::TempDir;
 
 use crate::dfs::Dfs;
 use crate::fs::IFileSystem;
@@ -11,6 +15,7 @@ use crate::localfs::LocalFS;
 use crate::meta_service::GetReq;
 use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
+use crate::tests::assert_meta_connection;
 use crate::tests::rand_local_addr;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -20,33 +25,39 @@ async fn test_distributed_fs_single_node() -> anyhow::Result<()> {
     // - Test read_all()
     // - Test reading an absent file.
 
+    let files = hashmap! {
+        "foo" => "bar",
+        "ping" => "pong",
+        "who/is/hiding/deeply" => "jerry"
+    };
     let dir = tempdir()?;
-    let root = dir.path();
-
-    let fs = LocalFS::try_create(root.to_str().unwrap().to_string())?;
-
-    let meta_addr = rand_local_addr();
-
-    let rst = MetaNode::boot(0, meta_addr.clone()).await;
-    assert!(rst.is_ok());
-    let mn = rst.unwrap();
-
-    let dfs = Dfs::create(fs, mn);
+    let (meta_addr, dfs) = bring_up_dfs(&dir, files.clone()).await?;
     {
-        let rst = dfs.add("foo".into(), "bar".as_bytes()).await;
-        rst.unwrap();
-
-        // check meta changes
-
         let mut client = MetaServiceClient::connect(format!("http://{}", meta_addr)).await?;
-        let req = tonic::Request::new(GetReq { key: "foo".into() });
-        let rst = client.get(req).await?.into_inner();
-        assert_eq!("", rst.value);
 
-        // read file and check
+        for (key, content) in files.iter() {
+            // check meta changes
 
-        let got = dfs.read_all("foo".into()).await?;
-        assert_eq!("bar".to_string().as_bytes(), got);
+            let req = tonic::Request::new(GetReq {
+                key: key.to_string(),
+            });
+            let rst = client.get(req).await?.into_inner();
+
+            // meanwhile the meta value is empty for every file
+            assert_eq!("", rst.value);
+
+            // read file and check
+
+            let got = dfs.read_all(key.to_string()).await?;
+            assert_eq!(
+                content.to_string().as_bytes(),
+                got,
+                "read content of file: {}",
+                key
+            );
+        }
+
+        // test absent file
 
         let got = dfs.read_all("absent".into()).await;
         assert!(got.is_err());
@@ -58,4 +69,23 @@ async fn test_distributed_fs_single_node() -> anyhow::Result<()> {
         // TODO: test a file presents in meta but not found on local fs.
     }
     Ok(())
+}
+
+// Start an dfs.
+// And feed files into dfs.
+async fn bring_up_dfs(root: &TempDir, files: HashMap<&str, &str>) -> anyhow::Result<(String, Dfs)> {
+    let root = root.path().to_str().unwrap().to_string();
+    let fs = LocalFS::try_create(root)?;
+
+    let meta_addr = rand_local_addr();
+    let mn = MetaNode::boot(0, meta_addr.clone()).await?;
+    assert_meta_connection(&meta_addr).await?;
+
+    let dfs = Dfs::create(fs, mn);
+    for (key, content) in files.iter() {
+        dfs.add((*key).into(), (*content).as_bytes()).await?;
+        tracing::debug!("dfs added file: {} {:?}", *key, *content);
+    }
+
+    Ok((meta_addr, dfs))
 }

--- a/fusestore/store/src/executor/action_handler_test.rs
+++ b/fusestore/store/src/executor/action_handler_test.rs
@@ -65,7 +65,7 @@ async fn bring_up_dfs_action_handler(
     let dfs = Dfs::create(fs, mn);
     for (key, content) in files.iter() {
         dfs.add((*key).into(), (*content).as_bytes()).await?;
-        tracing::debug!("added file: {} {:?}", *key, *content);
+        tracing::debug!("dfs added file: {} {:?}", *key, *content);
     }
 
     let ah = ActionHandler::create(Arc::new(dfs));

--- a/fusestore/store/src/meta_service/meta_service_impl_test.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl_test.rs
@@ -6,13 +6,13 @@
 use log::info;
 use pretty_assertions::assert_eq;
 
-use crate::meta_service::raftmeta_test::assert_connection;
 use crate::meta_service::ClientRequest;
 use crate::meta_service::ClientResponse;
 use crate::meta_service::Cmd;
 use crate::meta_service::GetReq;
 use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
+use crate::tests::assert_meta_connection;
 use crate::tests::rand_local_addr;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -20,7 +20,7 @@ async fn test_meta_server_add_file() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
     let _mn = MetaNode::boot(0, addr.clone()).await?;
-    assert_connection(&addr).await?;
+    assert_meta_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
 
@@ -55,7 +55,7 @@ async fn test_meta_server_sed_file() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
     let _mn = MetaNode::boot(0, addr.clone()).await?;
-    assert_connection(&addr).await?;
+    assert_meta_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
 
@@ -91,7 +91,7 @@ async fn test_meta_server_add_set_get() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
     let _mn = MetaNode::boot(0, addr.clone()).await?;
-    assert_connection(&addr).await?;
+    assert_meta_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
 
@@ -177,7 +177,7 @@ async fn test_meta_server_incr_seq() -> anyhow::Result<()> {
     let addr = rand_local_addr();
 
     let _mn = MetaNode::boot(0, addr.clone()).await?;
-    assert_connection(&addr).await?;
+    assert_meta_connection(&addr).await?;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
 

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-mod meta;
-mod meta_service_impl;
+pub mod meta;
+pub mod meta_service_impl;
 pub mod placement;
-mod raftmeta;
+pub mod raftmeta;
+pub mod state_machine;
 
 pub use async_raft::NodeId;
 pub use meta::Meta;
@@ -17,11 +18,11 @@ pub use raftmeta::ClientRequest;
 pub use raftmeta::ClientResponse;
 pub use raftmeta::Cmd;
 pub use raftmeta::MemStore;
-pub use raftmeta::MemStoreStateMachine;
 pub use raftmeta::MetaNode;
 pub use raftmeta::Network;
 pub use raftmeta::RaftTxId;
 pub use raftmeta::ShutdownError;
+pub use state_machine::MemStoreStateMachine;
 
 pub use crate::protobuf::meta_service_client::MetaServiceClient;
 pub use crate::protobuf::meta_service_server::MetaService;

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 use std::collections::BTreeMap;
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::fmt;
@@ -44,7 +43,7 @@ use tokio::sync::RwLockWriteGuard;
 use tokio::task::JoinHandle;
 use tonic::transport::channel::Channel;
 
-use crate::meta_service::Meta;
+use crate::meta_service::MemStoreStateMachine;
 use crate::meta_service::MetaServiceClient;
 use crate::meta_service::MetaServiceImpl;
 use crate::meta_service::MetaServiceServer;
@@ -254,44 +253,6 @@ pub struct MemStoreSnapshot {
     pub membership: MembershipConfig,
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
-}
-
-/// The state machine of the `MemStore`.
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
-pub struct MemStoreStateMachine {
-    pub last_applied_log: u64,
-    /// A mapping of client IDs to their state info:
-    /// (serial, ClientResponse)
-    pub client_serial_responses: HashMap<String, (u64, ClientResponse)>,
-
-    pub meta: Meta,
-}
-
-impl MemStoreStateMachine {
-    /// Apply an log entry to state machine.
-    ///
-    /// If a duplicated log entry is detected by checking data.txid, no update
-    /// will be made and the previous resp is returned. In this way a client is able to re-send a
-    /// command safely in case of network failure etc.
-    #[tracing::instrument(level = "info", skip(self))]
-    pub fn apply(&mut self, index: u64, data: &ClientRequest) -> Result<ClientResponse> {
-        self.last_applied_log = index;
-        if let Some(ref txid) = data.txid {
-            if let Some((serial, resp)) = self.client_serial_responses.get(&txid.client) {
-                if serial == &txid.serial {
-                    return Ok(resp.clone());
-                }
-            }
-        }
-
-        let resp = self.meta.apply(data)?;
-
-        if let Some(ref txid) = data.txid {
-            self.client_serial_responses
-                .insert(txid.client.clone(), (txid.serial, resp.clone()));
-        }
-        Ok(resp)
-    }
 }
 
 /// An in-memory storage system implementing the `async_raft::RaftStorage` trait.

--- a/fusestore/store/src/meta_service/state_machine.rs
+++ b/fusestore/store/src/meta_service/state_machine.rs
@@ -1,0 +1,51 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::meta_service::ClientRequest;
+use crate::meta_service::ClientResponse;
+use crate::meta_service::Meta;
+
+/// The state machine of the `MemStore`.
+/// It includes a core storage engine `Meta` and raft-related information: `last_applied_logs` and `client_serial_responses` to achieve idempotence.
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct MemStoreStateMachine {
+    pub last_applied_log: u64,
+    /// A mapping of client IDs to their state info:
+    /// (serial, ClientResponse)
+    pub client_serial_responses: HashMap<String, (u64, ClientResponse)>,
+
+    pub meta: Meta,
+}
+
+impl MemStoreStateMachine {
+    /// Apply an log entry to state machine.
+    ///
+    /// If a duplicated log entry is detected by checking data.txid, no update
+    /// will be made and the previous resp is returned. In this way a client is able to re-send a
+    /// command safely in case of network failure etc.
+    #[tracing::instrument(level = "info", skip(self))]
+    pub fn apply(&mut self, index: u64, data: &ClientRequest) -> anyhow::Result<ClientResponse> {
+        self.last_applied_log = index;
+        if let Some(ref txid) = data.txid {
+            if let Some((serial, resp)) = self.client_serial_responses.get(&txid.client) {
+                if serial == &txid.serial {
+                    return Ok(resp.clone());
+                }
+            }
+        }
+
+        let resp = self.meta.apply(data)?;
+
+        if let Some(ref txid) = data.txid {
+            self.client_serial_responses
+                .insert(txid.client.clone(), (txid.serial, resp.clone()));
+        }
+        Ok(resp)
+    }
+}

--- a/fusestore/store/src/tests/mod.rs
+++ b/fusestore/store/src/tests/mod.rs
@@ -9,5 +9,6 @@ pub mod seq;
 
 pub use logging::init_tracing;
 pub use seq::Seq;
+pub use service::assert_meta_connection;
 pub use service::rand_local_addr;
 pub use service::start_store_server;

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -7,6 +7,8 @@ use rand::Rng;
 
 use crate::api::StoreServer;
 use crate::configs::Config;
+use crate::meta_service::GetReq;
+use crate::meta_service::MetaServiceClient;
 
 // Start one random service and get the session manager.
 pub async fn start_store_server() -> Result<String> {
@@ -30,4 +32,14 @@ pub fn rand_local_addr() -> String {
     let port: u32 = rng.gen_range(10000..11000);
     let addr = format!("127.0.0.1:{}", port);
     return addr;
+}
+
+pub async fn assert_meta_connection(addr: &str) -> anyhow::Result<()> {
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
+    let req = tonic::Request::new(GetReq { key: "foo".into() });
+    let rst = client.get(req).await?.into_inner();
+    assert_eq!("", rst.value, "connected");
+    Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store/dfs] test: add deep path test
- move connection check to shared sub mod `tests`.


##### [store/meta] refactor: move state-machine into standalone file

## Changelog


- Improvement



## Related Issues

#271

## Test Plan

