### PR TITLE
[store] refactor terms

### DIFF
--- a/fusestore/store/src/dfs/distributed_fs.rs
+++ b/fusestore/store/src/dfs/distributed_fs.rs
@@ -14,8 +14,8 @@ use common_tracing::tracing;
 use crate::fs::FileSystem;
 use crate::fs::ListResult;
 use crate::localfs::LocalFS;
-use crate::meta_service::ClientRequest;
 use crate::meta_service::Cmd;
+use crate::meta_service::LogEntry;
 use crate::meta_service::MetaNode;
 
 /// DFS is a distributed file system impl.
@@ -52,7 +52,7 @@ impl FileSystem for Dfs {
 
         // update meta, other store nodes will be informed about this change and then pull the data to complete replication.
 
-        let req = ClientRequest {
+        let req = LogEntry {
             txid: None,
             cmd: Cmd::AddFile {
                 key: path.to_string(),

--- a/fusestore/store/src/executor/kv_handlers.rs
+++ b/fusestore/store/src/executor/kv_handlers.rs
@@ -11,14 +11,14 @@ use common_store_api::UpsertKVActionResult;
 
 use crate::executor::action_handler::RequestHandler;
 use crate::executor::ActionHandler;
-use crate::meta_service::ClientRequest;
-use crate::meta_service::ClientResponse;
+use crate::meta_service::AppliedState;
 use crate::meta_service::Cmd;
+use crate::meta_service::LogEntry;
 
 #[async_trait::async_trait]
 impl RequestHandler<UpsertKVAction> for ActionHandler {
     async fn handle(&self, act: UpsertKVAction) -> common_exception::Result<UpsertKVActionResult> {
-        let cr = ClientRequest {
+        let cr = LogEntry {
             txid: None,
             cmd: Cmd::UpsertKV {
                 key: act.key,
@@ -34,7 +34,7 @@ impl RequestHandler<UpsertKVAction> for ActionHandler {
             .map_err(|e| ErrorCode::MetaNodeInternalError(e.to_string()))?;
 
         match rst {
-            ClientResponse::KV { prev, result } => Ok(UpsertKVActionResult { prev, result }),
+            AppliedState::KV { prev, result } => Ok(UpsertKVActionResult { prev, result }),
             _ => Err(ErrorCode::MetaNodeInternalError("not a KV result")),
         }
     }

--- a/fusestore/store/src/meta_service/applied_state.rs
+++ b/fusestore/store/src/meta_service/applied_state.rs
@@ -1,0 +1,120 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use async_raft::AppDataResponse;
+use common_metatypes::Database;
+use common_metatypes::SeqValue;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::meta_service::Node;
+use crate::meta_service::RaftMes;
+use crate::meta_service::RetryableError;
+
+/// The state of an applied raft log.
+/// Normally it includes two fields: the state before applying and the state after applying the log.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum AppliedState {
+    String {
+        // The value before applying a RaftRequest.
+        prev: Option<String>,
+        // The value after applying a RaftRequest.
+        result: Option<String>,
+    },
+    Seq {
+        seq: u64,
+    },
+    Node {
+        prev: Option<Node>,
+        result: Option<Node>,
+    },
+    DataBase {
+        prev: Option<Database>,
+        result: Option<Database>,
+    },
+
+    KV {
+        prev: Option<SeqValue>,
+        result: Option<SeqValue>,
+    },
+}
+
+impl AppDataResponse for AppliedState {}
+
+// === raw applied result to AppliedState
+
+impl From<(Option<String>, Option<String>)> for AppliedState {
+    fn from(v: (Option<String>, Option<String>)) -> Self {
+        AppliedState::String {
+            prev: v.0,
+            result: v.1,
+        }
+    }
+}
+
+impl From<u64> for AppliedState {
+    fn from(seq: u64) -> Self {
+        AppliedState::Seq { seq }
+    }
+}
+
+impl From<(Option<Node>, Option<Node>)> for AppliedState {
+    fn from(v: (Option<Node>, Option<Node>)) -> Self {
+        AppliedState::Node {
+            prev: v.0,
+            result: v.1,
+        }
+    }
+}
+
+impl From<(Option<Database>, Option<Database>)> for AppliedState {
+    fn from(v: (Option<Database>, Option<Database>)) -> Self {
+        AppliedState::DataBase {
+            prev: v.0,
+            result: v.1,
+        }
+    }
+}
+
+impl From<(Option<SeqValue>, Option<SeqValue>)> for AppliedState {
+    fn from(v: (Option<SeqValue>, Option<SeqValue>)) -> Self {
+        AppliedState::KV {
+            prev: v.0,
+            result: v.1,
+        }
+    }
+}
+
+// === from and to transport message
+
+impl From<AppliedState> for RaftMes {
+    fn from(msg: AppliedState) -> Self {
+        let data = serde_json::to_string(&msg).expect("fail to serialize");
+        RaftMes {
+            data,
+            error: "".to_string(),
+        }
+    }
+}
+impl From<Result<AppliedState, RetryableError>> for RaftMes {
+    fn from(rst: Result<AppliedState, RetryableError>) -> Self {
+        match rst {
+            Ok(resp) => resp.into(),
+            Err(err) => err.into(),
+        }
+    }
+}
+
+impl From<RaftMes> for Result<AppliedState, RetryableError> {
+    fn from(msg: RaftMes) -> Self {
+        if !msg.data.is_empty() {
+            let resp: AppliedState = serde_json::from_str(&msg.data).expect("fail to deserialize");
+            Ok(resp)
+        } else {
+            let err: RetryableError =
+                serde_json::from_str(&msg.error).expect("fail to deserialize");
+            Err(err)
+        }
+    }
+}

--- a/fusestore/store/src/meta_service/cmd.rs
+++ b/fusestore/store/src/meta_service/cmd.rs
@@ -1,0 +1,67 @@
+use std::fmt;
+
+use async_raft::NodeId;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::meta_service::Node;
+
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+/// Cmd is an action a client wants to take.
+/// A Cmd is committed by raft leader before being applied.
+
+/// A Cmd describes what a user want to do to raft state machine
+/// and is the essential part of a raft log.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum Cmd {
+    /// AKA put-if-absent. add a key-value record only when key is absent.
+    AddFile { key: String, value: String },
+
+    /// Override the record with key.
+    SetFile { key: String, value: String },
+
+    /// Increment the sequence number generator specified by `key` and returns the new value.
+    IncrSeq { key: String },
+
+    /// Add node if absent
+    AddNode { node_id: NodeId, node: Node },
+
+    /// Add a database if absent
+    AddDatabase { name: String },
+
+    /// Update or insert a general purpose kv store
+    UpsertKV {
+        key: String,
+        /// Set to Some() to modify the value only when the seq matches.
+        /// Since a sequence number is positive, use Some(0) to perform an add-if-absent operation.
+        seq: Option<u64>,
+        value: Vec<u8>,
+    },
+}
+
+impl fmt::Display for Cmd {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Cmd::AddFile { key, value } => {
+                write!(f, "add_file:{}={}", key, value)
+            }
+            Cmd::SetFile { key, value } => {
+                write!(f, "set_file:{}={}", key, value)
+            }
+            Cmd::IncrSeq { key } => {
+                write!(f, "incr_seq:{}", key)
+            }
+            Cmd::AddNode { node_id, node } => {
+                write!(f, "add_node:{}={}", node_id, node)
+            }
+            Cmd::AddDatabase { name } => {
+                write!(f, "add_db:{}", name)
+            }
+            Cmd::UpsertKV { key, seq, value } => {
+                write!(f, "upsert_kv: {}({:?}) = {:?}", key, seq, value)
+            }
+        }
+    }
+}

--- a/fusestore/store/src/meta_service/errors.rs
+++ b/fusestore/store/src/meta_service/errors.rs
@@ -1,0 +1,23 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use async_raft::NodeId;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Error, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum RetryableError {
+    /// Trying to write to a non-leader returns the latest leader the raft node knows,
+    /// to indicate the client to retry.
+    #[error("request must be forwarded to leader: {leader}")]
+    ForwardToLeader { leader: NodeId },
+}
+
+/// Error used to trigger Raft shutdown from storage.
+#[derive(Clone, Debug, Error)]
+pub enum ShutdownError {
+    #[error("unsafe storage error")]
+    UnsafeStorageError,
+}

--- a/fusestore/store/src/meta_service/log_entry.rs
+++ b/fusestore/store/src/meta_service/log_entry.rs
@@ -1,0 +1,49 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::convert::TryFrom;
+
+use async_raft::AppData;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::meta_service::Cmd;
+use crate::meta_service::RaftMes;
+use crate::meta_service::RaftTxId;
+
+/// The application data request type which the `MetaStore` works with.
+///
+/// The client and the serial together provides external consistency:
+/// If a client failed to recv the response, it  re-send another RaftRequest with the same
+/// "client" and "serial", thus the raft engine is able to distinguish if a request is duplicated.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LogEntry {
+    /// When not None, it is used to filter out duplicated logs, which are caused by retries by client.
+    pub txid: Option<RaftTxId>,
+
+    /// The action a client want to take.
+    pub cmd: Cmd,
+}
+
+impl AppData for LogEntry {}
+
+impl tonic::IntoRequest<RaftMes> for LogEntry {
+    fn into_request(self) -> tonic::Request<RaftMes> {
+        let mes = RaftMes {
+            data: serde_json::to_string(&self).expect("fail to serialize"),
+            error: "".to_string(),
+        };
+        tonic::Request::new(mes)
+    }
+}
+
+impl TryFrom<RaftMes> for LogEntry {
+    type Error = tonic::Status;
+
+    fn try_from(mes: RaftMes) -> Result<Self, Self::Error> {
+        let req: LogEntry =
+            serde_json::from_str(&mes.data).map_err(|e| tonic::Status::internal(e.to_string()))?;
+        Ok(req)
+    }
+}

--- a/fusestore/store/src/meta_service/meta_service_impl.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl.rs
@@ -10,9 +10,9 @@ use std::sync::Arc;
 
 use common_tracing::tracing;
 
-use crate::meta_service::ClientRequest;
 use crate::meta_service::GetReply;
 use crate::meta_service::GetReq;
+use crate::meta_service::LogEntry;
 use crate::meta_service::MetaNode;
 use crate::meta_service::MetaService;
 use crate::meta_service::RaftMes;
@@ -37,7 +37,7 @@ impl MetaService for MetaServiceImpl {
         request: tonic::Request<RaftMes>,
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
         let mes = request.into_inner();
-        let req: ClientRequest = mes.try_into()?;
+        let req: LogEntry = mes.try_into()?;
 
         let rst = self
             .meta_node

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -2,22 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+pub mod applied_state;
+pub mod cmd;
+pub mod errors;
+pub mod log_entry;
 pub mod meta_service_impl;
 pub mod placement;
+pub mod raft_txid;
 pub mod raftmeta;
 pub mod state_machine;
 
+pub use applied_state::AppliedState;
 pub use async_raft::NodeId;
+pub use cmd::Cmd;
+pub use errors::RetryableError;
+pub use errors::ShutdownError;
+pub use log_entry::LogEntry;
 pub use meta_service_impl::MetaServiceImpl;
 pub use placement::Placement;
-pub use raftmeta::ClientRequest;
-pub use raftmeta::ClientResponse;
-pub use raftmeta::Cmd;
-pub use raftmeta::MemStore;
+pub use raft_txid::RaftTxId;
 pub use raftmeta::MetaNode;
+pub use raftmeta::MetaStore;
 pub use raftmeta::Network;
-pub use raftmeta::RaftTxId;
-pub use raftmeta::ShutdownError;
 pub use state_machine::Node;
 pub use state_machine::Slot;
 pub use state_machine::StateMachine;

--- a/fusestore/store/src/meta_service/raft_txid.rs
+++ b/fusestore/store/src/meta_service/raft_txid.rs
@@ -1,0 +1,27 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// RaftTxId is the essential info to identify an write operation to raft.
+/// Logs with the same RaftTxId are considered the same and only the first of them will be applied.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct RaftTxId {
+    /// The ID of the client which has sent the request.
+    pub client: String,
+    /// The serial number of this request.
+    /// TODO(xp): a client must generate consistent `client` and globally unique serial.
+    /// TODO(xp): in this impl the state machine records only one serial, which implies serial must be monotonic incremental for every client.
+    pub serial: u64,
+}
+
+impl RaftTxId {
+    pub fn new(client: &str, serial: u64) -> Self {
+        Self {
+            client: client.to_string(),
+            serial,
+        }
+    }
+}

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -4,8 +4,6 @@
 
 use std::collections::BTreeMap;
 use std::collections::HashSet;
-use std::convert::TryFrom;
-use std::fmt;
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -24,8 +22,6 @@ use async_raft::raft::VoteResponse;
 use async_raft::storage::CurrentSnapshotData;
 use async_raft::storage::HardState;
 use async_raft::storage::InitialState;
-use async_raft::AppData;
-use async_raft::AppDataResponse;
 use async_raft::ClientWriteError;
 use async_raft::NodeId;
 use async_raft::Raft;
@@ -46,120 +42,24 @@ use common_runtime::tokio::task::JoinHandle;
 use common_tracing::tracing;
 use serde::Deserialize;
 use serde::Serialize;
-use thiserror::Error;
 use tonic::transport::channel::Channel;
 
+use crate::meta_service::AppliedState;
+use crate::meta_service::Cmd;
+use crate::meta_service::LogEntry;
 use crate::meta_service::MetaServiceClient;
 use crate::meta_service::MetaServiceImpl;
 use crate::meta_service::MetaServiceServer;
 use crate::meta_service::Node;
 use crate::meta_service::RaftMes;
+use crate::meta_service::RetryableError;
+use crate::meta_service::ShutdownError;
 use crate::meta_service::StateMachine;
 
 const ERR_INCONSISTENT_LOG: &str =
     "a query was received which was expecting data to be in place which does not exist in the log";
 
-/// Cmd is an action a client wants to take.
-/// A Cmd is committed by raft leader before being applied.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub enum Cmd {
-    /// AKA put-if-absent. add a key-value record only when key is absent.
-    AddFile { key: String, value: String },
-
-    /// Override the record with key.
-    SetFile { key: String, value: String },
-
-    /// Increment the sequence number generator specified by `key` and returns the new value.
-    IncrSeq { key: String },
-
-    /// Add node if absent
-    AddNode { node_id: NodeId, node: Node },
-
-    /// Add a database if absent
-    AddDatabase { name: String },
-
-    /// Update or insert a general purpose kv store
-    UpsertKV {
-        key: String,
-        /// Set to Some() to modify the value only when the seq matches.
-        /// Since a sequence number is positive, use Some(0) to perform an add-if-absent operation.
-        seq: Option<u64>,
-        value: Vec<u8>,
-    },
-}
-
-impl fmt::Display for Cmd {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Cmd::AddFile { key, value } => {
-                write!(f, "add_file:{}={}", key, value)
-            }
-            Cmd::SetFile { key, value } => {
-                write!(f, "set_file:{}={}", key, value)
-            }
-            Cmd::IncrSeq { key } => {
-                write!(f, "incr_seq:{}", key)
-            }
-            Cmd::AddNode { node_id, node } => {
-                write!(f, "add_node:{}={}", node_id, node)
-            }
-            Cmd::AddDatabase { name } => {
-                write!(f, "add_db:{}", name)
-            }
-            Cmd::UpsertKV { key, seq, value } => {
-                write!(f, "upsert_kv: {}({:?}) = {:?}", key, seq, value)
-            }
-        }
-    }
-}
-
-/// RaftTxId is the essential info to identify an write operation to raft.
-/// Logs with the same RaftTxId are considered the same and only the first of them will be applied.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct RaftTxId {
-    /// The ID of the client which has sent the request.
-    pub client: String,
-    /// The serial number of this request.
-    /// TODO(xp): a client must generate consistent `client` and globally unique serial.
-    /// TODO(xp): in this impl the state machine records only one serial, which implies serial must be monotonic incremental for every client.
-    pub serial: u64,
-}
-
-impl RaftTxId {
-    pub fn new(client: &str, serial: u64) -> Self {
-        Self {
-            client: client.to_string(),
-            serial,
-        }
-    }
-}
-
-/// The application data request type which the `MemStore` works with.
-///
-/// The client and the serial together provides external consistency:
-/// If a client failed to recv the response, it  re-send another ClientRequest with the same
-/// "client" and "serial", thus the raft engine is able to distinguish if a request is duplicated.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ClientRequest {
-    /// When not None, it is used to filter out duplicated logs, which are caused by retries by client.
-    pub txid: Option<RaftTxId>,
-
-    /// The action a client want to take.
-    pub cmd: Cmd,
-}
-
-impl AppData for ClientRequest {}
-
-impl tonic::IntoRequest<RaftMes> for ClientRequest {
-    fn into_request(self) -> tonic::Request<RaftMes> {
-        let mes = RaftMes {
-            data: serde_json::to_string(&self).expect("fail to serialize"),
-            error: "".to_string(),
-        };
-        tonic::Request::new(mes)
-    }
-}
-impl tonic::IntoRequest<RaftMes> for AppendEntriesRequest<ClientRequest> {
+impl tonic::IntoRequest<RaftMes> for AppendEntriesRequest<LogEntry> {
     fn into_request(self) -> tonic::Request<RaftMes> {
         let mes = RaftMes {
             data: serde_json::to_string(&self).expect("fail to serialize"),
@@ -187,62 +87,6 @@ impl tonic::IntoRequest<RaftMes> for VoteRequest {
     }
 }
 
-impl TryFrom<RaftMes> for ClientRequest {
-    type Error = tonic::Status;
-
-    fn try_from(mes: RaftMes) -> Result<Self, Self::Error> {
-        let req: ClientRequest =
-            serde_json::from_str(&mes.data).map_err(|e| tonic::Status::internal(e.to_string()))?;
-        Ok(req)
-    }
-}
-
-#[derive(Error, Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub enum RetryableError {
-    /// Trying to write to a non-leader returns the latest leader the raft node knows,
-    /// to indicate the client to retry.
-    #[error("request must be forwarded to leader: {leader}")]
-    ForwardToLeader { leader: NodeId },
-}
-
-/// The application data response type which the `MemStore` works with.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub enum ClientResponse {
-    String {
-        // The value before applying a ClientRequest.
-        prev: Option<String>,
-        // The value after applying a ClientRequest.
-        result: Option<String>,
-    },
-    Seq {
-        seq: u64,
-    },
-    Node {
-        prev: Option<Node>,
-        result: Option<Node>,
-    },
-    DataBase {
-        prev: Option<Database>,
-        result: Option<Database>,
-    },
-
-    KV {
-        prev: Option<SeqValue>,
-        result: Option<SeqValue>,
-    },
-}
-
-impl AppDataResponse for ClientResponse {}
-
-impl From<ClientResponse> for RaftMes {
-    fn from(msg: ClientResponse) -> Self {
-        let data = serde_json::to_string(&msg).expect("fail to serialize");
-        RaftMes {
-            data,
-            error: "".to_string(),
-        }
-    }
-}
 impl From<RetryableError> for RaftMes {
     fn from(err: RetryableError) -> Self {
         let error = serde_json::to_string(&err).expect("fail to serialize");
@@ -253,81 +97,9 @@ impl From<RetryableError> for RaftMes {
     }
 }
 
-impl From<Result<ClientResponse, RetryableError>> for RaftMes {
-    fn from(rst: Result<ClientResponse, RetryableError>) -> Self {
-        match rst {
-            Ok(resp) => resp.into(),
-            Err(err) => err.into(),
-        }
-    }
-}
-
-impl From<RaftMes> for Result<ClientResponse, RetryableError> {
-    fn from(msg: RaftMes) -> Self {
-        if !msg.data.is_empty() {
-            let resp: ClientResponse =
-                serde_json::from_str(&msg.data).expect("fail to deserialize");
-            Ok(resp)
-        } else {
-            let err: RetryableError =
-                serde_json::from_str(&msg.error).expect("fail to deserialize");
-            Err(err)
-        }
-    }
-}
-
-impl From<(Option<String>, Option<String>)> for ClientResponse {
-    fn from(v: (Option<String>, Option<String>)) -> Self {
-        ClientResponse::String {
-            prev: v.0,
-            result: v.1,
-        }
-    }
-}
-
-impl From<u64> for ClientResponse {
-    fn from(seq: u64) -> Self {
-        ClientResponse::Seq { seq }
-    }
-}
-
-impl From<(Option<Node>, Option<Node>)> for ClientResponse {
-    fn from(v: (Option<Node>, Option<Node>)) -> Self {
-        ClientResponse::Node {
-            prev: v.0,
-            result: v.1,
-        }
-    }
-}
-
-impl From<(Option<Database>, Option<Database>)> for ClientResponse {
-    fn from(v: (Option<Database>, Option<Database>)) -> Self {
-        ClientResponse::DataBase {
-            prev: v.0,
-            result: v.1,
-        }
-    }
-}
-
-impl From<(Option<SeqValue>, Option<SeqValue>)> for ClientResponse {
-    fn from(v: (Option<SeqValue>, Option<SeqValue>)) -> Self {
-        ClientResponse::KV {
-            prev: v.0,
-            result: v.1,
-        }
-    }
-}
-
-/// Error used to trigger Raft shutdown from storage.
-#[derive(Clone, Debug, Error)]
-pub enum ShutdownError {
-    #[error("unsafe storage error")]
-    UnsafeStorageError,
-}
-
-/// The application snapshot type which the `MemStore` works with.
+/// The application snapshot type which the `MetaStore` works with.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MemStoreSnapshot {
+pub struct MetaStoreSnapshot {
     /// The last index covered by this snapshot.
     pub index: u64,
     /// The term of the last index covered by this snapshot.
@@ -339,21 +111,21 @@ pub struct MemStoreSnapshot {
 }
 
 /// An in-memory storage system implementing the `async_raft::RaftStorage` trait.
-pub struct MemStore {
+pub struct MetaStore {
     /// The ID of the Raft node for which this memory storage instances is configured.
     id: NodeId,
     /// The Raft log.
-    log: RwLock<BTreeMap<u64, Entry<ClientRequest>>>,
+    log: RwLock<BTreeMap<u64, Entry<LogEntry>>>,
     /// The Raft state machine.
     sm: RwLock<StateMachine>,
     /// The current hard state.
     hs: RwLock<Option<HardState>>,
     /// The current snapshot.
-    current_snapshot: RwLock<Option<MemStoreSnapshot>>,
+    current_snapshot: RwLock<Option<MetaStoreSnapshot>>,
 }
 
-impl MemStore {
-    /// Create a new `MemStore` instance.
+impl MetaStore {
+    /// Create a new `MetaStore` instance.
     pub fn new(id: NodeId) -> Self {
         let log = RwLock::new(BTreeMap::new());
         let sm = RwLock::new(StateMachine::default());
@@ -369,14 +141,14 @@ impl MemStore {
         }
     }
 
-    /// Create a new `MemStore` instance with some existing state (for testing).
+    /// Create a new `MetaStore` instance with some existing state (for testing).
     #[cfg(test)]
     pub fn new_with_state(
         id: NodeId,
-        log: BTreeMap<u64, Entry<ClientRequest>>,
+        log: BTreeMap<u64, Entry<LogEntry>>,
         sm: StateMachine,
         hs: Option<HardState>,
-        current_snapshot: Option<MemStoreSnapshot>,
+        current_snapshot: Option<MetaStoreSnapshot>,
     ) -> Self {
         let log = RwLock::new(log);
         let sm = RwLock::new(sm);
@@ -392,7 +164,7 @@ impl MemStore {
     }
 
     /// Get a handle to the log for testing purposes.
-    pub async fn get_log(&self) -> RwLockWriteGuard<'_, BTreeMap<u64, Entry<ClientRequest>>> {
+    pub async fn get_log(&self) -> RwLockWriteGuard<'_, BTreeMap<u64, Entry<LogEntry>>> {
         self.log.write().await
     }
 
@@ -408,7 +180,7 @@ impl MemStore {
 }
 
 #[async_trait]
-impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
+impl RaftStorage<LogEntry, AppliedState> for MetaStore {
     type Snapshot = Cursor<Vec<u8>>;
     type ShutdownError = ShutdownError;
 
@@ -465,11 +237,7 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
     }
 
     #[tracing::instrument(level = "info", skip(self), fields(myid=self.id))]
-    async fn get_log_entries(
-        &self,
-        start: u64,
-        stop: u64,
-    ) -> anyhow::Result<Vec<Entry<ClientRequest>>> {
+    async fn get_log_entries(&self, start: u64, stop: u64) -> anyhow::Result<Vec<Entry<LogEntry>>> {
         // Invalid request, return empty vec.
         if start > stop {
             tracing::error!("invalid request, start > stop");
@@ -500,14 +268,14 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
     }
 
     #[tracing::instrument(level = "info", skip(self, entry), fields(myid=self.id))]
-    async fn append_entry_to_log(&self, entry: &Entry<ClientRequest>) -> anyhow::Result<()> {
+    async fn append_entry_to_log(&self, entry: &Entry<LogEntry>) -> anyhow::Result<()> {
         let mut log = self.log.write().await;
         log.insert(entry.index, entry.clone());
         Ok(())
     }
 
     #[tracing::instrument(level = "info", skip(self, entries), fields(myid=self.id))]
-    async fn replicate_to_log(&self, entries: &[Entry<ClientRequest>]) -> anyhow::Result<()> {
+    async fn replicate_to_log(&self, entries: &[Entry<LogEntry>]) -> anyhow::Result<()> {
         let mut log = self.log.write().await;
         for entry in entries {
             log.insert(entry.index, entry.clone());
@@ -519,8 +287,8 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
     async fn apply_entry_to_state_machine(
         &self,
         index: &u64,
-        data: &ClientRequest,
-    ) -> anyhow::Result<ClientResponse> {
+        data: &LogEntry,
+    ) -> anyhow::Result<AppliedState> {
         let mut sm = self.sm.write().await;
         let resp = sm.apply(*index, data)?;
         Ok(resp)
@@ -529,7 +297,7 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
     #[tracing::instrument(level = "info", skip(self, entries), fields(myid=self.id))]
     async fn replicate_to_state_machine(
         &self,
-        entries: &[(&u64, &ClientRequest)],
+        entries: &[(&u64, &LogEntry)],
     ) -> anyhow::Result<()> {
         let mut sm = self.sm.write().await;
         for (index, data) in entries {
@@ -583,7 +351,7 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
                 ),
             );
 
-            let snapshot = MemStoreSnapshot {
+            let snapshot = MetaStoreSnapshot {
                 index: last_applied_log,
                 term,
                 membership: membership_config.clone(),
@@ -625,7 +393,8 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
         );
         let raw = serde_json::to_string_pretty(snapshot.get_ref().as_slice())?;
         println!("JSON SNAP:\n{}", raw);
-        let new_snapshot: MemStoreSnapshot = serde_json::from_slice(snapshot.get_ref().as_slice())?;
+        let new_snapshot: MetaStoreSnapshot =
+            serde_json::from_slice(snapshot.get_ref().as_slice())?;
         // Update log.
         {
             // Go backwards through the log to find the most recent membership config <= the `through` index.
@@ -685,11 +454,11 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
 }
 
 pub struct Network {
-    sto: Arc<MemStore>,
+    sto: Arc<MetaStore>,
 }
 
 impl Network {
-    pub fn new(sto: Arc<MemStore>) -> Network {
+    pub fn new(sto: Arc<MetaStore>) -> Network {
         Network { sto }
     }
 
@@ -707,12 +476,12 @@ impl Network {
 }
 
 #[async_trait]
-impl RaftNetwork<ClientRequest> for Network {
+impl RaftNetwork<LogEntry> for Network {
     #[tracing::instrument(level = "info", skip(self), fields(myid=self.sto.id))]
     async fn append_entries(
         &self,
         target: NodeId,
-        rpc: AppendEntriesRequest<ClientRequest>,
+        rpc: AppendEntriesRequest<LogEntry>,
     ) -> anyhow::Result<AppendEntriesResponse> {
         tracing::debug!("append_entries req to: id={}: {:?}", target, rpc);
 
@@ -763,20 +532,20 @@ impl RaftNetwork<ClientRequest> for Network {
 }
 
 // MetaRaft is a impl of the generic Raft handling meta data R/W.
-pub type MetaRaft = Raft<ClientRequest, ClientResponse, Network, MemStore>;
+pub type MetaRaft = Raft<LogEntry, AppliedState, Network, MetaStore>;
 
 // MetaNode is the container of meta data related components and threads, such as storage, the raft node and a raft-state monitor.
 pub struct MetaNode {
     // metrics subscribes raft state changes. The most important field is the leader node id, to which all write operations should be forward.
     pub metrics_rx: watch::Receiver<RaftMetrics>,
-    pub sto: Arc<MemStore>,
+    pub sto: Arc<MetaStore>,
     pub raft: MetaRaft,
     pub running_tx: watch::Sender<()>,
     pub running_rx: watch::Receiver<()>,
     pub join_handles: Mutex<Vec<JoinHandle<common_exception::Result<()>>>>,
 }
 
-impl MemStore {
+impl MetaStore {
     pub async fn get_node(&self, node_id: &NodeId) -> Option<Node> {
         let sm = self.sm.read().await;
 
@@ -815,7 +584,7 @@ impl MemStore {
 pub struct MetaNodeBuilder {
     node_id: Option<NodeId>,
     config: Option<Config>,
-    sto: Option<Arc<MemStore>>,
+    sto: Option<Arc<MetaStore>>,
     monitor_metrics: bool,
     start_grpc_service: bool,
 }
@@ -869,7 +638,7 @@ impl MetaNodeBuilder {
         self.node_id = Some(node_id);
         self
     }
-    pub fn sto(mut self, sto: Arc<MemStore>) -> Self {
+    pub fn sto(mut self, sto: Arc<MetaStore>) -> Self {
         self.sto = Some(sto);
         self
     }
@@ -943,7 +712,7 @@ impl MetaNode {
     pub async fn new(node_id: NodeId) -> Arc<MetaNode> {
         let b = MetaNode::builder()
             .node_id(node_id)
-            .sto(Arc::new(MemStore::new(node_id)));
+            .sto(Arc::new(MetaStore::new(node_id)));
 
         b.build().await.expect("can not fail")
     }
@@ -1067,7 +836,7 @@ impl MetaNode {
 
         // When booting, there is addr stored in local store.
         // Thus we need to start grpc manually.
-        let sto = MemStore::new(node_id);
+        let sto = MetaStore::new(node_id);
 
         let b = MetaNode::builder()
             .node_id(node_id)
@@ -1129,10 +898,10 @@ impl MetaNode {
         &self,
         node_id: NodeId,
         addr: String,
-    ) -> common_exception::Result<ClientResponse> {
+    ) -> common_exception::Result<AppliedState> {
         // TODO: use txid?
         let _resp = self
-            .write(ClientRequest {
+            .write(LogEntry {
                 txid: None,
                 cmd: Cmd::AddNode {
                     node_id,
@@ -1166,7 +935,7 @@ impl MetaNode {
 
     /// Submit a write request to the known leader. Returns the response after applying the request.
     #[tracing::instrument(level = "info", skip(self))]
-    pub async fn write(&self, req: ClientRequest) -> common_exception::Result<ClientResponse> {
+    pub async fn write(&self, req: LogEntry) -> common_exception::Result<AppliedState> {
         let mut curr_leader = self.get_leader().await;
         loop {
             let rst = if curr_leader == self.sto.id {
@@ -1181,7 +950,7 @@ impl MetaNode {
                     .await
                     .map_err(|e| ErrorCode::CannotConnectNode(e.to_string()))?;
                 let resp = client.write(req.clone()).await?;
-                let rst: Result<ClientResponse, RetryableError> = resp.into_inner().into();
+                let rst: Result<AppliedState, RetryableError> = resp.into_inner().into();
                 rst
             };
 
@@ -1232,8 +1001,8 @@ impl MetaNode {
     #[tracing::instrument(level = "info", skip(self))]
     pub async fn write_to_local_leader(
         &self,
-        req: ClientRequest,
-    ) -> common_exception::Result<Result<ClientResponse, RetryableError>> {
+        req: LogEntry,
+    ) -> common_exception::Result<Result<AppliedState, RetryableError>> {
         let write_rst = self.raft.client_write(ClientWriteRequest::new(req)).await;
 
         tracing::debug!("raft.client_write rst: {:?}", write_rst);

--- a/fusestore/store/src/meta_service/state_machine.rs
+++ b/fusestore/store/src/meta_service/state_machine.rs
@@ -17,9 +17,9 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::meta_service::placement::rand_n_from_m;
-use crate::meta_service::ClientRequest;
-use crate::meta_service::ClientResponse;
+use crate::meta_service::AppliedState;
 use crate::meta_service::Cmd;
+use crate::meta_service::LogEntry;
 use crate::meta_service::NodeId;
 use crate::meta_service::Placement;
 
@@ -52,9 +52,9 @@ pub struct StateMachine {
     pub last_applied_log: u64,
 
     /// raft state: A mapping of client IDs to their state info:
-    /// (serial, ClientResponse)
-    /// This is used to de-dup client request, to impl  idempotent operations.
-    pub client_serial_responses: HashMap<String, (u64, ClientResponse)>,
+    /// (serial, RaftResponse)
+    /// This is used to de-dup client request, to impl idempotent operations.
+    pub client_last_resp: HashMap<String, (u64, AppliedState)>,
 
     /// The file names stored in this cluster
     pub keys: BTreeMap<String, String>,
@@ -81,14 +81,14 @@ pub struct StateMachine {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct MetaBuilder {
+pub struct StateMachineBuilder {
     /// The number of slots to allocated.
     initial_slots: Option<u64>,
     /// The replication strategy.
     replication: Option<Replication>,
 }
 
-impl MetaBuilder {
+impl StateMachineBuilder {
     /// Set the number of slots to boot up a cluster.
     pub fn slots(mut self, n: u64) -> Self {
         self.initial_slots = Some(n);
@@ -107,7 +107,7 @@ impl MetaBuilder {
 
         let mut m = StateMachine {
             last_applied_log: 0,
-            client_serial_responses: Default::default(),
+            client_last_resp: Default::default(),
             keys: BTreeMap::new(),
             sequences: BTreeMap::new(),
             slots: Vec::with_capacity(initial_slots as usize),
@@ -125,8 +125,8 @@ impl MetaBuilder {
 }
 
 impl StateMachine {
-    pub fn builder() -> MetaBuilder {
-        MetaBuilder {
+    pub fn builder() -> StateMachineBuilder {
+        StateMachineBuilder {
             ..Default::default()
         }
     }
@@ -152,10 +152,10 @@ impl StateMachine {
     /// will be made and the previous resp is returned. In this way a client is able to re-send a
     /// command safely in case of network failure etc.
     #[tracing::instrument(level = "trace", skip(self))]
-    pub fn apply(&mut self, index: u64, data: &ClientRequest) -> anyhow::Result<ClientResponse> {
+    pub fn apply(&mut self, index: u64, data: &LogEntry) -> anyhow::Result<AppliedState> {
         self.last_applied_log = index;
         if let Some(ref txid) = data.txid {
-            if let Some((serial, resp)) = self.client_serial_responses.get(&txid.client) {
+            if let Some((serial, resp)) = self.client_last_resp.get(&txid.client) {
                 if serial == &txid.serial {
                     return Ok(resp.clone());
                 }
@@ -165,7 +165,7 @@ impl StateMachine {
         let resp = self.apply_non_dup(data)?;
 
         if let Some(ref txid) = data.txid {
-            self.client_serial_responses
+            self.client_last_resp
                 .insert(txid.client.clone(), (txid.serial, resp.clone()));
         }
         Ok(resp)
@@ -176,10 +176,7 @@ impl StateMachine {
     /// This is the only entry to modify state machine.
     /// The `data` is always committed by raft before applying.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub fn apply_non_dup(
-        &mut self,
-        data: &ClientRequest,
-    ) -> common_exception::Result<ClientResponse> {
+    pub fn apply_non_dup(&mut self, data: &LogEntry) -> common_exception::Result<AppliedState> {
         match data.cmd {
             Cmd::AddFile { ref key, ref value } => {
                 if self.keys.contains_key(key) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor terms
- Rename:
  ```
  ClientRequest -> LogEntry
  ClientResponse -> AppliedState
  ```

move the following types to  standalone files:

- applied_state.rs
- cmd.rs
- log_entry.rs
- raft_txid.rs

Nothing really changed.

## Changelog

- Improvement




## Related Issues

#271