### PR TITLE
[common/exceptions] feature: add convertion from and to tonic::Status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,9 +701,11 @@ dependencies = [
  "anyhow",
  "backtrace",
  "common-arrow",
+ "serde",
  "serde_json",
  "sqlparser",
  "thiserror",
+ "tonic",
 ]
 
 [[package]]

--- a/common/exception/Cargo.toml
+++ b/common/exception/Cargo.toml
@@ -8,10 +8,13 @@ edition = "2018"
 
 [dependencies] # In alphabetical order
 common-arrow = {path = "../arrow"}
-thiserror = "1.0.25"
+
 anyhow = "1.0.41"
-serde_json = "1.0"
 backtrace = "0.3.60"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+thiserror = "1.0.25"
+tonic = "0.4.3"
 
 # Github dependencies
 sqlparser =  { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "35ef0ee"}

--- a/fusequery/query/src/api/rpc/mod.rs
+++ b/fusequery/query/src/api/rpc/mod.rs
@@ -15,54 +15,19 @@ mod flight_dispatcher;
 mod flight_scatter;
 mod flight_service_new;
 
-use std::sync::Arc;
-
 pub use actions::ExecutePlanWithShuffleAction;
-use common_exception::exception::ErrorCodeBacktrace;
 use common_exception::ErrorCode;
 pub use flight_client_new::FlightClient;
 pub use flight_dispatcher::FlightDispatcher;
 pub use flight_dispatcher::StreamInfo;
 pub use flight_service_new::FlightStream;
 pub use flight_service_new::FuseQueryService;
-use tonic::Code;
 use tonic::Status;
 
-#[derive(serde::Serialize, serde::Deserialize)]
-struct SerializedError {
-    code: u16,
-    message: String,
-    backtrace: String,
-}
-
 pub fn to_status(error: ErrorCode) -> Status {
-    let serialized_error_json = serde_json::to_string::<SerializedError>(&SerializedError {
-        code: error.code(),
-        message: error.message(),
-        backtrace: error.backtrace_str(),
-    });
-
-    match serialized_error_json {
-        Ok(serialized_error_json) => Status::internal(serialized_error_json),
-        Err(error) => Status::unknown(error.to_string()),
-    }
+    error.into()
 }
 
 pub fn from_status(status: Status) -> ErrorCode {
-    match status.code() {
-        Code::Internal => match serde_json::from_str::<SerializedError>(&status.message()) {
-            Err(error) => ErrorCode::from(error),
-            Ok(serialized_error) => match serialized_error.backtrace.len() {
-                0 => ErrorCode::create(serialized_error.code, serialized_error.message, None),
-                _ => ErrorCode::create(
-                    serialized_error.code,
-                    serialized_error.message,
-                    Some(ErrorCodeBacktrace::Serialized(Arc::new(
-                        serialized_error.backtrace,
-                    ))),
-                ),
-            },
-        },
-        _ => ErrorCode::UnImplement(status.to_string()),
-    }
+    status.into()
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [common/exceptions] feature: add convertion from and to tonic::Status
So that FuseQuery and FuseStore talks the same error exchange protocol.

- ErrorCode serialization in Query now depends on this feature.

## Changelog

- New Feature





## Related Issues

#271