### PR TITLE
[store] refactor: IFileSystem API uses ref to str instead of String

### DIFF
--- a/common/aggregate_functions/src/aggregate_combinator_distinct.rs
+++ b/common/aggregate_functions/src/aggregate_combinator_distinct.rs
@@ -55,7 +55,7 @@ impl AggregateDistinctCombinator {
             _ => arguments.clone(),
         };
 
-        let nested = nested_creator(nested_name, nested_arguments.clone())?;
+        let nested = nested_creator(nested_name, nested_arguments)?;
         Ok(Box::new(AggregateDistinctCombinator {
             nested_name: nested_name.to_owned(),
             arguments,

--- a/fusestore/store/src/data_part/appender.rs
+++ b/fusestore/store/src/data_part/appender.rs
@@ -51,8 +51,10 @@ impl Appender {
                 let part_uuid = Uuid::new_v4().to_simple().to_string() + ".parquet";
                 let location = format!("{}/{}", path, part_uuid);
                 let buffer = write_in_memory(block)?;
+
                 result.append_part(&location, rows, cols, wire_bytes, buffer.len());
-                self.fs.add(location, &buffer).await?;
+
+                self.fs.add(&location, &buffer).await?;
             }
             Ok(result)
         } else {

--- a/fusestore/store/src/dfs/distributed_fs_test.rs
+++ b/fusestore/store/src/dfs/distributed_fs_test.rs
@@ -50,7 +50,7 @@ async fn test_distributed_fs_single_node_read_all() -> anyhow::Result<()> {
 
         // read file and check
 
-        let got = dfs.read_all(key.to_string()).await?;
+        let got = dfs.read_all(key).await?;
         assert_eq!(
             content.to_string().as_bytes(),
             got,
@@ -95,7 +95,7 @@ async fn test_distributed_fs_single_node_list() -> anyhow::Result<()> {
     ];
 
     for (prefix, want) in cases.iter() {
-        let got = dfs.list(prefix.to_string()).await?;
+        let got = dfs.list(prefix).await?;
         assert_eq!(want.len(), got.files.len());
         for (i, w) in want.iter().enumerate() {
             assert_eq!(w.to_string(), got.files[i]);

--- a/fusestore/store/src/executor/action_handler.rs
+++ b/fusestore/store/src/executor/action_handler.rs
@@ -63,8 +63,8 @@ impl ActionHandler {
         }
     }
 
-    /// Handle pull-file reqeust, which is used internally for replicating data copies.
-    /// In FuseStore impl there is no internal file id etc, thus replication use the same `key` in communacation with FuseQuery as in internal replication.
+    /// Handle pull-file request, which is used internally for replicating data copies.
+    /// In FuseStore impl there is no internal file id etc, thus replication use the same `key` in communication with FuseQuery as in internal replication.
     pub async fn do_pull_file(
         &self,
         key: String,
@@ -73,7 +73,7 @@ impl ActionHandler {
         // TODO: stream read if the file is too large.
         let buf = self
             .fs
-            .read_all(key)
+            .read_all(&key)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -251,7 +251,7 @@ impl ActionHandler {
             anyhow::bail!("invalid PlanNode passed in")
         };
 
-        let content = self.fs.read_all(part_file.to_string()).await?;
+        let content = self.fs.read_all(&part_file).await?;
         let cursor = SliceableCursor::new(content);
 
         let file_reader = SerializedFileReader::new(cursor)?;

--- a/fusestore/store/src/fs/ifs.rs
+++ b/fusestore/store/src/fs/ifs.rs
@@ -14,13 +14,13 @@ where Self: Sync + Send
 {
     /// Add file atomically.
     /// AKA put_if_absent
-    async fn add(&self, path: String, data: &[u8]) -> anyhow::Result<()>;
+    async fn add(&self, path: &str, data: &[u8]) -> anyhow::Result<()>;
 
     /// read all bytes from a file
-    async fn read_all(&self, path: String) -> exception::Result<Vec<u8>>;
+    async fn read_all(&self, path: &str) -> exception::Result<Vec<u8>>;
 
     /// List dir and returns directories and files.
-    async fn list(&self, path: String) -> anyhow::Result<ListResult>;
+    async fn list(&self, prefix: &str) -> anyhow::Result<ListResult>;
 
     // async fn read(
     //     path: &str,

--- a/fusestore/store/src/localfs/local_fs.rs
+++ b/fusestore/store/src/localfs/local_fs.rs
@@ -32,9 +32,9 @@ impl LocalFS {
 #[async_trait]
 impl IFileSystem for LocalFS {
     #[tracing::instrument(level = "debug", skip(self, data))]
-    async fn add(&self, path: String, data: &[u8]) -> anyhow::Result<()> {
+    async fn add(&self, path: &str, data: &[u8]) -> anyhow::Result<()> {
         // TODO: test atomicity: write temp file and rename it
-        let p = Path::new(self.root.as_path()).join(&path);
+        let p = Path::new(self.root.as_path()).join(path);
         let mut an = p.ancestors();
         let _tail = an.next();
         let base = an.next();
@@ -59,8 +59,8 @@ impl IFileSystem for LocalFS {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn read_all(&self, path: String) -> exception::Result<Vec<u8>> {
-        let p = Path::new(self.root.as_path()).join(&path);
+    async fn read_all(&self, path: &str) -> exception::Result<Vec<u8>> {
+        let p = Path::new(self.root.as_path()).join(path);
         tracing::info!("read: {}", p.as_path().display());
 
         let data = std::fs::read(p.as_path()).map_err_to_code(ErrorCodes::FileDamaged, || {
@@ -70,8 +70,8 @@ impl IFileSystem for LocalFS {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn list(&self, path: String) -> anyhow::Result<ListResult> {
-        let p = Path::new(self.root.as_path()).join(&path);
+    async fn list(&self, path: &str) -> anyhow::Result<ListResult> {
+        let p = Path::new(self.root.as_path()).join(path);
         let entries = std::fs::read_dir(p.as_path())
             .with_context(|| format!("LocalFS: fail to list {}", path))?;
 

--- a/fusestore/store/src/localfs/local_fs_test.rs
+++ b/fusestore/store/src/localfs/local_fs_test.rs
@@ -16,7 +16,7 @@ async fn test_localfs_read_all() -> anyhow::Result<()> {
     let f = LocalFS::try_create(root.to_str().unwrap().to_string())?;
     {
         // read absent file
-        let got = f.read_all("foo.txt".into()).await;
+        let got = f.read_all("foo.txt").await;
         assert_eq!(
             "localfs: fail to read: \"foo.txt\", cause: No such file or directory (os error 2)",
             got.err().unwrap().message()
@@ -24,13 +24,13 @@ async fn test_localfs_read_all() -> anyhow::Result<()> {
     }
     {
         // add foo.txt and read
-        f.add("foo.txt".to_string(), "123".as_bytes()).await?;
-        let got = f.read_all("foo.txt".into()).await?;
+        f.add("foo.txt", "123".as_bytes()).await?;
+        let got = f.read_all("foo.txt").await?;
         assert_eq!("123", std::str::from_utf8(&got)?);
     }
     {
         // add foo.txt twice, fail
-        let got = f.add("foo.txt".to_string(), "123".as_bytes()).await;
+        let got = f.add("foo.txt", "123".as_bytes()).await;
         assert_eq!(
             "LocalFS: fail to open foo.txt",
             got.err().unwrap().to_string()
@@ -39,14 +39,14 @@ async fn test_localfs_read_all() -> anyhow::Result<()> {
     {
         // add long/bar.txt and read
         f.add("long/bar.txt".into(), "456".as_bytes()).await?;
-        let got = f.read_all("long/bar.txt".into()).await?;
+        let got = f.read_all("long/bar.txt").await?;
         assert_eq!("456", std::str::from_utf8(&got)?);
     }
 
     {
         // add long/path/file.txt and read
         f.add("long/path/file.txt".into(), "789".as_bytes()).await?;
-        let got = f.read_all("long/path/file.txt".into()).await?;
+        let got = f.read_all("long/path/file.txt").await?;
         assert_eq!("789", std::str::from_utf8(&got)?);
     }
     {


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: IFileSystem API uses ref to str instead of String

## Changelog




- Improvement

## Related Issues

#271