### PR TITLE
[store]: refactor: Cmd::UpsertKV use MatchSeq to specify what seq to match

### DIFF
--- a/common/flights/src/store_do_action.rs
+++ b/common/flights/src/store_do_action.rs
@@ -13,7 +13,6 @@ use crate::impls::kv_api_impl::DeleteKVReq;
 use crate::impls::kv_api_impl::GetKVAction;
 use crate::impls::kv_api_impl::MGetKVAction;
 use crate::impls::kv_api_impl::PrefixListReq;
-use crate::impls::kv_api_impl::UpdateKVReq;
 use crate::impls::kv_api_impl::UpsertKVAction;
 use crate::impls::meta_api_impl::CreateDatabaseAction;
 use crate::impls::meta_api_impl::CreateTableAction;
@@ -62,7 +61,6 @@ pub enum StoreDoAction {
     MGetKV(MGetKVAction),
     PrefixListKV(PrefixListReq),
     DeleteKV(DeleteKVReq),
-    UpdateKV(UpdateKVReq),
 }
 
 /// Try convert tonic::Request<Action> to DoActionAction.

--- a/common/management/Cargo.toml
+++ b/common/management/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [dependencies]
 common-exception= {path = "../exception"}
+common-metatypes= {path = "../metatypes"}
 common-store-api= {path = "../store-api"}
 
 async-trait = "0.1"

--- a/common/metatypes/src/lib.rs
+++ b/common/metatypes/src/lib.rs
@@ -13,6 +13,24 @@ use serde::Serialize;
 /// Value with a corresponding sequence number
 pub type SeqValue = (u64, Vec<u8>);
 
