### PR TITLE
[store] refactor: raftmeta: use common/exception::ErrorCode instead of anyhow::Error if possible

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -158,6 +158,24 @@ build_exceptions! {
 
     FileMetaNotFound(2001),
     FileDamaged(2002),
+
+    // store node errors
+
+    UnknownNode(2101),
+
+    // meta service errors
+
+    // meta service does not work.
+    MetaServiceError(2201),
+    // meta service is shut down.
+    MetaServiceShutdown(2202),
+    // meta service is unavailable for now.
+    MetaServiceUnavailable(2203),
+
+    // config errors
+
+    InvalidConfig(2301),
+
 }
 
 pub type Result<T> = std::result::Result<T, ErrorCode>;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: raftmeta: use common/exception::ErrorCode instead of anyhow::Error if possible

## Changelog




- Improvement


## Related Issues

#271