### PR TITLE
[common/metatypes] feature: complete MatchSeq: add display, matching impl, errors etc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,8 +789,10 @@ dependencies = [
 name = "common-metatypes"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "pretty_assertions",
  "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/common/metatypes/Cargo.toml
+++ b/common/metatypes/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0.25"
 
 [dev-dependencies]
+anyhow = "1.0.41"
 pretty_assertions = "0.7"

--- a/common/metatypes/src/errors.rs
+++ b/common/metatypes/src/errors.rs
@@ -1,0 +1,15 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::MatchSeq;
+
+#[derive(Error, Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum SeqError {
+    #[error("seq not match, expect: {got} {want}")]
+    NotMatch { want: MatchSeq, got: u64 },
+}

--- a/common/metatypes/src/lib.rs
+++ b/common/metatypes/src/lib.rs
@@ -4,32 +4,22 @@
 
 //! This crate defines data types used in meta data storage service.
 
+mod errors;
+mod match_seq;
+
+#[cfg(test)]
+mod match_seq_test;
+
 use std::collections::HashMap;
 use std::collections::HashSet;
 
+pub use errors::SeqError;
+pub use match_seq::MatchSeq;
 use serde::Deserialize;
 use serde::Serialize;
 
 /// Value with a corresponding sequence number
-pub type SeqValue = (u64, Vec<u8>);
-
-/// Describes what `seq` an operation must match to take effect.
-/// Every value written to meta data has a unique `seq` bound.
-/// Any conditioned or non-conditioned write operation can be done through the corresponding MatchSeq.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
-pub enum MatchSeq {
-    /// Any value is acceptable, i.e. does not check seq at all.
-    Any,
-
-    /// To match an exact value of seq.
-    /// E.g., CAS updates the exact version of some value,
-    /// and put-if-absent adds a value only when seq is 0.
-    Exact(u64),
-
-    /// To match a seq that is greater-or-equal some value.
-    /// E.g., GE(1) perform an update on any existent value.
-    GE(u64),
-}
+pub type SeqValue<T = Vec<u8>> = (u64, T);
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Database {

--- a/common/metatypes/src/match_seq.rs
+++ b/common/metatypes/src/match_seq.rs
@@ -1,0 +1,91 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::SeqError;
+use crate::SeqValue;
+
+/// Describes what `seq` an operation must match to take effect.
+/// Every value written to meta data has a unique `seq` bound.
+/// Any conditioned or non-conditioned write operation can be done through the corresponding MatchSeq.
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MatchSeq {
+    /// Any value is acceptable, i.e. does not check seq at all.
+    Any,
+
+    /// To match an exact value of seq.
+    /// E.g., CAS updates the exact version of some value,
+    /// and put-if-absent adds a value only when seq is 0.
+    Exact(u64),
+
+    /// To match a seq that is greater-or-equal some value.
+    /// E.g., GE(1) perform an update on any existent value.
+    GE(u64),
+}
+
+impl From<Option<u64>> for MatchSeq {
+    fn from(s: Option<u64>) -> Self {
+        match s {
+            None => MatchSeq::Any,
+            Some(s) => MatchSeq::Exact(s),
+        }
+    }
+}
+
+impl Display for MatchSeq {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MatchSeq::Any => {
+                write!(f, "is any value")
+            }
+            MatchSeq::Exact(s) => {
+                write!(f, "== {}", s)
+            }
+            MatchSeq::GE(s) => {
+                write!(f, ">= {}", s)
+            }
+        }
+    }
+}
+
+impl MatchSeq {
+    /// Match against a SeqValue by checking if the seq in SeqValue satisfies the condition.
+    /// On success it returns the value extracted from SeqValue.
+    /// Otherwise it returns an Err() with the unmatched seq in it.
+    pub fn match_seq_value<T>(&self, sv: SeqValue<T>) -> Result<T, SeqError> {
+        self.match_seq(sv.0)?;
+        Ok(sv.1)
+    }
+
+    pub fn match_seq(&self, seq: u64) -> Result<(), SeqError> {
+        match self {
+            MatchSeq::Any => Ok(()),
+            MatchSeq::Exact(s) => {
+                if seq == *s {
+                    Ok(())
+                } else {
+                    Err(SeqError::NotMatch {
+                        want: *self,
+                        got: seq,
+                    })
+                }
+            }
+            MatchSeq::GE(s) => {
+                if seq >= *s {
+                    Ok(())
+                } else {
+                    Err(SeqError::NotMatch {
+                        want: *self,
+                        got: seq,
+                    })
+                }
+            }
+        }
+    }
+}

