### PR TITLE
ISSUE-899 try fix cannot destroy session when panic for MySQL

### DIFF
--- a/common/infallible/src/exit_guard.rs
+++ b/common/infallible/src/exit_guard.rs
@@ -1,0 +1,15 @@
+pub struct ExitGuard<F: Fn()> {
+    function: F,
+}
+
+impl<F: Fn()> ExitGuard<F> {
+    pub fn create(f: F) -> ExitGuard<F> {
+        ExitGuard { function: f }
+    }
+}
+
+impl<F: Fn()> Drop for ExitGuard<F> {
+    fn drop(&mut self) {
+        (self.function)();
+    }
+}

--- a/common/infallible/src/exit_guard.rs
+++ b/common/infallible/src/exit_guard.rs
@@ -1,3 +1,7 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
 pub struct ExitGuard<F: Fn()> {
     function: F,
 }

--- a/common/infallible/src/lib.rs
+++ b/common/infallible/src/lib.rs
@@ -22,5 +22,3 @@ macro_rules! exit_scope {
         let _exit_guard = ExitGuard::create(move || $x);
     };
 }
-
-// pub use exit_scope;

--- a/common/infallible/src/lib.rs
+++ b/common/infallible/src/lib.rs
@@ -7,8 +7,20 @@ mod mutex_test;
 #[cfg(test)]
 mod rwlock_test;
 
+mod exit_guard;
 mod mutex;
 mod rwlock;
 
+pub use exit_guard::ExitGuard;
 pub use mutex::Mutex;
 pub use rwlock::RwLock;
+
+#[macro_export]
+macro_rules! exit_scope {
+    ($x:block) => {
+        use common_infallible::ExitGuard;
+        let _exit_guard = ExitGuard::create(move || $x);
+    };
+}
+
+// pub use exit_scope;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

try fix cannot destroy session when panic for MySQLHandler

## Changelog

- Improvement

## Related Issues

#899 

