### PR TITLE
[store] refactor: simplify user-apis with map_err_to_code() and MatchSeq

### DIFF
--- a/common/management/src/user/user_api.rs
+++ b/common/management/src/user/user_api.rs
@@ -5,6 +5,7 @@
 
 use async_trait::async_trait;
 use common_exception::Result;
+use common_metatypes::SeqValue;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct UserInfo {
@@ -30,13 +31,13 @@ pub trait UserMgrApi {
         &mut self,
         username: V,
         seq: Option<u64>,
-    ) -> common_exception::Result<(u64, UserInfo)>
+    ) -> common_exception::Result<SeqValue<UserInfo>>
     where
         V: AsRef<str> + Send;
 
-    async fn get_all_users(&mut self) -> Result<Vec<(u64, UserInfo)>>;
+    async fn get_all_users(&mut self) -> Result<Vec<SeqValue<UserInfo>>>;
 
-    async fn get_users<V>(&mut self, usernames: &[V]) -> Result<Vec<Option<(u64, UserInfo)>>>
+    async fn get_users<V>(&mut self, usernames: &[V]) -> Result<Vec<Option<SeqValue<UserInfo>>>>
     where V: AsRef<str> + Sync;
 
     async fn update_user<V>(

--- a/common/management/src/user/user_mgr.rs
+++ b/common/management/src/user/user_mgr.rs
@@ -165,7 +165,10 @@ impl<T: KVApi + Send> UserMgrApi for UserMgr<T> {
         let value = serde_json::to_vec(&user_info)?;
         let key = utils::prepend(&user_info.name);
 
-        let match_seq = seq.into();
+        let match_seq = match seq {
+            None => MatchSeq::GE(1),
+            Some(s) => MatchSeq::Exact(s),
+        };
         let res = self.kv_api.upsert_kv(&key, match_seq, value).await?;
         match res.result {
             Some((s, _)) => Ok(Some(s)),


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: simplify user-apis with map_err_to_code() and MatchSeq

## Changelog




- Improvement


## Related Issues

#271