### PR TITLE
Fix: unit test hang after tokio version bumped to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4242,9 +4242,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aea337f72e96efe29acc234d803a5981cd9a2b6ed21655cd7fc21cfe021e8ec7"
+checksum = "c79ba603c337335df6ba6dd6afc38c38a7d5e1b0c871678439ea973cd62a118e"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -4254,6 +4254,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/common/flights/Cargo.toml
+++ b/common/flights/Cargo.toml
@@ -29,7 +29,7 @@ tokio-stream = "0.1"
 tonic = "0.4.3"
 hyper = "0.14.9"
 lazy_static = "1.4.0"
-tokio = { version = "1.6", features = ["macros", "rt","rt-multi-thread", "sync"] }
+tokio = { version = "1.7", features = ["macros", "rt","rt-multi-thread", "sync"] }
 trust-dns-resolver = { version = "0.20.3", features = ["system-config"] }
 
 [dev-dependencies]

--- a/common/profiling/Cargo.toml
+++ b/common/profiling/Cargo.toml
@@ -12,4 +12,4 @@ common-exception = {path = "../exception"}
 
 # Crates.io dependencies
 pprof = { version = "0.4", features = ["flamegraph", "protobuf"] }
-tokio = { version = "1.6"}
+tokio = { version = "1.7"}

--- a/common/runtime/Cargo.toml
+++ b/common/runtime/Cargo.toml
@@ -14,7 +14,7 @@ common-exception = {path = "../exception"}
 
 # Crates.io dependencies
 anyhow = "1.0.41"
-tokio = { version = "1.6", features = ["macros", "rt","rt-multi-thread", "sync"] }
+tokio = { version = "1.7", features = ["macros", "rt","rt-multi-thread", "sync"] }
 
 [dev-dependencies]
 

--- a/common/streams/Cargo.toml
+++ b/common/streams/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0.41"
 crossbeam = "0.8"
 futures = "0.3"
 pin-project-lite = "^0.2"
-tokio = { version = "1.6", features = ["macros", "rt","rt-multi-thread", "sync"] }
+tokio = { version = "1.7", features = ["macros", "rt","rt-multi-thread", "sync"] }
 
 [dev-dependencies]
 pretty_assertions = "0.7"

--- a/fusequery/benchmarks/nyctaxi/Cargo.toml
+++ b/fusequery/benchmarks/nyctaxi/Cargo.toml
@@ -17,6 +17,6 @@ fuse-query = {path = "../../query"}
 # Crates.io dependencies
 futures = "0.3"
 structopt = "0.3"
-tokio = { version = "1.6", features = ["macros", "rt","rt-multi-thread", "sync"] }
+tokio = { version = "1.7", features = ["macros", "rt","rt-multi-thread", "sync"] }
 
 [dev-dependencies]

--- a/fusequery/query/Cargo.toml
+++ b/fusequery/query/Cargo.toml
@@ -69,7 +69,7 @@ serde_json = "1.0"
 structopt = "0.3"
 structopt-toml = "0.4.5"
 threadpool = "1.8.1"
-tokio = { version = "1.6", features = ["macros", "rt","rt-multi-thread", "sync"] }
+tokio = { version = "1.7", features = ["macros", "rt","rt-multi-thread", "sync"] }
 tokio-stream = "0.1"
 toml = "0.5.6"
 tonic = "0.4"

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -54,7 +54,7 @@ structopt-toml = "0.4.5"
 tempfile = "3.2.0"
 thiserror = "1.0.25"
 threadpool = "1.8.1"
-tokio = { version = "1.6", features = ["macros", "rt","rt-multi-thread", "sync"] }
+tokio = { version = "1.7", features = ["macros", "rt","rt-multi-thread", "sync"] }
 tokio-stream = "0.1"
 tonic = "0.4"
 uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/fusestore/store/src/meta_service/meta_service_impl_test.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl_test.rs
@@ -230,9 +230,10 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
     let _mn0 = MetaNode::boot(0, addr0.clone()).await?;
     assert_meta_connection(&addr0).await?;
 
+    // add node 1 as non-voter
+    let _mn1 = MetaNode::boot_non_voter(1, &addr1).await?;
+
     {
-        // add node 1 as non-voter
-        let _mn1 = MetaNode::boot_non_voter(1, &addr1).await?;
         assert_meta_connection(&addr0).await?;
 
         let resp = _mn0.add_node(1, addr1.clone()).await?;
@@ -268,6 +269,8 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
             assert_eq!(leader, 0);
         }
     }
