### PR TITLE
[common/metatypes] feature: make match_seq() a generic method

### DIFF
--- a/common/management/src/user/user_mgr.rs
+++ b/common/management/src/user/user_mgr.rs
@@ -8,6 +8,7 @@ use common_exception::ErrorCode;
 use common_exception::Result;
 use common_exception::ToErrorCode;
 use common_metatypes::MatchSeq;
+use common_metatypes::MatchSeqExt;
 use common_metatypes::SeqValue;
 use common_store_api::KVApi;
 use sha2::Digest;
@@ -80,10 +81,8 @@ impl<T: KVApi + Send> UserMgrApi for UserMgr<T> {
             .result
             .ok_or_else(|| ErrorCode::UnknownUser(format!("unknown user {}", username.as_ref())))?;
 
-        let curr_seq = seq_value.0;
-
         let ms: MatchSeq = seq.into();
-        ms.match_seq(curr_seq)
+        ms.match_seq(&seq_value)
             .map_err_to_code(ErrorCode::UnknownUser, || {
                 format!("username: {}", username.as_ref(),)
             })?;
@@ -91,7 +90,7 @@ impl<T: KVApi + Send> UserMgrApi for UserMgr<T> {
         let user_info = serde_json::from_slice(&seq_value.1)
             .map_err_to_code(ErrorCode::IllegalUserInfoFormat, || "")?;
 
-        Ok((curr_seq, user_info))
+        Ok((seq_value.0, user_info))
     }
 
     async fn get_all_users(&mut self) -> Result<Vec<SeqValue<UserInfo>>> {

--- a/common/metatypes/src/lib.rs
+++ b/common/metatypes/src/lib.rs
@@ -15,6 +15,7 @@ use std::collections::HashSet;
 
 pub use errors::SeqError;
 pub use match_seq::MatchSeq;
+pub use match_seq::MatchSeqExt;
 use serde::Deserialize;
 use serde::Serialize;
 

--- a/common/metatypes/src/match_seq_test.rs
+++ b/common/metatypes/src/match_seq_test.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 use crate::MatchSeq;
+use crate::MatchSeqExt;
 use crate::SeqError;
+use crate::SeqValue;
 
 #[test]
 fn test_seq_error_display() -> anyhow::Result<()> {
@@ -39,28 +41,35 @@ fn test_seq_error_display() -> anyhow::Result<()> {
 
 #[test]
 fn test_match_seq_match_seq_value() -> anyhow::Result<()> {
-    assert_eq!(MatchSeq::Any.match_seq_value((0, 1)), Ok(1));
-    assert_eq!(MatchSeq::Any.match_seq_value((1, 1)), Ok(1));
+    assert_eq!(MatchSeq::Any.match_seq(&Some((0, 1))), Ok(()));
+    assert_eq!(MatchSeq::Any.match_seq(&Some((1, 1))), Ok(()));
 
     //
 
     assert_eq!(
-        MatchSeq::Exact(3).match_seq_value((0, 1)),
+        MatchSeq::Exact(3).match_seq(&None::<SeqValue>),
         Err(SeqError::NotMatch {
             want: MatchSeq::Exact(3),
             got: 0
         })
     );
     assert_eq!(
-        MatchSeq::Exact(3).match_seq_value((2, 1)),
+        MatchSeq::Exact(3).match_seq(&Some((0, 1))),
+        Err(SeqError::NotMatch {
+            want: MatchSeq::Exact(3),
+            got: 0
+        })
+    );
+    assert_eq!(
+        MatchSeq::Exact(3).match_seq(&Some((2, 1))),
         Err(SeqError::NotMatch {
             want: MatchSeq::Exact(3),
             got: 2
         })
     );
-    assert_eq!(MatchSeq::Exact(3).match_seq_value((3, 1)), Ok(1));
+    assert_eq!(MatchSeq::Exact(3).match_seq(&Some((3, 1))), Ok(()));
     assert_eq!(
-        MatchSeq::Exact(3).match_seq_value((4, 1)),
+        MatchSeq::Exact(3).match_seq(&Some((4, 1))),
         Err(SeqError::NotMatch {
             want: MatchSeq::Exact(3),
             got: 4
@@ -70,21 +79,28 @@ fn test_match_seq_match_seq_value() -> anyhow::Result<()> {
     //
 
     assert_eq!(
-        MatchSeq::GE(3).match_seq_value((0, 1)),
+        MatchSeq::GE(3).match_seq(&None::<SeqValue>),
         Err(SeqError::NotMatch {
             want: MatchSeq::GE(3),
             got: 0
         })
     );
     assert_eq!(
-        MatchSeq::GE(3).match_seq_value((2, 1)),
+        MatchSeq::GE(3).match_seq(&Some((0, 1))),
+        Err(SeqError::NotMatch {
+            want: MatchSeq::GE(3),
+            got: 0
+        })
+    );
+    assert_eq!(
+        MatchSeq::GE(3).match_seq(&Some((2, 1))),
         Err(SeqError::NotMatch {
             want: MatchSeq::GE(3),
             got: 2
         })
     );
-    assert_eq!(MatchSeq::GE(3).match_seq_value((3, 1)), Ok(1));
-    assert_eq!(MatchSeq::GE(3).match_seq_value((4, 1)), Ok(1));
+    assert_eq!(MatchSeq::GE(3).match_seq(&Some((3, 1))), Ok(()));
+    assert_eq!(MatchSeq::GE(3).match_seq(&Some((4, 1))), Ok(()));
 
     Ok(())
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [common/metatypes] feature: make match_seq() a generic method

## Changelog

- New Feature





## Related Issues

#271