### PR TITLE
[store] feature: flight: add get_database()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "common-planners",
  "common-runtime",
  "common-streams",
+ "common-tracing",
  "futures",
  "hyper",
  "jwt-simple",

--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -376,7 +376,11 @@ impl From<ErrorCode> for Status {
         let rst_json = serde_json::to_string::<SerializedError>(&SerializedError {
             code: err.code(),
             message: err.message(),
-            backtrace: err.backtrace_str(),
+            backtrace: {
+                let mut str = err.backtrace_str();
+                str.truncate(2 * 1024);
+                str
+            },
         });
 
         match rst_json {

--- a/common/flights/Cargo.toml
+++ b/common/flights/Cargo.toml
@@ -15,6 +15,7 @@ common-exception= {path = "../exception"}
 common-planners = {path = "../planners"}
 common-runtime = {path = "../runtime"}
 common-streams = {path = "../streams"}
+common-tracing = {path = "../tracing"}
 
 # Github dependencies
 

--- a/common/flights/src/store_client.rs
+++ b/common/flights/src/store_client.rs
@@ -26,6 +26,7 @@ use common_planners::DropTablePlan;
 use common_planners::ScanPlan;
 use common_runtime::tokio;
 use common_streams::SendableDataBlockStream;
+use common_tracing::tracing;
 use futures::stream;
 use futures::SinkExt;
 use futures::StreamExt;
@@ -51,6 +52,8 @@ use crate::CreateDatabaseActionResult;
 use crate::CreateTableActionResult;
 use crate::DropTableAction;
 use crate::DropTableActionResult;
+use crate::GetDatabaseAction;
+use crate::GetDatabaseActionResult;
 use crate::GetTableAction;
 use crate::GetTableActionResult;
 use crate::ScanPartitionAction;
@@ -110,6 +113,21 @@ impl StoreClient {
             return Ok(rst);
         }
         anyhow::bail!("invalid response")
+    }
+
+    pub async fn get_database(
+        &mut self,
+        db: &str,
+    ) -> common_exception::Result<GetDatabaseActionResult> {
+        let action = StoreDoAction::GetDatabase(GetDatabaseAction { db: db.to_string() });
+        let rst = self.do_action_err_code(&action).await?;
+
+        match rst {
+            StoreDoActionResult::GetDatabase(rst) => Ok(rst),
+            _ => Err(ErrorCode::UnknownException(
+                "result is not StoreDoActionResult::GetDatabase",
+            )),
+        }
     }
 
     /// Drop database call.
@@ -256,6 +274,32 @@ impl StoreClient {
             ),
             Some(resp) => {
                 info!("do_action: resp: {:}", flight_result_to_str(&resp));
+
+                let action_rst: StoreDoActionResult = resp.try_into()?;
+                Ok(action_rst)
+            }
+        }
+    }
+
+    /// A transitional method that use ErrorCode instead of anyhow:Error
+    /// TODO replace do_action with this function when all of the error types are replcaed with ErrorCode
+    async fn do_action_err_code(
+        &mut self,
+        action: &StoreDoAction,
+    ) -> common_exception::Result<StoreDoActionResult> {
+        // TODO: an action can always be able to serialize, or it is a bug.
+        let mut req: Request<Action> = action.try_into()?;
+        req.set_timeout(self.timeout);
+
+        let mut stream = self.client.do_action(req).await?.into_inner();
+
+        match stream.message().await? {
+            None => Err(ErrorCode::UnknownException(format!(
+                "Can not receive data from store flight server, action: {:?}",
+                action
+            ))),
+            Some(resp) => {
+                tracing::debug!("do_action: resp: {:}", flight_result_to_str(&resp));
 
                 let action_rst: StoreDoActionResult = resp.try_into()?;
                 Ok(action_rst)

--- a/fusestore/store/src/configs/config.rs
+++ b/fusestore/store/src/configs/config.rs
@@ -68,3 +68,14 @@ pub struct Config {
     )]
     pub boot: bool,
 }
+
+impl Config {
+    /// StructOptToml provides a default Default impl that loads config from cli args,
+    /// which conflicts with unit test if case-filter arguments passed, e.g.:
+    /// `cargo test my_unit_test_fn`
+    ///
+    /// Thus we need another method to generate an empty default instance.
+    pub fn empty() -> Self {
+        Self::from_iter(&Vec::<&'static str>::new())
+    }
+}

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -15,7 +15,7 @@ use crate::meta_service::MetaServiceClient;
 pub async fn start_store_server() -> Result<String> {
     let addr = rand_local_addr();
 
-    let mut conf = Config::default();
+    let mut conf = Config::empty();
     conf.flight_api_address = addr.clone();
 
     let srv = StoreServer::create(conf);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: flight: add get_database()
- Add a transitional method that use ErrorCode instead of anyhow::Error.

- Fix: Config::default() should not try to parse cli args. Otherwise it
  reads the cargo test arguments and result in an unexpected argument
  error.
  Add another method Config::empty() to build a default instance.

## Changelog

- New Feature





## Related Issues

#271 

#774 