### PR TITLE
[ci] add basic build cache

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -24,7 +24,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ env.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -15,6 +15,17 @@ jobs:
         run: |
           bash ./scripts/setup/dev_setup.sh
 
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ env.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run clippy
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -24,7 +24,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-clippycache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/datafuse-build.yml
+++ b/.github/workflows/datafuse-build.yml
@@ -26,7 +26,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ env.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/datafuse-build.yml
+++ b/.github/workflows/datafuse-build.yml
@@ -26,7 +26,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-buildcache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/datafuse-build.yml
+++ b/.github/workflows/datafuse-build.yml
@@ -17,5 +17,16 @@ jobs:
         run: |
           bash ./scripts/setup/dev_setup.sh
 
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ env.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/stateless-tests-cluster.yml
+++ b/.github/workflows/stateless-tests-cluster.yml
@@ -24,7 +24,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-buildcache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/stateless-tests-cluster.yml
+++ b/.github/workflows/stateless-tests-cluster.yml
@@ -15,6 +15,17 @@ jobs:
         run: |
           bash ./scripts/setup/dev_setup.sh
 
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ env.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Build
         run: cargo build --verbose
 

--- a/.github/workflows/stateless-tests-cluster.yml
+++ b/.github/workflows/stateless-tests-cluster.yml
@@ -24,7 +24,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ env.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/stateless-tests-standalone.yml
+++ b/.github/workflows/stateless-tests-standalone.yml
@@ -24,7 +24,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-buildcache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/stateless-tests-standalone.yml
+++ b/.github/workflows/stateless-tests-standalone.yml
@@ -15,6 +15,17 @@ jobs:
         run: |
           bash ./scripts/setup/dev_setup.sh
 
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ env.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Build
         run: cargo build --verbose
 

--- a/.github/workflows/stateless-tests-standalone.yml
+++ b/.github/workflows/stateless-tests-standalone.yml
@@ -24,7 +24,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ env.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-testcache-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ env.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,6 +16,17 @@ jobs:
         run: |
           bash ./scripts/setup/dev_setup.sh
 
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ env.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Run test
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

add basic build cache

need to add secrets.CACHE_RESET_KEY to control the cache version.

for example, clippy time is reduced from `5m 48s` to `25.74s`. 

## Changelog

- Build/Testing/CI

## Related Issues

Fixes #913 

## Test Plan

No
