### PR TITLE
[store/meta] feature: deal with ForwardToLeader. Now every node can accept an meta write operation.

### DIFF
--- a/fusestore/store/proto/store_meta.proto
+++ b/fusestore/store/proto/store_meta.proto
@@ -57,7 +57,10 @@ message GetReply {
   string value = 3;
 }
 
-message RaftMes { string data = 1; }
+message RaftMes {
+  string data = 1;
+  string error = 2;
+}
 
 service MetaService {
 

--- a/fusestore/store/src/meta_service/meta_service_impl.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl.rs
@@ -36,15 +36,14 @@ impl MetaService for MetaServiceImpl {
         let mes = request.into_inner();
         let req: ClientRequest = mes.try_into()?;
 
-        // TODO: handle ForwardToLeader error
-        let resp = self
+        let rst = self
             .meta_node
             .write_to_local_leader(req)
             .await
             .map_err(|e| tonic::Status::internal(e.to_string()))?;
 
-        let mes: RaftMes = resp.into();
-        Ok(tonic::Response::new(mes))
+        let raft_mes = rst.into();
+        Ok(tonic::Response::new(raft_mes))
     }
 
     #[tracing::instrument(level = "info", skip(self))]
@@ -87,7 +86,10 @@ impl MetaService for MetaServiceImpl {
             .await
             .map_err(|x| tonic::Status::internal(x.to_string()))?;
         let data = serde_json::to_string(&resp).expect("fail to serialize resp");
-        let mes = RaftMes { data };
+        let mes = RaftMes {
+            data,
+            error: "".to_string(),
+        };
 
         Ok(tonic::Response::new(mes))
     }
@@ -109,7 +111,10 @@ impl MetaService for MetaServiceImpl {
             .await
             .map_err(|x| tonic::Status::internal(x.to_string()))?;
         let data = serde_json::to_string(&resp).expect("fail to serialize resp");
-        let mes = RaftMes { data };
+        let mes = RaftMes {
+            data,
+            error: "".to_string(),
+        };
 
         Ok(tonic::Response::new(mes))
     }
@@ -131,7 +136,10 @@ impl MetaService for MetaServiceImpl {
             .await
             .map_err(|x| tonic::Status::internal(x.to_string()))?;
         let data = serde_json::to_string(&resp).expect("fail to serialize resp");
-        let mes = RaftMes { data };
+        let mes = RaftMes {
+            data,
+            error: "".to_string(),
+        };
 
         Ok(tonic::Response::new(mes))
     }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store/meta] feature: deal with ForwardToLeader. Now every node can accept an meta write operation.
- Add `RetryableError` to indicate that the caller could choose to retry
  an operation.
  Non-retryable errors are returned in an `anyhow::Error`.

- The `write` family API(methods of `MetaNode` methods of
  `MetaService`) returns two level result:
  ```
  Result<
    Result<ClientResponse, RetryableError>,
    anyhow::Error
  >
  ```

  An `anyhow::Error` indicates something wrong and can not be dealt by
  the program, such as a Storage error.
  And it is converted to a `tonic::Status` error when responding grpc
  client.

  The inner `Result` should be well handled by the caller.

- To support the above protocol, another field `error` is added to
  `RaftMes`, in order to transport an `RetryableError`

- Some of the `From` trait for `RaftMes`, `ClientResponse` and
  `RetryableError` is rewritten to adapt the type convertion.

- Deal with `ForwardToLeader` error: detect and return this error to
  caller. And retry sending request.

- Add tests about dealing `ForwardToLeader` to local and remote write
  operations.

## Changelog

- New Feature





## Related Issues

#271