+    _mn0.stop().await?;
+    _mn1.stop().await?;
 
     Ok(())
 }

--- a/fusestore/store/src/meta_service/raftmeta_test.rs
+++ b/fusestore/store/src/meta_service/raftmeta_test.rs
@@ -304,6 +304,11 @@ async fn test_meta_node_write() -> anyhow::Result<()> {
         assert_get_file(all.clone(), &key, &key).await?;
     }
 
+    mn0.stop().await?;
+    mn1.stop().await?;
+    mn2.stop().await?;
+    mn3.stop().await?;
+
     Ok(())
 }
 
@@ -337,6 +342,9 @@ async fn test_meta_node_3_members() -> anyhow::Result<()> {
 
     assert_set_file_synced(vec![mn0.clone(), mn1.clone(), mn2.clone()], "foo-2").await?;
 
+    mn0.stop().await?;
+    mn1.stop().await?;
+    mn2.stop().await?;
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

After the lovely bot bumped tokio to v1.7.0, some ut cases hang (for far more than 60s). 

Backtrace shows that tokio is blocked while shutting down the runtime:

~~~
   #12 0x0000562b2d0f1d2e in tokio::park::thread::CachedParkThread::block_on (self=0x7f4c623ee140,
    f=0x7f4c623ee970)
    at .../tokio-1.7.0/src/park/thread.rs:267
#13 0x0000562b2d0cce90 in tokio::runtime::enter::Enter::block_on (self=0x7f4c623ee1b0, f=0x7f4c623ee970)
    at .../tokio-1.7.0/src/runtime/enter.rs:151
#14 0x0000562b2d096143 in tokio::runtime::blocking::shutdown::Receiver::wait (self=0x7f4c623ee970,
    timeout=...)
    at .../tokio-1.7.0/src/runtime/blocking/shutdown.rs:67
#15 0x0000562b2d094032 in tokio::runtime::blocking::pool::BlockingPool::shutdown (self=0x7f4c623ee968,
    timeout=...)
    at .../tokio-1.7.0/src/runtime/blocking/pool.rs:145
#16 0x0000562b2d09457c in <tokio::runtime::blocking::pool::BlockingPool as core::ops::drop::Drop>::drop (
    self=0x7f4c623ee968)
    at .../tokio-1.7.0/src/runtime/blocking/pool.rs:162
#17 0x0000562b2d0b2bc7 in core::ptr::drop_in_place<tokio::runtime::blocking::pool::BlockingPool> ()
    at /rustc/657bc01888e6297257655585f9c475a0801db6d2/library/core/src/ptr/mod.rs:192
#18 0x0000562b2d0b18aa in core::ptr::drop_in_place<tokio::runtime::Runtime> ()
    at /rustc/657bc01888e6297257655585f9c475a0801db6d2/library/core/src/ptr/mod.rs:192
#19 0x0000562b2c0c93b6 in fuse_store::meta_service::meta_service_impl_test::test_meta_cluster_write_on_non_leader () at fusestore/store/src/meta_service/meta_service_impl_test.rs:273
#20 0x0000562b2be0f68e in fuse_store::meta_service::meta_service_impl_test::test_meta_cluster_write_on_non_leader::{{closure}} () at fusestore/store/src/meta_service/meta_service_impl_test.rs:223
~~~

After adding manual shutdown instructions to the hanging cases, everything seems going well.

**Things that I am not sure about:**
- Could not find clues in the [changelog](https://github.com/tokio-rs/tokio/blob/master/tokio/CHANGELOG.md#170-june-15-2021) of tokio of which changes cause this issue 
- There are ut cases that create multi meta nodes, which I did NOT add explicit `node.stop().await?`, can pass the test without hanging (for many times locally).

  for example:

https://github.com/datafuselabs/datafuse/blob/6d2bf71e1842a8ad7693f37c0fd124dafa8fa66b/fusestore/store/src/meta_service/raftmeta_test.rs#L210

  I left them unchanged on purpose, to check if they can be passed in CI Env.



**For the curious**

this issue could be re-check at:

- https://github.com/datafuselabs/datafuse/pull/839/checks?check_run_id=2836068821

- or commit 2401ef3f085da1b62e52a956d66c65cbf2d2254b

`cargo test` will lead you to the hangs.

## Changelog

- Manually shut down before exiting the cases

## Related Issues

N/A

## Test Plan

Unit Tests

Stateless Tests

