### PR TITLE
Allocator feature disable by default

### DIFF
--- a/fusequery/query/Cargo.toml
+++ b/fusequery/query/Cargo.toml
@@ -16,7 +16,7 @@ name = "fuse-benchmark"
 path = "src/bin/fuse-benchmark.rs"
 
 [features]
-default = ["simd", "allocator"]
+default = ["simd"]
 simd = ["common-arrow/simd"]
 allocator = ["common-allocators/snmalloc-alloc"]
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Allocator feature disable by default

## Changelog

- Bug Fix

## Related Issues

fixes #982
