### PR TITLE
ISSUE-822: add allocators and set fuse-query default malloc to snmalloc

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -12,5 +12,8 @@ ignore:
   - "*/ext/*"
   - "*/exception/*"
   - "*/tests/*"
+  - "*/arrow/*"
+  - "*/allocators/*"
+  - "*/building/*"
   - "*/profiling/*"
   - "*/api/http/debug/*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,7 @@ dependencies = [
 name = "common-allocators"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 1.0.0",
  "jemallocator",
  "snmalloc-rs",
  "tcmalloc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,6 +616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "coarsetime"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +644,15 @@ checksum = "a2d47c1b11006b87e492b53b313bb699ce60e16613c4dddaa91f8f7c220ab2fa"
 dependencies = [
  "bytes 1.0.1",
  "memchr",
+]
+
+[[package]]
+name = "common-allocators"
+version = "0.1.0"
+dependencies = [
+ "jemallocator",
+ "snmalloc-rs",
+ "tcmalloc",
 ]
 
 [[package]]
@@ -1510,6 +1528,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "fsio"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1558,7 @@ dependencies = [
  "async-trait",
  "clickhouse-rs",
  "clickhouse-srv",
+ "common-allocators",
  "common-arrow",
  "common-building",
  "common-datablocks",
@@ -2172,6 +2197,27 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "jobserver"
@@ -4167,6 +4213,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
+name = "snmalloc-rs"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5a6194d59b08fc87381e7c8a04ab4ab9967282b00f409bb742e08f3514ed0b"
+dependencies = [
+ "snmalloc-sys",
+]
+
+[[package]]
+name = "snmalloc-sys"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9518813a25ab2704a6df4968f609aa6949705409b6a854dcc87018d12961cbc8"
+dependencies = [
+ "cmake",
+]
+
+[[package]]
 name = "socket2"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4476,6 +4540,21 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tcmalloc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375205113d84a1c5eeed67beaa0ce08e41be1a9d5acc3425ad2381fddd9d819b"
+dependencies = [
+ "tcmalloc-sys",
+]
+
+[[package]]
+name = "tcmalloc-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7ad73e635dd232c2c2106d59269f59a61de421cc6b95252d2d932094ff1f40"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     # Common
+    "common/allocators",
     "common/arrow",
     "common/building",
     "common/datablocks",

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ in Rust, inspired by [ClickHouse](https://github.com/ClickHouse/ClickHouse) and 
 | SELECT sum(number) / count(number) FROM numbers_mt(100000000000) | 3.90 s.<br />(25.62 billion rows/s., 205.13 GB/s.)  | **×2.5 slow, (9.70 s.)** <br /> (10.31 billion rows/s., 82.52 GB/s.) |
 | SELECT sum(number) / count(number), max(number), min(number) FROM numbers_mt(100000000000) | 8.28 s.<br />(12.07 billion rows/s., 96.66 GB/s.)   | **×4.0 slow, (32.87 s.)** <br /> (3.04 billion rows/s., 24.34 GB/s.) |
 | SELECT number FROM numbers_mt(10000000000) ORDER BY number DESC LIMIT 100 | 4.80 s.<br />(2.08 billion rows/s., 16.67 GB/s.)    | **×2.9 slow, (13.95 s.)** <br /> (716.62 million rows/s., 5.73 GB/s.) |
-| SELECT max(number), sum(number) FROM numbers_mt(1000000000) GROUP BY sipHash64(number % 3), sipHash64(number % 4), sipHash64(number % 5) | 37.07 s.<br />(31.18 million rows/s., 249.68 MB/s.) | **×4 fast, (9.17 s.)** <br /> (109.02 million rows/s., 872.20 MB/s.) |
+| SELECT max(number), sum(number) FROM numbers_mt(1000000000) GROUP BY sipHash64(number % 3), sipHash64(number % 4) | 14.84 s.<br />(67.38 million rows/s., 539.51 MB/s.) | **×1.5 fast, (10.24 s.)** <br /> (97.65 million rows/s., 781.23 MB/s.) |
 
 Note:
 

--- a/common/allocators/Cargo.toml
+++ b/common/allocators/Cargo.toml
@@ -22,6 +22,7 @@ snmalloc-alloc = ["snmalloc-rs"]
 # Github dependencies
 
 # Crates.io dependencies
+cfg-if = "1.0.0"
 tcmalloc= { version = "0.3", optional = true }
 jemallocator = { version = "0.3", optional = true }
 snmalloc-rs = { version = "0.2", optional = true }

--- a/common/allocators/Cargo.toml
+++ b/common/allocators/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "common-allocators"
+version = "0.1.0"
+authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[features]
+# Enable jemalloc for binaries
+jemalloc-alloc = ["jemallocator"]
+
+# Enable bundled tcmalloc
+tcmalloc-alloc = ["tcmalloc/bundled"]
+
+# Enable snmalloc for binaries
+snmalloc-alloc = ["snmalloc-rs"]
+
+[dependencies] # In alphabetical order
+# Workspace dependencies
+
+# Github dependencies
+
+# Crates.io dependencies
+tcmalloc= { version = "0.3", optional = true }
+jemallocator = { version = "0.3", optional = true }
+snmalloc-rs = { version = "0.2", optional = true }
+
+[dev-dependencies]

--- a/common/allocators/src/lib.rs
+++ b/common/allocators/src/lib.rs
@@ -1,0 +1,28 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+#[cfg(feature = "jemalloc-alloc")]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[cfg(feature = "tcmalloc-alloc")]
+#[global_allocator]
+static ALLOC: tcmalloc::TCMalloc = tcmalloc::TCMalloc;
+
+#[cfg(feature = "snmalloc-alloc")]
+#[global_allocator]
+static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+
+// To use the global alloc
+// put let _ = common_allocators::init() in your main method.
+pub fn init() -> String {
+    #[cfg(feature = "jemalloc-alloc")]
+    return "jemalloc".to_string();
+
+    #[cfg(feature = "tcmalloc-alloc")]
+    return "tcmalloc".to_string();
+
+    #[cfg(feature = "snmalloc-alloc")]
+    return "snmalloc".to_string();
+}

--- a/common/allocators/src/lib.rs
+++ b/common/allocators/src/lib.rs
@@ -17,12 +17,18 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 // To use the global alloc
 // put let _ = common_allocators::init() in your main method.
 pub fn init() -> String {
-    #[cfg(feature = "jemalloc-alloc")]
-    return "jemalloc".to_string();
-
-    #[cfg(feature = "tcmalloc-alloc")]
-    return "tcmalloc".to_string();
-
-    #[cfg(feature = "snmalloc-alloc")]
-    return "snmalloc".to_string();
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "jemalloc-alloc")] {
+            return "jemalloc".to_string();
+        }
+        else if #[cfg(feature = "tcmalloc-alloc")] {
+            return "tcmalloc".to_string();
+        }
+        else if #[cfg(feature = "snmalloc-alloc")] {
+            return "snmalloc".to_string();
+        }
+        else {
+            "default".to_string()
+        }
+    }
 }

