### PR TITLE
[store] refine: use native waiting util to watch raft metrics changes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha#919d91cb31b307cede7d0911ff45e1030174a340"
+source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.1#24d9e9280725b2da39b27dde3d7b393477b496e2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -33,7 +33,7 @@ common-tracing = {path = "../../common/tracing"}
 
 # Crates.io dependencies
 anyhow = "1.0.41"
-async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha" }
+async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.1" }
 async-trait = "0.1"
 env_logger = "0.8"
 futures = "0.3"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refine: use native waiting util to watch raft metrics changes.

Oh yeah 65 LOC reduced! :DDD

## Changelog




- Improvement


## Related Issues

#271