### PR TITLE
[store] test: add test for meta-op DeleteKV

### DIFF
--- a/fusestore/store/src/executor/kv_handlers.rs
+++ b/fusestore/store/src/executor/kv_handlers.rs
@@ -14,7 +14,7 @@ use common_flights::kv_api_impl::PrefixListReply;
 use common_flights::kv_api_impl::PrefixListReq;
 use common_flights::kv_api_impl::UpsertKVAction;
 use common_flights::kv_api_impl::UpsertKVActionResult;
-use Cmd::DeleteByKeyKV;
+use Cmd::DeleteKVByKey;
 
 use crate::executor::action_handler::RequestHandler;
 use crate::executor::ActionHandler;
@@ -75,9 +75,9 @@ impl RequestHandler<DeleteKVReq> for ActionHandler {
     async fn handle(&self, act: DeleteKVReq) -> common_exception::Result<DeleteKVReply> {
         let cr = LogEntry {
             txid: None,
-            cmd: DeleteByKeyKV {
+            cmd: DeleteKVByKey {
                 key: act.key,
-                seq: act.seq,
+                seq: act.seq.into(),
             },
         };
 

--- a/fusestore/store/src/meta_service/cmd.rs
+++ b/fusestore/store/src/meta_service/cmd.rs
@@ -53,9 +53,9 @@ pub enum Cmd {
         seq: MatchSeq,
         value: Vec<u8>,
     },
-    DeleteByKeyKV {
+    DeleteKVByKey {
         key: String,
-        seq: Option<u64>,
+        seq: MatchSeq,
     },
 }
 
@@ -80,7 +80,7 @@ impl fmt::Display for Cmd {
             Cmd::UpsertKV { key, seq, value } => {
                 write!(f, "upsert_kv: {}({:?}) = {:?}", key, seq, value)
             }
-            Cmd::DeleteByKeyKV { key, seq } => {
+            Cmd::DeleteKVByKey { key, seq } => {
                 write!(f, "delete_by_key_kv: {}({:?})", key, seq)
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] test: add test for meta-op DeleteKV
Fix:

- Fix: When seq mismatch, DeleteKVByKey should return (prev, prev), not
  (prev, None) to indicate that nothing changed.

Test:

- Add `test_state_machine_apply_non_dup_generic_kv_delete`: to test
  delete-kv on meta data.

- Upsert test: `test_state_machine_apply_non_dup_generic_kv`:
  add a case of `MatchSeq::GE`

Refactor:

- Cmd::DeleteKVByKey replace `Option<u64>` with MatchSeq to specify the expected seq.

- Rename DeleteByKeyKV to DeleteKVByKey

## Changelog




- Improvement
- Build/Testing/CI

## Related Issues

#271