--- a/common/allocators/src/lib.rs
+++ b/common/allocators/src/lib.rs
@@ -2,30 +2,33 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-#[cfg(feature = "jemalloc-alloc")]
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
-#[cfg(feature = "tcmalloc-alloc")]
-#[global_allocator]
-static ALLOC: tcmalloc::TCMalloc = tcmalloc::TCMalloc;
-
-#[cfg(feature = "snmalloc-alloc")]
-#[global_allocator]
-static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+cfg_if::cfg_if! {
+    if #[cfg(feature = "jemalloc-alloc")] {
+        #[global_allocator]
+        static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    }
+    else if #[cfg(feature = "tcmalloc-alloc")] {
+        #[global_allocator]
+        static ALLOC: tcmalloc::TCMalloc = tcmalloc::TCMalloc;
+    }
+    else if #[cfg(feature = "snmalloc-alloc")] {
+        #[global_allocator]
+        static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+    }
+}
 
 // To use the global alloc
 // put let _ = common_allocators::init() in your main method.
 pub fn init() -> String {
     cfg_if::cfg_if! {
         if #[cfg(feature = "jemalloc-alloc")] {
-            return "jemalloc".to_string();
+            "jemalloc".to_string()
         }
         else if #[cfg(feature = "tcmalloc-alloc")] {
-            return "tcmalloc".to_string();
+            "tcmalloc".to_string()
         }
         else if #[cfg(feature = "snmalloc-alloc")] {
