### PR TITLE
[docs] add default host & port for clickhouse cli

### DIFF
--- a/website/datafuse/docs/overview/building-and-running.md
+++ b/website/datafuse/docs/overview/building-and-running.md
@@ -55,7 +55,7 @@ This document describes how to build and run [FuseQuery](https://github.com/data
         numbers(N) – A table for test with the single `number` column (UInt64) that contains integers from 0 to N-1.
 
     ```
-    $ clickhouse client
+    $ clickhouse client --host 0.0.0.0 --port 9001
     ```
 
     ```


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Add default host and port for `clickhouse client`.

In our configs (like fusequery-docker.toml or fusequery-node-1.toml):

```
# ClickHouse Handler.
clickhouse_handler_host = "0.0.0.0"
clickhouse_handler_port = 9001
```

## Changelog

- Documentation
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

## Test Plan

No

