### PR TITLE
[common/exception] feature: add convertion from &Status

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -84,7 +84,7 @@ macro_rules! as_item {
 }
 
 macro_rules! build_exceptions {
-    ($($body:tt($code:expr)),*) => {
+    ($($body:tt($code:expr)),*$(,)*) => {
         as_item! {
             impl ErrorCode {
                 $(
@@ -150,14 +150,14 @@ build_exceptions! {
     CannotListenerPort(45),
 
     UnknownException(1000),
-    TokioError(1001)
+    TokioError(1001),
 }
 
 // Store errors
 build_exceptions! {
 
     FileMetaNotFound(2001),
-    FileDamaged(2002)
+    FileDamaged(2002),
 }
 
 pub type Result<T> = std::result::Result<T, ErrorCode>;

--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -346,8 +346,8 @@ struct SerializedError {
     backtrace: String,
 }
 
-impl From<Status> for ErrorCode {
-    fn from(status: Status) -> Self {
+impl From<&Status> for ErrorCode {
+    fn from(status: &Status) -> Self {
         match status.code() {
             tonic::Code::Internal => {
                 match serde_json::from_str::<SerializedError>(&status.message()) {
@@ -368,6 +368,12 @@ impl From<Status> for ErrorCode {
             }
             _ => ErrorCode::UnImplement(status.to_string()),
         }
+    }
+}
+
+impl From<Status> for ErrorCode {
+    fn from(status: Status) -> Self {
+        (&status).into()
     }
 }
 

--- a/common/exception/src/exception_test.rs
+++ b/common/exception/src/exception_test.rs
@@ -61,10 +61,23 @@ fn test_from_and_to_status() -> anyhow::Result<()> {
     // Only compare the code and message. Discard backtrace.
     assert_eq!(r#"{"code":7,"message":"foo","#, &status.message()[..26]);
 
-    let e2: ErrorCode = status.into();
+    {
+        // test from &Status
 
-    assert_eq!(7, e2.code());
-    assert_eq!("foo", e2.message());
+        let e2: ErrorCode = (&status).into();
+
+        assert_eq!(7, e2.code());
+        assert_eq!("foo", e2.message());
+    }
+
+    {
+        // test from Status
+
+        let e2: ErrorCode = status.into();
+
+        assert_eq!(7, e2.code());
+        assert_eq!("foo", e2.message());
+    }
 
     Ok(())
 }

--- a/common/exception/src/lib.rs
+++ b/common/exception/src/lib.rs
@@ -10,3 +10,10 @@ pub mod exception;
 pub use exception::ErrorCode;
 pub use exception::Result;
 pub use exception::ToErrorCode;
+
+pub mod prelude {
+
+    pub use crate::exception::ErrorCode;
+    pub use crate::exception::Result;
+    pub use crate::exception::ToErrorCode;
+}

--- a/common/exception/tests/prelude_test.rs
+++ b/common/exception/tests/prelude_test.rs
@@ -1,0 +1,17 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use common_exception::prelude::*;
+
+#[test]
+fn test_prelude() -> anyhow::Result<()> {
+    let x: std::result::Result<(), std::fmt::Error> = Err(std::fmt::Error {});
+    let y: common_exception::Result<()> = x.map_err_to_code(ErrorCode::UnknownException, || 123);
+
+    assert_eq!(
+        "Code: 1000, displayText = 123, cause: an error occurred when formatting an argument.",
+        format!("{}", y.unwrap_err())
+    );
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [common/exception] feature: add convertion from &Status

##### [common/exception] add prelude for ease of use

## Changelog

- New Feature


