### PR TITLE
[store/meta] feature: add "unclassified" namespace to meta to store everything else a user need.

### DIFF
--- a/common/metatypes/src/lib.rs
+++ b/common/metatypes/src/lib.rs
@@ -10,6 +10,9 @@ use std::collections::HashSet;
 use serde::Deserialize;
 use serde::Serialize;
 
+/// Value with a corresponding sequence number
+pub type SeqValue = (u64, Vec<u8>);
+
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Database {
     pub database_id: u64,

--- a/fusestore/store/src/meta_service/meta.rs
+++ b/fusestore/store/src/meta_service/meta.rs
@@ -21,6 +21,8 @@ use crate::meta_service::Cmd;
 use crate::meta_service::NodeId;
 use crate::meta_service::Placement;
 
+/// seq number key to generate seq for the value of a `unclassified` record.
+const SEQ_UNCLASSIFIED: &str = "unclassified";
 /// seq number key to generate database id
 const SEQ_DATABASE_ID: &str = "database_id";
 /// seq number key to generate table id
@@ -62,6 +64,11 @@ pub struct Meta {
 
     /// table id to table mapping
     pub tables: BTreeMap<u64, Table>,
+
+    /// A kv store of all other unclassified information.
+    /// The value is tuple of a monotonic sequence number and userdata value in string.
+    /// The sequence number is guaranteed to increment(by some value greater than 0) everytime the record changes.
+    pub unclassified: BTreeMap<String, (u64, String)>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -97,6 +104,7 @@ impl MetaBuilder {
             replication,
             databases: BTreeMap::new(),
             tables: BTreeMap::new(),
+            unclassified: BTreeMap::new(),
         };
         for _i in 0..initial_slots {
             m.slots.push(Slot::default());
@@ -184,6 +192,39 @@ impl Meta {
                     Ok((prev, Some(db)).into())
                 }
             }
+
+            Cmd::UpsertUnclassified {
+                ref key,
+                ref seq,
+                ref value,
+            } => {
+                let prev = self.unclassified.get(key).cloned();
+
+                let seq_matched = if let Some(seq) = seq {
+                    if *seq == 0 {
+                        prev.is_none()
+                    } else {
+                        match prev {
+                            Some(ref p) => *seq == (*p).0,
+                            None => false,
+                        }
+                    }
+                } else {
+                    // If seq is None, always override it.
+                    true
+                };
+
+                if !seq_matched {
+                    return Ok((prev, None).into());
+                }
+
+                let new_seq = self.incr_seq(SEQ_UNCLASSIFIED);
+                let record_value = (new_seq, value.clone());
+                self.unclassified.insert(key.clone(), record_value.clone());
+                tracing::debug!("applied UpsertUnclassified: {}={:?}", key, record_value);
+
+                Ok((prev, Some(record_value)).into())
+            }
         }
     }
 
@@ -234,6 +275,11 @@ impl Meta {
 
     pub fn get_database(&self, name: &str) -> Option<Database> {
         let x = self.databases.get(name);
+        x.cloned()
+    }
+
+    pub fn get_unclassified(&self, name: &str) -> Option<(u64, String)> {
+        let x = self.unclassified.get(name);
         x.cloned()
     }
 }

