### PR TITLE
ISSUE-873: system.tracing table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ perf.*
 *.stdout
 *.out
 *.swp
+_logs/*
+
 # for tests in mac
 *.stderr-e
 *.stdout-e

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1518,6 +1518,7 @@ dependencies = [
  "toml",
  "tonic",
  "uuid",
+ "walkdir",
  "warp",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,8 @@ name = "common-tracing"
 version = "0.1.0"
 dependencies = [
  "tracing",
+ "tracing-appender",
+ "tracing-bunyan-formatter",
  "tracing-futures",
  "tracing-subscriber",
 ]
@@ -1684,6 +1686,16 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e692e296bfac1d2533ef168d0b60ff5897b8b70a4009276834014dd8924cc028"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4687,6 +4699,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9965507e507f12c8901432a33e31131222abac31edd90cabbcf85cf544b7127a"
+dependencies = [
+ "chrono",
+ "crossbeam-channel 0.5.1",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4695,6 +4718,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tracing-bunyan-formatter"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06718867c20ea03700d41a9413610cccf5d772caea792f34cc73cdd43f0e14a6"
+dependencies = [
+ "chrono",
+ "gethostname",
+ "log 0.4.14",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/common/tracing/Cargo.toml
+++ b/common/tracing/Cargo.toml
@@ -8,5 +8,7 @@ edition = "2018"
 
 [dependencies] # In alphabetical order
 tracing = "0.1.26"
+tracing-appender = "0.1.2"
+tracing-bunyan-formatter = "0.1"
 tracing-futures = { version = "0.2.5", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/common/tracing/src/lib.rs
+++ b/common/tracing/src/lib.rs
@@ -5,5 +5,5 @@
 mod logging;
 
 pub use logging::init_default_tracing;
-pub use logging::init_tracing_with_level;
+pub use logging::init_tracing_with_file;
 pub use tracing;

--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -4,36 +4,60 @@
 
 use std::sync::Once;
 
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling::RollingFileAppender;
+use tracing_appender::rolling::Rotation;
+use tracing_bunyan_formatter::BunyanFormattingLayer;
+use tracing_bunyan_formatter::JsonStorageLayer;
 use tracing_subscriber::fmt;
+use tracing_subscriber::fmt::Layer;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Registry;
 
+/// Write logs to stdout.
 pub fn init_default_tracing() {
     static START: Once = Once::new();
 
     START.call_once(|| {
-        init_tracing(EnvFilter::from_default_env());
+        init_tracing_stdout("error");
     });
 }
 
-pub fn init_tracing_with_level(level: &str) {
-    static START: Once = Once::new();
-
-    START.call_once(|| {
-        let log_layer_filter = EnvFilter::try_new(level).unwrap();
-        init_tracing(log_layer_filter);
-    });
-}
-
-fn init_tracing(filter: EnvFilter) {
+fn init_tracing_stdout(level: &str) {
     let fmt_layer = fmt::Layer::default()
         .with_thread_ids(true)
         .with_ansi(true)
         .with_span_events(fmt::format::FmtSpan::FULL);
 
-    let subscriber = Registry::default().with(filter).with(fmt_layer);
+    let subscriber = Registry::default()
+        .with(EnvFilter::new(level))
+        .with(fmt_layer);
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("error setting global tracing subscriber");
+}
+
+/// Write logs to file and rotation by HOUR.
+pub fn init_tracing_with_file(app_name: &str, dir: &str, level: &str) -> Vec<WorkerGuard> {
+    let mut guards = vec![];
+
+    let (stdout_writer, stdout_guard) = tracing_appender::non_blocking(std::io::stdout());
+    let stdout_logging_layer = Layer::new().with_writer(stdout_writer);
+    guards.push(stdout_guard);
+
+    let file_appender = RollingFileAppender::new(Rotation::HOURLY, dir, app_name);
+    let (file_writer, file_guard) = tracing_appender::non_blocking(file_appender);
+    let file_logging_layer = BunyanFormattingLayer::new(app_name.to_string(), file_writer);
+    guards.push(file_guard);
+
+    let subscriber = Registry::default()
+        .with(EnvFilter::new(level))
+        .with(stdout_logging_layer)
+        .with(JsonStorageLayer)
+        .with(file_logging_layer);
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("error setting global tracing subscriber");
+
+    guards
 }

--- a/fusequery/benchmarks/nyctaxi/src/bin/nyctaxi.rs
+++ b/fusequery/benchmarks/nyctaxi/src/bin/nyctaxi.rs
@@ -14,6 +14,7 @@ use common_planners::CreateTablePlan;
 use common_planners::TableEngineType;
 use common_planners::TableOptions;
 use common_runtime::tokio;
+use fuse_query::configs::Config;
 use fuse_query::interpreters::InterpreterFactory;
 use fuse_query::optimizers::Optimizers;
 use fuse_query::sessions::FuseQueryContext;
@@ -41,7 +42,7 @@ struct Opt {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let opt = Opt::from_args();
-    let ctx = FuseQueryContext::try_create()?;
+    let ctx = FuseQueryContext::try_create(Config::default())?;
     if opt.threads > 0 {
         ctx.set_max_threads(opt.threads as u64)?;
     }

--- a/fusequery/query/Cargo.toml
+++ b/fusequery/query/Cargo.toml
@@ -62,6 +62,7 @@ num = "0.4"
 nom = "6.1.2"
 num_cpus = "1.0"
 paste = "^1.0"
+pnet = "0.27.2"
 prost = "0.7"
 rand = "0.8.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -72,9 +73,9 @@ threadpool = "1.8.1"
 tokio-stream = { version = "0.1", features = ["net"] }
 toml = "0.5.6"
 tonic = "0.4"
+walkdir = "2.3.2"
 warp = "0.3.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
-pnet = "0.27.2"
 
 [dev-dependencies]
 pretty_assertions = "0.7"

--- a/fusequery/query/src/bin/fuse-query.rs
+++ b/fusequery/query/src/bin/fuse-query.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use common_exception::ErrorCode;
 use common_runtime::tokio;
-use common_tracing::init_tracing_with_level;
+use common_tracing::init_tracing_with_file;
 use fuse_query::api::HttpService;
 use fuse_query::api::RpcService;
 use fuse_query::clusters::Cluster;
@@ -35,7 +35,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         env_logger::Env::default().default_filter_or(conf.log_level.to_lowercase().as_str()),
     )
     .init();
-    init_tracing_with_level(conf.log_level.as_str());
+    let _guards =
+        init_tracing_with_file("fuse-query", conf.log_dir.as_str(), conf.log_level.as_str());
 
     info!("{:?}", conf);
     info!(

--- a/fusequery/query/src/configs/config.rs
+++ b/fusequery/query/src/configs/config.rs
@@ -34,6 +34,9 @@ pub struct Config {
     #[structopt(long, env = "FUSE_QUERY_LOG_LEVEL", default_value = "INFO")]
     pub log_level: String,
 
+    #[structopt(long, env = "FUSE_QUERY_LOG_DIR", default_value = "./_logs")]
+    pub log_dir: String,
+
     #[structopt(long, env = "FUSE_QUERY_NUM_CPUS", default_value = "0")]
     pub num_cpus: u64,
 
@@ -114,6 +117,7 @@ impl Config {
     pub fn default() -> Self {
         Config {
             log_level: "debug".to_string(),
+            log_dir: "./_logs".to_string(),
             num_cpus: 8,
             mysql_handler_host: "127.0.0.1".to_string(),
             mysql_handler_port: 3307,

--- a/fusequery/query/src/configs/config_test.rs
+++ b/fusequery/query/src/configs/config_test.rs
@@ -12,6 +12,7 @@ fn test_config() -> common_exception::Result<()> {
     {
         let expect = Config {
             log_level: "debug".to_string(),
+            log_dir: "./_logs".to_string(),
             num_cpus: 8,
             mysql_handler_host: "127.0.0.1".to_string(),
             mysql_handler_port: 3307,

--- a/fusequery/query/src/datasources/system/mod.rs
+++ b/fusequery/query/src/datasources/system/mod.rs
@@ -29,6 +29,7 @@ mod system_database;
 mod system_factory;
 mod tables_table;
 mod tracing_table;
+mod tracing_table_stream;
 
 pub use clusters_table::ClustersTable;
 pub use contributors_table::ContributorsTable;
@@ -41,3 +42,5 @@ pub use settings_table::SettingsTable;
 pub use system_database::SystemDatabase;
 pub use system_factory::SystemFactory;
 pub use tables_table::TablesTable;
+pub use tracing_table::TracingTable;
+pub use tracing_table_stream::TracingTableStream;

--- a/fusequery/query/src/datasources/system/mod.rs
+++ b/fusequery/query/src/datasources/system/mod.rs
@@ -16,6 +16,8 @@ mod numbers_table_test;
 mod settings_table_test;
 #[cfg(test)]
 mod tables_table_test;
+#[cfg(test)]
+mod tracing_table_test;
 
 mod clusters_table;
 mod contributors_table;

--- a/fusequery/query/src/datasources/system/mod.rs
+++ b/fusequery/query/src/datasources/system/mod.rs
@@ -28,6 +28,7 @@ mod settings_table;
 mod system_database;
 mod system_factory;
 mod tables_table;
+mod tracing_table;
 
 pub use clusters_table::ClustersTable;
 pub use contributors_table::ContributorsTable;

--- a/fusequery/query/src/datasources/system/system_database.rs
+++ b/fusequery/query/src/datasources/system/system_database.rs
@@ -34,6 +34,7 @@ impl SystemDatabase {
             Arc::new(system::TablesTable::create()),
             Arc::new(system::ClustersTable::create()),
             Arc::new(system::DatabasesTable::create()),
+            Arc::new(system::TracingTable::create()),
         ];
         let mut tables: HashMap<String, Arc<dyn Table>> = HashMap::default();
         for tbl in table_list.iter() {

--- a/fusequery/query/src/datasources/system/tables_table_test.rs
+++ b/fusequery/query/src/datasources/system/tables_table_test.rs
@@ -38,6 +38,7 @@ async fn test_tables_table() -> anyhow::Result<()> {
         "| system   | one           | SystemOne          |",
         "| system   | settings      | SystemSettings     |",
         "| system   | tables        | SystemTables       |",
+        "| system   | tracing       | SystemTracing      |",
         "+----------+---------------+--------------------+",
     ];
     common_datablocks::assert_blocks_sorted_eq(expected, result.as_slice());

--- a/fusequery/query/src/datasources/system/tracing_table.rs
+++ b/fusequery/query/src/datasources/system/tracing_table.rs
@@ -1,0 +1,111 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use common_aggregate_functions::AggregateFunctionFactory;
+use common_datablocks::DataBlock;
+use common_datavalues::BooleanArray;
+use common_datavalues::DataField;
+use common_datavalues::DataSchemaRef;
+use common_datavalues::DataSchemaRefExt;
+use common_datavalues::DataType;
+use common_datavalues::StringArray;
+use common_exception::Result;
+use common_functions::FunctionFactory;
+use common_planners::Partition;
+use common_planners::ReadDataSourcePlan;
+use common_planners::ScanPlan;
+use common_planners::Statistics;
+use common_streams::DataBlockStream;
+use common_streams::SendableDataBlockStream;
+
+use crate::datasources::Table;
+use crate::sessions::FuseQueryContextRef;
+
+pub struct TracingTable {
+    schema: DataSchemaRef,
+}
+
+impl TracingTable {
+    pub fn create() -> Self {
+        TracingTable {
+            schema: DataSchemaRefExt::create(vec![
+                DataField::new("name", DataType::Utf8, false),
+                DataField::new("is_aggregate", DataType::Boolean, false),
+            ]),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Table for TracingTable {
+    fn name(&self) -> &str {
+        "tracing"
+    }
+
+    fn engine(&self) -> &str {
+        "SystemTracing"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> Result<DataSchemaRef> {
+        Ok(self.schema.clone())
+    }
+
+    fn is_local(&self) -> bool {
+        true
+    }
+
+    fn read_plan(
+        &self,
+        _ctx: FuseQueryContextRef,
+        scan: &ScanPlan,
+        _partitions: usize,
+    ) -> Result<ReadDataSourcePlan> {
+        Ok(ReadDataSourcePlan {
+            db: "system".to_string(),
+            table: self.name().to_string(),
+            schema: self.schema.clone(),
+            partitions: vec![Partition {
+                name: "".to_string(),
+                version: 0,
+            }],
+            statistics: Statistics::default(),
+            description: "(Read from system.functions table)".to_string(),
+            scan_plan: Arc::new(scan.clone()),
+            remote: false,
+        })
+    }
+
+    async fn read(&self, _ctx: FuseQueryContextRef) -> Result<SendableDataBlockStream> {
+        let func_names = FunctionFactory::registered_names();
+        let aggr_func_names = AggregateFunctionFactory::registered_names();
+
+        let names: Vec<&str> = func_names
+            .iter()
+            .chain(aggr_func_names.iter())
+            .map(|x| x.as_ref())
+            .collect();
+
+        let is_aggregate = (0..names.len())
+            .map(|i| i >= func_names.len())
+            .collect::<Vec<bool>>();
+
+        let block = DataBlock::create_by_array(self.schema.clone(), vec![
+            Arc::new(StringArray::from(names)),
+            Arc::new(BooleanArray::from(is_aggregate)),
+        ]);
+
+        Ok(Box::pin(DataBlockStream::create(
+            self.schema.clone(),
+            None,
+            vec![block],
+        )))
+    }
+}

--- a/fusequery/query/src/datasources/system/tracing_table_stream.rs
+++ b/fusequery/query/src/datasources/system/tracing_table_stream.rs
@@ -1,0 +1,36 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::task::Poll;
+
+use common_datablocks::DataBlock;
+use common_exception::Result;
+use futures::Stream;
+
+pub struct TracingTableStream {
+    log_dir: String,
+}
+
+impl TracingTableStream {
+    pub fn try_create(log_dir: String) -> Result<Self> {
+        Ok(TracingTableStream { log_dir })
+    }
+
+    pub fn try_get_one_block(&self) -> Result<Option<DataBlock>> {
+        let _dir = self.log_dir.clone();
+        todo!()
+    }
+}
+
+impl Stream for TracingTableStream {
+    type Item = Result<DataBlock>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let block = self.try_get_one_block()?;
+        Poll::Ready(block.map(Ok))
+    }
+}

--- a/fusequery/query/src/datasources/system/tracing_table_stream.rs
+++ b/fusequery/query/src/datasources/system/tracing_table_stream.rs
@@ -2,24 +2,90 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::sync::Arc;
 use std::task::Poll;
 
+use common_arrow::arrow::array::StringArray;
+use common_arrow::arrow::datatypes::SchemaRef;
 use common_datablocks::DataBlock;
+use common_datavalues::Int64Array;
+use common_datavalues::Int8Array;
 use common_exception::Result;
 use futures::Stream;
 
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+struct LogEntry {
+    v: i64,
+    name: String,
+    msg: String,
+    level: i8,
+    hostname: String,
+    pid: i64,
+    time: String,
+}
+
 pub struct TracingTableStream {
-    log_dir: String,
+    idx: usize,
+    log_files: Vec<String>,
+    schema: SchemaRef,
 }
 
 impl TracingTableStream {
-    pub fn try_create(log_dir: String) -> Result<Self> {
-        Ok(TracingTableStream { log_dir })
+    pub fn try_create(schema: SchemaRef, log_files: Vec<String>) -> Result<Self> {
+        Ok(TracingTableStream {
+            schema,
+            log_files,
+            idx: 0,
+        })
     }
 
-    pub fn try_get_one_block(&self) -> Result<Option<DataBlock>> {
-        let _dir = self.log_dir.clone();
-        todo!()
+    pub fn try_get_one_block(&mut self) -> Result<Option<DataBlock>> {
+        if self.idx >= self.log_files.len() {
+            return Ok(None);
+        }
+
+        let mut version_col = vec![];
+        let mut name_col = vec![];
+        let mut msg_col = vec![];
+        let mut level_col = vec![];
+        let mut host_col = vec![];
+        let mut pid_col = vec![];
+        let mut time_col = vec![];
+
+        let file = File::open(self.log_files[self.idx].clone())?;
+        self.idx += 1;
+
+        let reader = BufReader::new(file);
+        for line in reader.lines() {
+            let entry: LogEntry = serde_json::from_str(line.unwrap().as_str()).unwrap();
+            version_col.push(entry.v);
+            name_col.push(entry.name);
+            msg_col.push(entry.msg);
+            level_col.push(entry.level);
+            host_col.push(entry.hostname);
+            pid_col.push(entry.pid);
+            time_col.push(entry.time);
+        }
+
+        let names: Vec<&str> = name_col.iter().map(|x| x.as_str()).collect();
+        let msgs: Vec<&str> = msg_col.iter().map(|x| x.as_str()).collect();
+        let hosts: Vec<&str> = host_col.iter().map(|x| x.as_str()).collect();
+        let times: Vec<&str> = time_col.iter().map(|x| x.as_str()).collect();
+
+        let block = DataBlock::create_by_array(self.schema.clone(), vec![
+            Arc::new(Int64Array::from(version_col)),
+            Arc::new(StringArray::from(names)),
+            Arc::new(StringArray::from(msgs)),
+            Arc::new(Int8Array::from(level_col)),
+            Arc::new(StringArray::from(hosts)),
+            Arc::new(Int64Array::from(pid_col)),
+            Arc::new(StringArray::from(times)),
+        ]);
+
+        Ok(Some(block))
     }
 }
 
@@ -27,7 +93,7 @@ impl Stream for TracingTableStream {
     type Item = Result<DataBlock>;
 
     fn poll_next(
-        self: std::pin::Pin<&mut Self>,
+        mut self: std::pin::Pin<&mut Self>,
         _: &mut std::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let block = self.try_get_one_block()?;

--- a/fusequery/query/src/datasources/system/tracing_table_test.rs
+++ b/fusequery/query/src/datasources/system/tracing_table_test.rs
@@ -1,0 +1,39 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use common_planners::*;
+use common_runtime::tokio;
+use futures::TryStreamExt;
+
+use crate::datasources::system::*;
+use crate::datasources::*;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_tracing_table() -> anyhow::Result<()> {
+    let ctx = crate::tests::try_create_context()?;
+    let table = TracingTable::create();
+    table.read_plan(
+        ctx.clone(),
+        &ScanPlan::empty(),
+        ctx.get_max_threads()? as usize,
+    )?;
+
+    let stream = table.read(ctx).await?;
+    let result = stream.try_collect::<Vec<_>>().await?;
+    let block = &result[0];
+    assert_eq!(block.num_columns(), 7);
+    assert_eq!(block.num_rows(), 2);
+
+    let expected = vec![
+            "+---+------------+---------------------------------------------+-------+----------+--------+-------------------------------------+",
+            "| v | name       | msg                                         | level | hostname | pid    | time                                |",
+            "+---+------------+---------------------------------------------+-------+----------+--------+-------------------------------------+",
+            "| 0 | fuse-query | signal received, starting graceful shutdown | 20    | thinkpad | 121242 | 2021-06-25T04:57:49.243264399+00:00 |",
+            "| 0 | fuse-query | signal received, starting graceful shutdown | 20    | thinkpad | 121242 | 2021-06-25T04:57:49.243264399+00:00 |",
+            "+---+------------+---------------------------------------------+-------+----------+--------+-------------------------------------+",
+    ];
+    common_datablocks::assert_blocks_sorted_eq(expected, result.as_slice());
+
+    Ok(())
+}

--- a/fusequery/query/src/sessions/context.rs
+++ b/fusequery/query/src/sessions/context.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 
 use crate::clusters::Cluster;
 use crate::clusters::ClusterRef;
+use crate::configs::Config;
 use crate::datasources::DataSource;
 use crate::datasources::Table;
 use crate::datasources::TableFunction;
@@ -28,6 +29,7 @@ use crate::sessions::Settings;
 
 #[derive(Clone)]
 pub struct FuseQueryContext {
+    conf: Config,
     uuid: Arc<RwLock<String>>,
     settings: Arc<Settings>,
     cluster: Arc<RwLock<ClusterRef>>,
@@ -43,9 +45,10 @@ pub struct FuseQueryContext {
 pub type FuseQueryContextRef = Arc<FuseQueryContext>;
 
 impl FuseQueryContext {
-    pub fn try_create() -> Result<FuseQueryContextRef> {
+    pub fn try_create(conf: Config) -> Result<FuseQueryContextRef> {
         let settings = Settings::try_create()?;
         let ctx = FuseQueryContext {
+            conf,
             uuid: Arc::new(RwLock::new(Uuid::new_v4().to_string())),
             settings: settings.clone(),
             cluster: Arc::new(RwLock::new(Cluster::empty())),
@@ -67,11 +70,13 @@ impl FuseQueryContext {
     }
 
     pub fn from_settings(
+        conf: Config,
         settings: Arc<Settings>,
         default_database: String,
         datasource: Arc<DataSource>,
     ) -> Result<FuseQueryContextRef> {
         Ok(Arc::new(FuseQueryContext {
+            conf,
             uuid: Arc::new(RwLock::new(Uuid::new_v4().to_string())),
             settings: settings.clone(),
             cluster: Arc::new(RwLock::new(Cluster::empty())),
@@ -244,6 +249,10 @@ impl FuseQueryContext {
 
     pub fn get_settings(&self) -> Arc<Settings> {
         self.settings.clone()
+    }
+
+    pub fn get_config(&self) -> Config {
+        self.conf.clone()
     }
 }
 

--- a/fusequery/query/src/sessions/session.rs
+++ b/fusequery/query/src/sessions/session.rs
@@ -8,6 +8,7 @@ use common_exception::Result;
 use common_infallible::Mutex;
 use common_runtime::tokio::net::TcpStream;
 
+use crate::configs::Config;
 use crate::servers::AbortableService;
 use crate::sessions::FuseQueryContextRef;
 use crate::sessions::SessionManagerRef;
@@ -16,7 +17,11 @@ use crate::sessions::SessionStatus;
 pub trait SessionCreator {
     type Session: ISession;
 
-    fn create(id: String, sessions: SessionManagerRef) -> Result<Arc<Box<dyn ISession>>>;
+    fn create(
+        conf: Config,
+        id: String,
+        sessions: SessionManagerRef,
+    ) -> Result<Arc<Box<dyn ISession>>>;
 }
 
 pub trait ISession: AbortableService<TcpStream, ()> + Send + Sync {

--- a/fusequery/query/src/sessions/sessions.rs
+++ b/fusequery/query/src/sessions/sessions.rs
@@ -29,6 +29,7 @@ use crate::sessions::FuseQueryContext;
 use crate::sessions::FuseQueryContextRef;
 
 pub struct SessionManager {
+    conf: Config,
     cluster: ClusterRef,
     datasource: Arc<DataSource>,
 
@@ -46,6 +47,7 @@ pub type SessionManagerRef = Arc<SessionManager>;
 impl SessionManager {
     pub fn try_create(max_mysql_sessions: u64) -> Result<SessionManagerRef> {
         Ok(Arc::new(SessionManager {
+            conf: Config::default(),
             cluster: Cluster::empty(),
             datasource: Arc::new(DataSource::try_create()?),
 
@@ -61,6 +63,7 @@ impl SessionManager {
     pub fn from_conf(conf: Config, cluster: ClusterRef) -> Result<SessionManagerRef> {
         let max_mysql_sessions = conf.mysql_handler_thread_num as usize;
         Ok(Arc::new(SessionManager {
+            conf,
             cluster,
             datasource: Arc::new(DataSource::try_create()?),
 
@@ -91,7 +94,7 @@ impl SessionManager {
             )),
             false => {
                 let id = uuid::Uuid::new_v4().to_string();
-                let session = S::create(id.clone(), self.clone())?;
+                let session = S::create(self.conf.clone(), id.clone(), self.clone())?;
                 sessions.insert(id, session.clone());
                 Ok(session)
             }
@@ -118,7 +121,7 @@ impl SessionManager {
     pub fn try_create_context(&self) -> Result<FuseQueryContextRef> {
         counter!(super::metrics::METRIC_SESSION_CONNECT_NUMBERS, 1);
 
-        let ctx = FuseQueryContext::try_create()?;
+        let ctx = FuseQueryContext::try_create(self.conf.clone())?;
         self.queries_context
             .write()
             .insert(ctx.get_id(), ctx.clone());

--- a/fusequery/query/src/sessions/status.rs
+++ b/fusequery/query/src/sessions/status.rs
@@ -13,6 +13,7 @@ use common_planners::PlanNode;
 use futures::future::AbortHandle;
 
 use crate::clusters::ClusterRef;
+use crate::configs::Config;
 use crate::datasources::DataSource;
 use crate::sessions::FuseQueryContext;
 use crate::sessions::FuseQueryContextRef;
@@ -79,10 +80,12 @@ impl SessionStatus {
 
     pub fn try_create_context(
         &mut self,
+        conf: Config,
         cluster: ClusterRef,
         datasource: Arc<DataSource>,
     ) -> Result<FuseQueryContextRef> {
         FuseQueryContext::from_settings(
+            conf,
             self.session_settings.clone(),
             self.current_database.clone(),
             datasource,

--- a/fusequery/query/src/tests/context.rs
+++ b/fusequery/query/src/tests/context.rs
@@ -4,11 +4,12 @@
 
 use common_exception::Result;
 
+use crate::configs::Config;
 use crate::sessions::FuseQueryContext;
 use crate::sessions::FuseQueryContextRef;
 
 pub fn try_create_context() -> Result<FuseQueryContextRef> {
-    let ctx = FuseQueryContext::try_create()?;
+    let ctx = FuseQueryContext::try_create(Config::default())?;
     ctx.with_id("2021")?;
 
     ctx.set_max_threads(8)?;

--- a/fusequery/query/src/tests/context.rs
+++ b/fusequery/query/src/tests/context.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::env;
+
 use common_exception::Result;
 
 use crate::configs::Config;
@@ -9,9 +11,16 @@ use crate::sessions::FuseQueryContext;
 use crate::sessions::FuseQueryContextRef;
 
 pub fn try_create_context() -> Result<FuseQueryContextRef> {
-    let ctx = FuseQueryContext::try_create(Config::default())?;
-    ctx.with_id("2021")?;
+    let mut config = Config::default();
+    // Setup log dir to the tests directory.
+    config.log_dir = env::current_dir()?
+        .join("../../tests/data/logs")
+        .display()
+        .to_string();
 
+    let ctx = FuseQueryContext::try_create(config)?;
+    ctx.with_id("2021")?;
     ctx.set_max_threads(8)?;
+
     Ok(ctx)
 }

--- a/tests/data/logs/fuse-query.2021-06-25-04
+++ b/tests/data/logs/fuse-query.2021-06-25-04
@@ -1,0 +1,2 @@
+{"v":0,"name":"fuse-query","msg":"signal received, starting graceful shutdown","level":20,"hostname":"thinkpad","pid":121242,"time":"2021-06-25T04:57:49.243264399+00:00"}
+{"v":0,"name":"fuse-query","msg":"signal received, starting graceful shutdown","level":20,"hostname":"thinkpad","pid":121242,"time":"2021-06-25T04:57:49.243264399+00:00"}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

- [x] add tracing to rotation file with json format
- [x] streaming logs to system.tracing from log dir


Start fuse-query with TRACE:
```
FUSE_QUERY_LOG_LEVEL="TRACE" ./target/debug/fuse-query
```
Make some logs:
```
datafuse :) SELECT max(number) FROM numbers_mt(10000) GROUP BY number % 3, number % 4;
```

Analyze on system.tracing example:
```
datafuse :) select max(pid) from system.tracing group by hostname;

SELECT max(pid)
FROM system.tracing
GROUP BY hostname

Query id: 38359d89-0196-42f7-b47c-d7689fc38007

┌─max(pid)─┐
│   123240 │
└──────────┘
```

## Changelog

- New Feature


## Related Issues

Fixes #873

## Test Plan

Unit Tests

Stateless Tests

