### PR TITLE
[ci] restroe friendly

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -24,7 +24,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-clippycache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-clippycache-${{ secrets.CACHE_RESET_KEY }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippycache-${{ secrets.CACHE_RESET_KEY }}-
+            ${{ runner.os }}-cargo-clippycache-
+            ${{ runner.os }}-cargo-
 
       - name: Run clippy
         uses: actions-rs/cargo@v1

--- a/.github/workflows/datafuse-build.yml
+++ b/.github/workflows/datafuse-build.yml
@@ -26,7 +26,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-buildcache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-buildcache-${{ secrets.CACHE_RESET_KEY }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-buildcache-${{ secrets.CACHE_RESET_KEY }}-
+            ${{ runner.os }}-cargo-buildcache-
+            ${{ runner.os }}-cargo-
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/stateless-tests-cluster.yml
+++ b/.github/workflows/stateless-tests-cluster.yml
@@ -24,7 +24,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-buildcache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-buildcache-${{ secrets.CACHE_RESET_KEY }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-buildcache-${{ secrets.CACHE_RESET_KEY }}-
+            ${{ runner.os }}-cargo-buildcache-
+            ${{ runner.os }}-cargo-
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/stateless-tests-standalone.yml
+++ b/.github/workflows/stateless-tests-standalone.yml
@@ -24,7 +24,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-buildcache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-buildcache-${{ secrets.CACHE_RESET_KEY }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-buildcache-${{ secrets.CACHE_RESET_KEY }}-
+            ${{ runner.os }}-cargo-buildcache-
+            ${{ runner.os }}-cargo-
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ secrets.CACHE_RESET_KEY }}-${{ runner.os }}-cargo-testcache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-testcache-${{ secrets.CACHE_RESET_KEY }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-testcache-${{ secrets.CACHE_RESET_KEY }}-
+            ${{ runner.os }}-cargo-testcache-
+            ${{ runner.os }}-cargo-
 
       - name: Run test
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Re-org key, and add restore-key. Try to improve cache hit rate.

old: `***-Linux-cargo-clippycache-ae1203a62a2ad511e54e1c3cad857e1726ab79cea7be7ade4916d96640e11a9f`

new: `Linux-cargo-clippycache-***-ae1203a62a2ad511e54e1c3cad857e1726ab79cea7be7ade4916d96640e11a9f, Linux-cargo-clippycache-***-, Linux-cargo-clippycache-, Linux-cargo-`

## Changelog

- Build/Testing/CI
- Not for changelog (changelog entry is not required)

## Related Issues

Fixes #issue

## Test Plan

No.

