### PR TITLE
[Build/CI] perf-tool container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ lint:
 docker:
 	docker build --network host -f docker/Dockerfile -t ${HUB}/fuse-query:${TAG} .
 
+perf-tool:
+	docker build --network host -f docker/perf-tool/Dockerfile -t ${HUB}/perf-tool:${TAG} .
+
 run-helm:
 	helm upgrade --install datafuse ./charts/datafuse \
 		--set image.repository=${HUB}/fuse-query --set image.tag=${TAG} --set configs.mysqlPort=3308

--- a/docker/perf-tool/Dockerfile
+++ b/docker/perf-tool/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:1.48.0-buster AS builder
+
+COPY ./ /app
+WORKDIR /app
+RUN make setup
+RUN make build
+
+FROM python:3
+COPY --from=builder /app/target/release/fuse-benchmark /fuse-benchmark
+COPY ./tests/perfs/perfs.py /perfs.py
+COPY ./tests/perfs/perfs.yaml /perfs.yaml
+RUN pip install --no-cache-dir pyyaml
+ENV BIN_LOCATION "/fuse-benchmark"
+ENV SERVER_HOST "127.0.0.1"
+ENV SERVER_PORT "9090"
+ENV ITERATION "3"
+ENV CONCURRENCY "1"
+CMD ["python", "./perfs.py", "-b", "${BIN_LOCATION}", "--host", "${SERVER_HOST}", "-p", "${SERVER_PORT}", "-c", "${CONCURRENCY}}", "-i", "${ITERATION}"]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary
Support to run perf tool in a standalone docker image, easier for CI and testings
Summary about this PR

## Changelog

- Build/Testing/CI

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

