### PR TITLE
[common/exception] refine: ToErrorCode should not expect E to be an std::error::Error in "Result<T, E>"

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -308,7 +308,9 @@ impl ErrorCode {
 ///     format!("{}", y.unwrap_err())
 /// );
 /// ```
-pub trait ToErrorCode<T, E, CtxFn> {
+pub trait ToErrorCode<T, E, CtxFn>
+where E: Display + Send + Sync + 'static
+{
     /// Wrap the error value with ErrorCode. It is lazily evaluated:
     /// only when an error does occur.
     ///
@@ -322,7 +324,7 @@ pub trait ToErrorCode<T, E, CtxFn> {
 }
 
 impl<T, E, CtxFn> ToErrorCode<T, E, CtxFn> for std::result::Result<T, E>
-where E: std::error::Error + Send + Sync + 'static
+where E: Display + Send + Sync + 'static
 {
     fn map_err_to_code<ErrFn, D>(self, make_exception: ErrFn, context_fn: CtxFn) -> Result<T>
     where

--- a/common/exception/src/exception_test.rs
+++ b/common/exception/src/exception_test.rs
@@ -52,6 +52,22 @@ fn test_derive_from_std_error() {
 }
 
 #[test]
+fn test_derive_from_display() {
+    use crate::exception::ErrorCode;
+    use crate::exception::ToErrorCode;
+
+    let rst: std::result::Result<(), u64> = Err(3);
+
+    let rst1: crate::exception::Result<()> =
+        rst.map_err_to_code(ErrorCode::UnknownException, || 123);
+
+    assert_eq!(
+        "Code: 1000, displayText = 123, cause: 3.",
+        format!("{}", rst1.as_ref().unwrap_err())
+    );
+}
+
+#[test]
 fn test_from_and_to_status() -> anyhow::Result<()> {
     use crate::exception::*;
     let e = ErrorCode::IllegalDataType("foo");


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [common/exception] refine: ToErrorCode should not expect E to be an std::error::Error in "Result<T, E>"
Since the Err() does not have to be an `Error`, but instead, any type should be OK.

## Changelog




- Improvement


## Related Issues

