### PR TITLE
ISSUE-945: add tracing to file for store

### DIFF
--- a/fusestore/store/src/bin/fuse-store.rs
+++ b/fusestore/store/src/bin/fuse-store.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 use common_runtime::tokio;
+use common_tracing::init_tracing_with_file;
 use fuse_store::api::StoreServer;
 use fuse_store::configs::Config;
 use fuse_store::metrics::MetricService;
@@ -16,6 +17,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         env_logger::Env::default().default_filter_or(conf.log_level.to_lowercase().as_str()),
     )
     .init();
+
+    let _guards =
+        init_tracing_with_file("fuse-store", conf.log_dir.as_str(), conf.log_level.as_str());
 
     info!("{:?}", conf.clone());
     info!(

--- a/fusestore/store/src/configs/config.rs
+++ b/fusestore/store/src/configs/config.rs
@@ -31,6 +31,9 @@ pub struct Config {
     #[structopt(long, env = "FUSE_STORE_LOG_LEVEL", default_value = "INFO")]
     pub log_level: String,
 
+    #[structopt(long, env = "FUSE_STORE_LOG_DIR", default_value = "./_logs")]
+    pub log_dir: String,
+
     #[structopt(
         long,
         env = "FUSE_STORE_METRIC_API_ADDRESS",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

* Tracing to rotate file by hour
* Default log directory is _log

## Changelog

- Improvement

## Related Issues

Fixes #945 

## Test Plan

Unit Tests

Stateless Tests