--- a/common/metatypes/src/match_seq_test.rs
+++ b/common/metatypes/src/match_seq_test.rs
@@ -1,0 +1,107 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use crate::MatchSeq;
+use crate::SeqError;
+
+#[test]
+fn test_seq_error_display() -> anyhow::Result<()> {
+    assert_eq!(
+        "seq not match, expect: 1 is any value",
+        SeqError::NotMatch {
+            want: MatchSeq::Any,
+            got: 1
+        }
+        .to_string()
+    );
+
+    assert_eq!(
+        "seq not match, expect: 1 == 5",
+        SeqError::NotMatch {
+            want: MatchSeq::Exact(5),
+            got: 1
+        }
+        .to_string()
+    );
+
+    assert_eq!(
+        "seq not match, expect: 1 >= 5",
+        SeqError::NotMatch {
+            want: MatchSeq::GE(5),
+            got: 1
+        }
+        .to_string()
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_match_seq_match_seq_value() -> anyhow::Result<()> {
+    assert_eq!(MatchSeq::Any.match_seq_value((0, 1)), Ok(1));
+    assert_eq!(MatchSeq::Any.match_seq_value((1, 1)), Ok(1));
+
+    //
+
+    assert_eq!(
+        MatchSeq::Exact(3).match_seq_value((0, 1)),
+        Err(SeqError::NotMatch {
+            want: MatchSeq::Exact(3),
+            got: 0
+        })
+    );
+    assert_eq!(
+        MatchSeq::Exact(3).match_seq_value((2, 1)),
+        Err(SeqError::NotMatch {
+            want: MatchSeq::Exact(3),
+            got: 2
+        })
+    );
+    assert_eq!(MatchSeq::Exact(3).match_seq_value((3, 1)), Ok(1));
+    assert_eq!(
+        MatchSeq::Exact(3).match_seq_value((4, 1)),
+        Err(SeqError::NotMatch {
+            want: MatchSeq::Exact(3),
+            got: 4
+        })
+    );
+
+    //
+
+    assert_eq!(
+        MatchSeq::GE(3).match_seq_value((0, 1)),
+        Err(SeqError::NotMatch {
+            want: MatchSeq::GE(3),
+            got: 0
+        })
+    );
+    assert_eq!(
+        MatchSeq::GE(3).match_seq_value((2, 1)),
+        Err(SeqError::NotMatch {
+            want: MatchSeq::GE(3),
+            got: 2
+        })
+    );
+    assert_eq!(MatchSeq::GE(3).match_seq_value((3, 1)), Ok(1));
+    assert_eq!(MatchSeq::GE(3).match_seq_value((4, 1)), Ok(1));
+
+    Ok(())
+}
+
+#[test]
+fn test_match_seq_from_opt_u64() -> anyhow::Result<()> {
+    assert_eq!(MatchSeq::Exact(3), Some(3).into());
+    assert_eq!(MatchSeq::Any, None.into());
+
+    Ok(())
+}
+
+#[test]
+fn test_match_seq_display() -> anyhow::Result<()> {
+    assert_eq!("is any value", format!("{}", MatchSeq::Any));
+    assert_eq!("== 3", format!("{}", MatchSeq::Exact(3)));
+    assert_eq!(">= 3", format!("{}", MatchSeq::GE(3)));
+
+    Ok(())
+}


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [common/metatypes] feature: complete MatchSeq: add display, matching impl, errors etc

## Changelog

- New Feature





## Related Issues

#271