+/// Describes what `seq` an operation must match to take effect.
+/// Every value written to meta data has a unique `seq` bound.
+/// Any conditioned or non-conditioned write operation can be done through the corresponding MatchSeq.
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MatchSeq {
+    /// Any value is acceptable, i.e. does not check seq at all.
+    Any,
+
+    /// To match an exact value of seq.
+    /// E.g., CAS updates the exact version of some value,
+    /// and put-if-absent adds a value only when seq is 0.
+    Exact(u64),
+
+    /// To match a seq that is greater-or-equal some value.
+    /// E.g., GE(1) perform an update on any existent value.
+    GE(u64),
+}
+
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Database {
     pub database_id: u64,

--- a/common/store-api/src/kv_api.rs
+++ b/common/store-api/src/kv_api.rs
@@ -4,6 +4,7 @@
 //
 
 use async_trait::async_trait;
+use common_metatypes::MatchSeq;
 use common_metatypes::SeqValue;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
@@ -31,7 +32,7 @@ pub trait KVApi {
     async fn upsert_kv(
         &mut self,
         key: &str,
-        seq: Option<u64>,
+        seq: MatchSeq,
         value: Vec<u8>,
     ) -> common_exception::Result<UpsertKVActionResult>;
 
@@ -39,13 +40,6 @@ pub trait KVApi {
         &mut self,
         key: &str,
         seq: Option<u64>,
-    ) -> common_exception::Result<Option<SeqValue>>;
-
-    async fn update_kv(
-        &mut self,
-        key: &str,
-        seq: Option<u64>,
-        value: Vec<u8>,
     ) -> common_exception::Result<Option<SeqValue>>;
 
     async fn get_kv(&mut self, key: &str) -> common_exception::Result<GetKVActionResult>;

--- a/fusestore/store/src/executor/action_handler.rs
+++ b/fusestore/store/src/executor/action_handler.rs
@@ -132,7 +132,6 @@ impl ActionHandler {
             StoreDoAction::MGetKV(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::PrefixListKV(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::DeleteKV(a) => s.serialize(self.handle(a).await?),
-            StoreDoAction::UpdateKV(a) => s.serialize(self.handle(a).await?),
         }
     }
 

--- a/fusestore/store/src/executor/kv_handlers.rs
+++ b/fusestore/store/src/executor/kv_handlers.rs
@@ -12,12 +12,9 @@ use common_flights::kv_api_impl::MGetKVAction;
 use common_flights::kv_api_impl::MGetKVActionResult;
 use common_flights::kv_api_impl::PrefixListReply;
 use common_flights::kv_api_impl::PrefixListReq;
-use common_flights::kv_api_impl::UpdateByKeyReply;
-use common_flights::kv_api_impl::UpdateKVReq;
 use common_flights::kv_api_impl::UpsertKVAction;
 use common_flights::kv_api_impl::UpsertKVActionResult;
 use Cmd::DeleteByKeyKV;
-use Cmd::UpdateByKeyKV;
 
 use crate::executor::action_handler::RequestHandler;
 use crate::executor::ActionHandler;
@@ -92,31 +89,6 @@ impl RequestHandler<DeleteKVReq> for ActionHandler {
 
         match rst {
             AppliedState::KV { prev, result } => Ok(DeleteKVReply { prev, result }),
-            _ => Err(ErrorCode::MetaNodeInternalError("not a KV result")),
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl RequestHandler<UpdateKVReq> for ActionHandler {
-    async fn handle(&self, act: UpdateKVReq) -> common_exception::Result<UpdateByKeyReply> {
-        let cr = LogEntry {
-            txid: None,
-            cmd: UpdateByKeyKV {
-                key: act.key,
-                seq: act.seq,
-                value: act.value,
-            },
-        };
-
-        let rst = self
-            .meta_node
-            .write(cr)
-            .await
-            .map_err(|e| ErrorCode::MetaNodeInternalError(e.to_string()))?;
-
-        match rst {
-            AppliedState::KV { prev, result } => Ok(UpdateByKeyReply { prev, result }),
             _ => Err(ErrorCode::MetaNodeInternalError("not a KV result")),
         }
     }

--- a/fusestore/store/src/meta_service/cmd.rs
+++ b/fusestore/store/src/meta_service/cmd.rs
@@ -1,16 +1,15 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
 use std::fmt;
 
 use async_raft::NodeId;
+use common_metatypes::MatchSeq;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::meta_service::Node;
-
-// Copyright 2020-2021 The Datafuse Authors.
-//
-// SPDX-License-Identifier: Apache-2.0.
-/// Cmd is an action a client wants to take.
-/// A Cmd is committed by raft leader before being applied.
 
 /// A Cmd describes what a user want to do to raft state machine
 /// and is the essential part of a raft log.
@@ -47,20 +46,16 @@ pub enum Cmd {
     /// Update or insert a general purpose kv store
     UpsertKV {
         key: String,
-        /// Set to Some() to modify the value only when the seq matches.
-        /// Since a sequence number is positive, use Some(0) to perform an add-if-absent operation.
-        seq: Option<u64>,
+        /// Since a sequence number is always positive, using Exact(0) to perform an add-if-absent operation.
+        /// GE(1) to perform an update-any operation.
+        /// Exact(n) to perform an update on some specified version.
+        /// Any to perform an update or insert that always takes effect.
+        seq: MatchSeq,
         value: Vec<u8>,
     },
     DeleteByKeyKV {
         key: String,
         seq: Option<u64>,
-    },
-
-    UpdateByKeyKV {
-        key: String,
-        seq: Option<u64>,
-        value: Vec<u8>,
     },
 }
 
@@ -87,9 +82,6 @@ impl fmt::Display for Cmd {
             }
             Cmd::DeleteByKeyKV { key, seq } => {
                 write!(f, "delete_by_key_kv: {}({:?})", key, seq)
-            }
-            Cmd::UpdateByKeyKV { key, seq, value } => {
-                write!(f, "update_kv: {}({:?}) = {:?}", key, seq, value)
             }
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store]: refactor: Cmd::UpsertKV use MatchSeq to specify what seq to match
The fully functional UpsertKV now supports all write operations.

Since a sequence number is always positive:
- `MatchSeq::Exact(0)` to perform an add-if-absent operation.
- `MatchSeq::Exact(n)` to perform an update on some specified version.
- `MatchSeq::GE(1)` to perform an update-any operation.
- `MatchSeq::Any` to perform an update or insert that always takes effect.


59 LOC reduced! 

## Changelog




- Improvement


## Related Issues

#271