### PR TITLE
[common/building] fix: fuse version should be built outside build.rs

### DIFF
--- a/common/building/src/lib.rs
+++ b/common/building/src/lib.rs
@@ -11,7 +11,7 @@ use vergen::ShaKind;
 /// Setup building environment:
 /// - Watch git HEAD to trigger a rebuild;
 /// - Generate vergen instruction to setup environment variables for building Fuse components. See: https://docs.rs/vergen/5.1.8/vergen/ ;
-/// - Generate Fuse environment variables, e.g., version and authors.
+/// - Generate Fuse environment variables, e.g., authors.
 pub fn setup() {
     if Path::new(".git/HEAD").exists() {
         println!("cargo:rerun-if-changed=.git/HEAD");
@@ -22,7 +22,6 @@ pub fn setup() {
 pub fn add_building_env_vars() {
     add_env_vergen();
     add_env_commit_authors();
-    add_env_commit_version();
 }
 
 pub fn add_env_vergen() {
@@ -43,19 +42,4 @@ pub fn add_env_commit_authors() {
         Err(e) => e.to_string(),
     };
     println!("cargo:rustc-env=FUSE_COMMIT_AUTHORS={}", authors);
-}
-
-/// Generate Fuse style commit-version and keep it in environment variable FUSE_COMMIT_VERSION.
-pub fn add_env_commit_version() {
-    let build_semver = option_env!("VERGEN_BUILD_SEMVER");
-    let git_sha = option_env!("VERGEN_GIT_SHA_SHORT");
-    let rustc_semver = option_env!("VERGEN_RUSTC_SEMVER");
-    let timestamp = option_env!("VERGEN_BUILD_TIMESTAMP");
-
-    let ver = match (build_semver, git_sha, rustc_semver, timestamp) {
-        (Some(v1), Some(v2), Some(v3), Some(v4)) => format!("{}-{}({}-{})", v1, v2, v3, v4),
-        _ => String::new(),
-    };
-
-    println!("cargo:rustc-env=FUSE_COMMIT_VERSION={}", ver);
 }

--- a/fusequery/query/src/bin/fuse-query.rs
+++ b/fusequery/query/src/bin/fuse-query.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("{:?}", conf);
     info!(
         "FuseQuery v-{}",
-        fuse_query::configs::config::FUSE_COMMIT_VERSION
+        *fuse_query::configs::config::FUSE_COMMIT_VERSION
     );
 
     let mut tasks = vec![];

--- a/fusequery/query/src/configs/config.rs
+++ b/fusequery/query/src/configs/config.rs
@@ -4,10 +4,24 @@
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use lazy_static::lazy_static;
 use structopt::StructOpt;
 use structopt_toml::StructOptToml;
 
-pub const FUSE_COMMIT_VERSION: &str = env!("FUSE_COMMIT_VERSION");
+lazy_static! {
+    pub static ref FUSE_COMMIT_VERSION: String = {
+        let build_semver = option_env!("VERGEN_BUILD_SEMVER");
+        let git_sha = option_env!("VERGEN_GIT_SHA_SHORT");
+        let rustc_semver = option_env!("VERGEN_RUSTC_SEMVER");
+        let timestamp = option_env!("VERGEN_BUILD_TIMESTAMP");
+
+        let ver = match (build_semver, git_sha, rustc_semver, timestamp) {
+            (Some(v1), Some(v2), Some(v3), Some(v4)) => format!("{}-{}({}-{})", v1, v2, v3, v4),
+            _ => String::new(),
+        };
+        ver
+    };
+}
 
 #[derive(Clone, Debug, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
 #[serde(default)]

--- a/fusequery/query/src/configs/config_test.rs
+++ b/fusequery/query/src/configs/config_test.rs
@@ -59,3 +59,10 @@ fn test_config() -> common_exception::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_fuse_commit_version() -> anyhow::Result<()> {
+    let v = &crate::configs::config::FUSE_COMMIT_VERSION;
+    assert!(v.len() > 0);
+    Ok(())
+}

--- a/fusestore/store/src/bin/fuse-store.rs
+++ b/fusestore/store/src/bin/fuse-store.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!("{:?}", conf.clone());
     info!(
         "FuseStore v-{}",
-        fuse_store::configs::config::FUSE_COMMIT_VERSION
+        *fuse_store::configs::config::FUSE_COMMIT_VERSION
     );
 
     // Metric API service.

--- a/fusestore/store/src/configs/config.rs
+++ b/fusestore/store/src/configs/config.rs
@@ -2,10 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use lazy_static::lazy_static;
 use structopt::StructOpt;
 use structopt_toml::StructOptToml;
 
-pub const FUSE_COMMIT_VERSION: &str = env!("FUSE_COMMIT_VERSION");
+lazy_static! {
+    pub static ref FUSE_COMMIT_VERSION: String = {
+        let build_semver = option_env!("VERGEN_BUILD_SEMVER");
+        let git_sha = option_env!("VERGEN_GIT_SHA_SHORT");
+        let rustc_semver = option_env!("VERGEN_RUSTC_SEMVER");
+        let timestamp = option_env!("VERGEN_BUILD_TIMESTAMP");
+
+        let ver = match (build_semver, git_sha, rustc_semver, timestamp) {
+            (Some(v1), Some(v2), Some(v3), Some(v4)) => format!("{}-{}({}-{})", v1, v2, v3, v4),
+            _ => String::new(),
+        };
+        ver
+    };
+}
 
 #[derive(Clone, Debug, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
 pub struct Config {

--- a/fusestore/store/src/configs/config_test.rs
+++ b/fusestore/store/src/configs/config_test.rs
@@ -1,0 +1,10 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+#[test]
+fn test_fuse_commit_version() -> anyhow::Result<()> {
+    let v = &crate::configs::config::FUSE_COMMIT_VERSION;
+    assert!(v.len() > 0);
+    Ok(())
+}

--- a/fusestore/store/src/configs/mod.rs
+++ b/fusestore/store/src/configs/mod.rs
@@ -3,5 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 pub mod config;
+#[cfg(test)]
+mod config_test;
 
 pub use config::Config;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [common/building] fix: fuse version should be built outside build.rs
Inside `build.rs`, the env vars such as `VERGEN_BUILD_SEMVER` is written
only to stdout thus it is impossible to reuse these vars to compose
`FUSE_COMMIT_VERSION`.

This patch fixes the issue by building `FUSE_COMMIT_VERSION` with a
`lazy_static` block from env vars in runtime.

## Changelog


- Bug Fix



## Related Issues

https://github.com/datafuselabs/datafuse/pull/782#issuecomment-857051879