### PR TITLE
Revert "Bump hyper from 0.14.9 to 0.14.10"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2054,9 +2054,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.10"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
+checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",

--- a/common/flights/Cargo.toml
+++ b/common/flights/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio-stream = "0.1"
 tonic = "0.4.3"
-hyper = "0.14.10"
+hyper = "0.14.9"
 lazy_static = "1.4.0"
 trust-dns-resolver = { version = "0.20.3", features = ["system-config"] }
 async-trait = "0.1"


### PR DESCRIPTION
Reverts datafuselabs/datafuse#1021
Due to the audit vulnerable found: https://github.com/datafuselabs/datafuse/runs/3024287865?check_suite_focus=true