### PR TITLE
ISSUES-832 support graceful shutdown for Metrics API

### DIFF
--- a/fusequery/query/src/bin/fuse-query.rs
+++ b/fusequery/query/src/bin/fuse-query.rs
@@ -83,17 +83,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Metric API service.
     {
-        let srv = MetricService::create(conf.clone());
-        tokio::spawn(async move {
-            srv.make_server().expect("Metrics service error");
-        });
-        info!("Metric API server listening on {}", conf.metric_api_address);
+        let addr = conf.metric_api_address.parse::<std::net::SocketAddr>()?;
+        let srv = MetricService::create();
+        let addr = srv.start((addr.ip().to_string(), addr.port())).await?;
+        services.push(srv);
+        info!("Metric API server listening on {}", addr);
     }
 
     // HTTP API service.
     {
-        let srv = HttpService::create(conf.clone(), cluster.clone());
         let addr = conf.http_api_address.parse::<std::net::SocketAddr>()?;
+        let srv = HttpService::create(conf.clone(), cluster.clone());
         let addr = srv.start((addr.ip().to_string(), addr.port())).await?;
         services.push(srv);
         info!("HTTP API server listening on {}", addr);

--- a/fusequery/query/src/metrics/metric_service.rs
+++ b/fusequery/query/src/metrics/metric_service.rs
@@ -2,30 +2,127 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use anyhow::anyhow;
-use anyhow::Result;
-use metrics_exporter_prometheus::PrometheusBuilder;
+use std::net::SocketAddr;
+use std::net::ToSocketAddrs;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::Instant;
 
-use crate::configs::Config;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_exception::ToErrorCode;
+use common_infallible::Mutex;
+use common_runtime::tokio;
+use common_runtime::tokio::sync::oneshot::Sender;
+use common_runtime::tokio::sync::Notify;
+use futures::future::FutureExt;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use warp::hyper::Body;
+use warp::reply::Response;
+use warp::Filter;
+use warp::Reply;
+
+use crate::servers::AbortableServer;
+use crate::servers::AbortableService;
+use crate::servers::Elapsed;
 
 pub struct MetricService {
-    conf: Config,
+    aborted: Arc<AtomicBool>,
+    abort_handle: Mutex<Option<Sender<()>>>,
+    aborted_notify: Arc<Notify>,
 }
 
 impl MetricService {
-    pub fn create(conf: Config) -> Self {
-        MetricService { conf }
+    pub fn create() -> AbortableServer {
+        Arc::new(MetricService {
+            aborted: Arc::new(AtomicBool::new(false)),
+            abort_handle: Mutex::new(None),
+            aborted_notify: Arc::new(Notify::new()),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl AbortableService<(String, u16), SocketAddr> for MetricService {
+    fn abort(&self, _force: bool) -> Result<()> {
+        if let Some(abort_handle) = self.abort_handle.lock().take() {
+            match abort_handle.send(()) {
+                Ok(_) => { /* do nothing */ }
+                Err(_) => {
+                    return Err(ErrorCode::LogicalError(
+                        "Cannot abort MetricService, cause: cannot send signal to service.",
+                    ))
+                }
+            }
+        }
+
+        Ok(())
     }
 
-    pub fn make_server(&self) -> Result<()> {
-        let addr = self
-            .conf
-            .metric_api_address
-            .parse::<std::net::SocketAddr>()?;
+    async fn start(&self, args: (String, u16)) -> Result<SocketAddr> {
+        let builder = PrometheusBuilder::new();
+        let prometheus_recorder = builder.build();
+        let prometheus_handle = prometheus_recorder.handle();
+        metrics::set_boxed_recorder(Box::new(prometheus_recorder))
+            .map_err_to_code(ErrorCode::UnknownException, || {
+                "Init prometheus recorder error"
+            })?;
 
-        PrometheusBuilder::new()
-            .listen_address(addr)
-            .install()
-            .map_err(|e| anyhow!(format!("Metrics prometheus exporter error: {:?}", e)))
+        let server = warp::serve(warp::any().map(move || MetricsReply(prometheus_handle.render())));
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        *self.abort_handle.lock() = Some(tx);
+        let addr = args.to_socket_addrs()?.next().unwrap();
+        let (addr, server) = server
+            .try_bind_with_graceful_shutdown(addr, rx.map(|_| ()))
+            .map_err_to_code(ErrorCode::CannotListenerPort, || {
+                format!("Cannot listener port {}", args.1)
+            })?;
+
+        let aborted = self.aborted.clone();
+        let aborted_notify = self.aborted_notify.clone();
+        tokio::spawn(async move {
+            server.await;
+            aborted.store(true, Ordering::Relaxed);
+            aborted_notify.notify_waiters();
+        });
+
+        Ok(addr)
+    }
+
+    async fn wait_terminal(&self, duration: Option<Duration>) -> Result<Elapsed> {
+        let instant = Instant::now();
+
+        match duration {
+            None => {
+                if !self.aborted.load(Ordering::Relaxed) {
+                    self.aborted_notify.notified().await;
+                }
+            }
+            Some(duration) => {
+                if !self.aborted.load(Ordering::Relaxed) {
+                    tokio::time::timeout(duration, self.aborted_notify.notified())
+                        .await
+                        .map_err(|_| {
+                            ErrorCode::Timeout(format!(
+                                "MetricService did not shutdown in {:?}",
+                                duration
+                            ))
+                        })?;
+                }
+            }
+        };
+
+        Ok(instant.elapsed())
+    }
+}
+
+struct MetricsReply(String);
+
+impl Reply for MetricsReply {
+    fn into_response(self) -> Response {
+        warp::http::Response::new(Body::from(self.0))
     }
 }

--- a/fusequery/query/src/metrics/metric_service_test.rs
+++ b/fusequery/query/src/metrics/metric_service_test.rs
@@ -1,0 +1,63 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::net::SocketAddr;
+
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_runtime::tokio;
+use metrics::counter;
+use warp::http::Uri;
+use warp::hyper::Client;
+
+use crate::metrics::MetricService;
+
+pub static METRIC_TEST: &str = "metrics.test";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_metrics_server() -> Result<()> {
+    let service = MetricService::create();
+    let address = service.start(("127.0.0.1".to_string(), 0)).await?;
+
+    assert_eq!(do_get(address).await?, "");
+    counter!(METRIC_TEST, 1);
+    assert_eq!(
+        do_get(address).await?,
+        "# TYPE metrics_test counter\nmetrics_test 1\n\n"
+    );
+    Ok(())
+}
+
+async fn do_get(address: SocketAddr) -> Result<String> {
+    let uri = match format!("http://{}", address).parse::<Uri>() {
+        Ok(uri) => uri,
+        Err(error) => {
+            return Err(ErrorCode::LogicalError(format!(
+                "Cannot parse uri {}",
+                error
+            )))
+        }
+    };
+
+    let client = Client::new();
+    match client.get(uri).await {
+        Err(error) => Err(ErrorCode::LogicalError(format!(
+            "Cannot request uri {}",
+            error
+        ))),
+        Ok(mut response) => match warp::hyper::body::to_bytes(response.body_mut()).await {
+            Err(error) => Err(ErrorCode::LogicalError(format!(
+                "Cannot parse response body {}",
+                error
+            ))),
+            Ok(body) => match std::str::from_utf8(body.as_ref()) {
+                Ok(str) => Ok(str.to_string()),
+                Err(error) => Err(ErrorCode::LogicalError(format!(
+                    "Cannot from utf8 {}",
+                    error
+                ))),
+            },
+        },
+    }
+}

--- a/fusequery/query/src/metrics/mod.rs
+++ b/fusequery/query/src/metrics/mod.rs
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+#[cfg(test)]
+mod metric_service_test;
+
 mod metric_service;
 
 pub use metric_service::MetricService;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Support graceful shutdown for Metrics API

## Changelog

- Improvement

## Related Issues

Related #832 