-            return "snmalloc".to_string();
+            "snmalloc".to_string()
         }
         else {
             "default".to_string()

--- a/fusequery/query/Cargo.toml
+++ b/fusequery/query/Cargo.toml
@@ -16,12 +16,14 @@ name = "fuse-benchmark"
 path = "src/bin/fuse-benchmark.rs"
 
 [features]
-default = ["simd"]
+default = ["simd", "allocator"]
 simd = ["common-arrow/simd"]
+allocator = ["common-allocators/snmalloc-alloc"]
 
 [dependencies]
 # Workspace dependencies
 common-arrow = {path = "../../common/arrow"}
+common-allocators = {path = "../../common/allocators"}
 common-datablocks = {path = "../../common/datablocks"}
 common-datavalues = {path = "../../common/datavalues"}
 common-exception = {path = "../../common/exception"}

--- a/fusequery/query/src/bin/fuse-benchmark.rs
+++ b/fusequery/query/src/bin/fuse-benchmark.rs
@@ -114,6 +114,9 @@ impl Stats {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Use customize malloc.
+    let _ = common_allocators::init();
+
     // First load configs from args.
     let conf = Config::load_from_args();
     let database_url = format!("tcp://{}:{}?compression=lz4", conf.host, conf.port);

--- a/fusequery/query/src/bin/fuse-query.rs
+++ b/fusequery/query/src/bin/fuse-query.rs
@@ -21,6 +21,9 @@ use log::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Use customize malloc.
+    let malloc = common_allocators::init();
+
     // First load configs from args.
     let mut conf = Config::load_from_args();
 
@@ -44,8 +47,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("{:?}", conf);
     info!(
-        "FuseQuery v-{}",
-        *fuse_query::configs::config::FUSE_COMMIT_VERSION
+        "FuseQuery v-{}, Allocator: {}",
+        *fuse_query::configs::config::FUSE_COMMIT_VERSION,
+        malloc
     );
 
     let mut services: Vec<AbortableServer> = vec![];

--- a/website/datafuse/docs/overview/performance.md
+++ b/website/datafuse/docs/overview/performance.md
@@ -22,7 +22,7 @@ title: Performance
 | SELECT sum(number) / count(number) FROM numbers_mt(100000000000) | 3.90 s.<br />(25.62 billion rows/s., 205.13 GB/s.)  | **×2.5 slow, (9.70 s.)** <br /> (10.31 billion rows/s., 82.52 GB/s.) |
 | SELECT sum(number) / count(number), max(number), min(number) FROM numbers_mt(100000000000) | 8.28 s.<br />(12.07 billion rows/s., 96.66 GB/s.)   | **×4.0 slow, (32.87 s.)** <br /> (3.04 billion rows/s., 24.34 GB/s.) |
 | SELECT number FROM numbers_mt(10000000000) ORDER BY number DESC LIMIT 100 | 4.80 s.<br />(2.08 billion rows/s., 16.67 GB/s.)    | **×2.9 slow, (13.95 s.)** <br /> (716.62 million rows/s., 5.73 GB/s.) |
-| SELECT max(number), sum(number) FROM numbers_mt(1000000000) GROUP BY sipHash64(number % 3), sipHash64(number % 4), sipHash64(number % 5) | 37.07 s.<br />(31.18 million rows/s., 249.68 MB/s.) | **×4 fast, (9.17 s.)** <br /> (109.02 million rows/s., 872.20 MB/s.) |
+| SELECT max(number), sum(number) FROM numbers_mt(1000000000) GROUP BY sipHash64(number % 3), sipHash64(number % 4) | 14.84 s.<br />(67.38 million rows/s., 539.51 MB/s.) | **×1.5 fast, (10.24 s.)** <br /> (97.65 million rows/s., 781.23 MB/s.) |
 
 !!! note "Notes"
     ClickHouse system.numbers_mt is <b>16-way</b> parallelism processing, [gist](https://gist.github.com/BohuTANG/bba7ec2c23da8017eced7118b59fc7d5) 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

add allocators and set fuse-query default malloc to snmalloc
snmalloc has 30%+ performance improve for the group by case.
```
0. Rust default

datafuse :) SELECT max(number), sum(number) FROM numbers_mt(1000000000) GROUP BY sipHash(number % 3), sipHash(number % 4)

SELECT
    max(number),
    sum(number)
FROM numbers_mt(1000000000)
GROUP BY
    sipHash(number % 3),
    sipHash(number % 4)

Query id: 4c1de62c-4120-4843-b15c-8552909278cb

┌─max(number)─┬───────sum(number)─┐
│   999999991 │ 41666666416666667 │
│   999999993 │ 41666666583333333 │
│   999999997 │ 41666666916666666 │
│   999999988 │ 41666666166666668 │
│   999999999 │ 41666667083333334 │
│   999999995 │ 41666666749999999 │
│   999999998 │ 41666667000000000 │
│   999999992 │ 41666666500000000 │
│   999999989 │ 41666666250000001 │
│   999999990 │ 41666666333333334 │
│   999999994 │ 41666666666666666 │
│   999999996 │ 41666666833333332 │
└─────────────┴───────────────────┘

12 rows in set. Elapsed: 21.511 sec. Processed 1.00 billion rows, 8.01 GB (46.49 million rows/s., 372.24 MB/s.)


1. jemalloc(nearly the Rust default alloc)
datafuse :) SELECT max(number),sum(number) FROM numbers_mt(1000000000) GROUP BY siphash(number % 3), siphash(number % 4);

SELECT
    max(number),
    sum(number)
FROM numbers_mt(1000000000)
GROUP BY
    siphash(number % 3),
    siphash(number % 4)

Query id: 77169df3-b01b-45b6-84cb-a497ab34f58e

┌─max(number)─┬───────sum(number)─┐
│   999999997 │ 41666666916666666 │
│   999999990 │ 41666666333333334 │
│   999999995 │ 41666666749999999 │
│   999999998 │ 41666667000000000 │
│   999999993 │ 41666666583333333 │
│   999999996 │ 41666666833333332 │
│   999999999 │ 41666667083333334 │
│   999999988 │ 41666666166666668 │
│   999999989 │ 41666666250000001 │
│   999999991 │ 41666666416666667 │
│   999999992 │ 41666666500000000 │
│   999999994 │ 41666666666666666 │
└─────────────┴───────────────────┘

12 rows in set. Elapsed: 19.114 sec. Processed 1.00 billion rows, 8.01 GB (52.32 million rows/s., 418.91 MB/s.) 


2. snmalloc

datafuse :) SELECT max(number),sum(number) FROM numbers_mt(1000000000) GROUP BY siphash(number % 3), siphash(number % 4);

SELECT
    max(number),
    sum(number)
FROM numbers_mt(1000000000)
GROUP BY
    siphash(number % 3),
    siphash(number % 4)

Query id: 51a78af1-1797-43c9-8495-50d976401842

┌─max(number)─┬───────sum(number)─┐
│   999999990 │ 41666666333333334 │
│   999999993 │ 41666666583333333 │
│   999999989 │ 41666666250000001 │
│   999999988 │ 41666666166666668 │
│   999999996 │ 41666666833333332 │
│   999999991 │ 41666666416666667 │
│   999999999 │ 41666667083333334 │
│   999999992 │ 41666666500000000 │
│   999999997 │ 41666666916666666 │
│   999999995 │ 41666666749999999 │
│   999999998 │ 41666667000000000 │
│   999999994 │ 41666666666666666 │
└─────────────┴───────────────────┘

12 rows in set. Elapsed: 14.814 sec. Processed 1.00 billion rows, 8.01 GB (67.50 million rows/s., 540.52 MB/s.) 

```

## Changelog

- Performance Improvement


## Related Issues

Fixes #822 

## Test Plan

Unit Tests

Stateless Tests

