### PR TITLE
fix container deploy err

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 /fuse-store &
 P1=$!
 /fuse-query -c fuse-query.toml &


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Summary about this PR
Without the new line, kubernetes deploy will encounter issue
standard_init_linux.go:219: exec user process caused: exec format error 
## Changelog

- Bug Fix

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