--- a/fusestore/store/src/meta_service/meta.rs
+++ b/fusestore/store/src/meta_service/meta.rs
@@ -68,7 +68,7 @@ pub struct Meta {
     /// A kv store of all other unclassified information.
     /// The value is tuple of a monotonic sequence number and userdata value in string.
     /// The sequence number is guaranteed to increment(by some value greater than 0) everytime the record changes.
-    pub unclassified: BTreeMap<String, (u64, String)>,
+    pub unclassified: BTreeMap<String, (u64, Vec<u8>)>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -278,8 +278,8 @@ impl Meta {
         x.cloned()
     }
 
-    pub fn get_unclassified(&self, name: &str) -> Option<(u64, String)> {
-        let x = self.unclassified.get(name);
+    pub fn get_unclassified(&self, key: &str) -> Option<(u64, Vec<u8>)> {
+        let x = self.unclassified.get(key);
         x.cloned()
     }
 }

--- a/fusestore/store/src/meta_service/meta_test.rs
+++ b/fusestore/store/src/meta_service/meta_test.rs
@@ -126,6 +126,7 @@ fn test_meta_apply_incr_seq() -> anyhow::Result<()> {
 
     Ok(())
 }
+
 #[test]
 fn test_meta_apply_add_database() -> anyhow::Result<()> {
     let mut m = Meta::builder().build()?;
@@ -193,6 +194,93 @@ fn test_meta_apply_add_database() -> anyhow::Result<()> {
             .get_database(c.name)
             .ok_or_else(|| anyhow::anyhow!("db not found: {}", c.name));
         assert_eq!(want, got.unwrap().database_id);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_meta_apply_unclassified() -> anyhow::Result<()> {
+    let mut m = Meta::builder().build()?;
+
+    struct T {
+        // input:
+        key: String,
+        seq: Option<u64>,
+        value: String,
+        // want:
+        prev: Option<(u64, String)>,
+        result: Option<(u64, String)>,
+    }
+
+    fn case(
+        name: &'static str,
+        seq: Option<u64>,
+        value: &'static str,
+        prev: Option<(u64, &'static str)>,
+        result: Option<(u64, &'static str)>,
+    ) -> T {
+        let name = name.to_string();
+        let value = value.to_string();
+        let prev = match prev {
+            None => None,
+            Some((s, v)) => Some((s, v.to_string())),
+        };
+        let result = match result {
+            None => None,
+            Some((s, v)) => Some((s, v.to_string())),
+        };
+        T {
+            key: name,
+            seq,
+            value,
+            prev,
+            result,
+        }
+    }
+
+    let cases: Vec<T> = vec![
+        case("foo", Some(5), "b", None, None),
+        case("foo", None, "a", None, Some((1, "a"))),
+        case("foo", None, "b", Some((1, "a")), Some((2, "b"))),
+        case("foo", Some(5), "b", Some((2, "b")), None),
+        case("bar", Some(0), "x", None, Some((3, "x"))),
+        case("bar", Some(0), "y", Some((3, "x")), None),
+    ];
+
+    for (i, c) in cases.iter().enumerate() {
+        let mes = format!("{}-th: {}({:?})={}", i, c.key, c.seq, c.value);
+
+        // write
+
+        let resp = m.apply(&ClientRequest {
+            txid: None,
+            cmd: Cmd::UpsertUnclassified {
+                key: c.key.clone(),
+                seq: c.seq,
+                value: c.value.clone(),
+            },
+        })?;
+        assert_eq!(
+            ClientResponse::Unclassified {
+                prev: c.prev.clone(),
+                result: c.result.clone(),
+            },
+            resp,
+            "write: {}",
+            mes,
+        );
+
+        // get
+
+        let want = match (&c.prev, &c.result) {
+            (_, Some(ref b)) => Some(b.clone()),
+            (Some(ref a), _) => Some(a.clone()),
+            _ => None,
+        };
+
+        let got = m.get_unclassified(&c.key);
+        assert_eq!(want, got, "get: {}", mes,);
     }
 
     Ok(())

--- a/fusestore/store/src/meta_service/meta_test.rs
+++ b/fusestore/store/src/meta_service/meta_test.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 use common_metatypes::Database;
+use common_metatypes::SeqValue;
 
 use crate::meta_service::meta::Replication;
 use crate::meta_service::ClientRequest;
@@ -207,10 +208,10 @@ fn test_meta_apply_unclassified() -> anyhow::Result<()> {
         // input:
         key: String,
         seq: Option<u64>,
-        value: String,
+        value: Vec<u8>,
         // want:
-        prev: Option<(u64, String)>,
-        result: Option<(u64, String)>,
+        prev: Option<SeqValue>,
+        result: Option<SeqValue>,
     }
 
     fn case(
@@ -221,14 +222,14 @@ fn test_meta_apply_unclassified() -> anyhow::Result<()> {
         result: Option<(u64, &'static str)>,
     ) -> T {
         let name = name.to_string();
-        let value = value.to_string();
+        let value = value.to_string().into_bytes();
         let prev = match prev {
             None => None,
-            Some((s, v)) => Some((s, v.to_string())),
+            Some((s, v)) => Some((s, v.to_string().into_bytes())),
         };
         let result = match result {
             None => None,
-            Some((s, v)) => Some((s, v.to_string())),
+            Some((s, v)) => Some((s, v.to_string().into_bytes())),
         };
         T {
             key: name,
@@ -249,7 +250,7 @@ fn test_meta_apply_unclassified() -> anyhow::Result<()> {
     ];
 
     for (i, c) in cases.iter().enumerate() {
-        let mes = format!("{}-th: {}({:?})={}", i, c.key, c.seq, c.value);
+        let mes = format!("{}-th: {}({:?})={:?}", i, c.key, c.seq, c.value);
 
         // write
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store/meta] feature: add "unclassified" namespace to meta to store everything else a user need.

The underlaying data structure impl of an general purpose  distributed KV storage service.

The `value` in this kv service is versioned, i.e. every written value has a corresponding globally unique `sequence` number bound to it. Thus CAS can be done by specifying the expected version to modify.


RPC API is coming soon in next pr~ :DDD


## Changelog

- New Feature





## Related Issues

#271

#883 
#900 