### PR TITLE
improve modulo functions and number streams

### DIFF
--- a/common/datavalues/src/series/date_wrap.rs
+++ b/common/datavalues/src/series/date_wrap.rs
@@ -163,8 +163,8 @@ macro_rules! impl_dyn_arrays {
             fn divide(&self, rhs: &Series) -> Result<Series> {
                 try_physical_dispatch!(self, divide, rhs)
             }
-            fn remainder(&self, rhs: &Series) -> Result<Series> {
-                try_physical_dispatch!(self, remainder, rhs)
+            fn remainder(&self, rhs: &Series, dtype: &DataType) -> Result<Series> {
+                try_physical_dispatch!(self, remainder, rhs, dtype)
             }
             fn negative(&self) -> Result<Series> {
                 try_physical_dispatch!(self, negative,)

--- a/common/datavalues/src/series/series_impl.rs
+++ b/common/datavalues/src/series/series_impl.rs
@@ -65,7 +65,7 @@ pub trait SeriesTrait: Send + Sync + fmt::Debug {
     fn add_to(&self, rhs: &Series) -> Result<Series>;
     fn multiply(&self, rhs: &Series) -> Result<Series>;
     fn divide(&self, rhs: &Series) -> Result<Series>;
-    fn remainder(&self, rhs: &Series) -> Result<Series>;
+    fn remainder(&self, rhs: &Series, dtype: &DataType) -> Result<Series>;
     fn negative(&self) -> Result<Series>;
 
     fn sum(&self) -> Result<DataValue>;

--- a/common/datavalues/src/series/wrap.rs
+++ b/common/datavalues/src/series/wrap.rs
@@ -119,8 +119,9 @@ macro_rules! impl_dyn_array {
             fn divide(&self, rhs: &Series) -> Result<Series> {
                 NumOpsDispatch::divide(&self.0, rhs)
             }
-            fn remainder(&self, rhs: &Series) -> Result<Series> {
-                NumOpsDispatch::remainder(&self.0, rhs)
+
+            fn remainder(&self, rhs: &Series, dtype: &DataType) -> Result<Series> {
+                NumOpsDispatch::remainder(&self.0, rhs, dtype)
             }
 
             fn negative(&self) -> Result<Series> {

--- a/fusequery/query/src/datasources/system/numbers_stream.rs
+++ b/fusequery/query/src/datasources/system/numbers_stream.rs
@@ -2,20 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use std::mem::ManuallyDrop;
-use std::mem::{self};
-use std::ptr::NonNull;
 use std::task::Context;
 use std::task::Poll;
 use std::usize;
 
-use common_arrow::arrow::array::ArrayData;
-use common_arrow::arrow::array::ArrayRef;
-use common_arrow::arrow::array::UInt64Array;
-use common_arrow::arrow::buffer::Buffer;
-use common_arrow::arrow::datatypes::DataType as ArrowDataType;
 use common_datablocks::DataBlock;
 use common_datavalues::prelude::*;
+use common_datavalues::AlignedVec;
+use common_datavalues::DFUInt64Array;
 use common_exception::Result;
 use common_streams::ProgressStream;
 use futures::stream::Stream;
@@ -93,36 +87,15 @@ impl NumbersStream {
         Ok(if current.begin == current.end {
             None
         } else {
-            let v = (current.begin..current.end).collect::<Vec<u64>>();
-            let mut me = ManuallyDrop::new(v);
-            let byte_size = mem::size_of::<u64>();
+            let mut av =
+                AlignedVec::with_capacity_len_aligned((current.end - current.begin) as usize);
 
-            unsafe {
-                let buffer = Buffer::from_raw_parts(
-                    NonNull::new(me.as_mut_ptr() as *mut u8).unwrap(),
-                    me.len() * byte_size,
-                    me.capacity() * byte_size,
-                );
-
-                let arr_data = ArrayData::builder(ArrowDataType::UInt64)
-                    .len(me.len())
-                    .offset(0)
-                    .add_buffer(buffer)
-                    .build();
-
-                let array = Arc::new(UInt64Array::from(arr_data)) as ArrayRef;
-                let block =
-                    DataBlock::create_by_array(self.schema.clone(), vec![array.into_series()]);
-                Some(block)
-            }
-
-            // let mut av = AlignedVec::with_capacity_aligned((current.end - current.begin) as usize);
-            // for val in current.begin..current.end {
-            //     av.push(val);
-            // }
-            // let series = DFUInt64Array::new_from_aligned_vec(av).into_series();
-            // let block = DataBlock::create_by_array(self.schema.clone(), vec![series]);
-            // Some(block)
+            av.iter_mut().enumerate().for_each(|(idx, num)| {
+                *num = current.begin + idx as u64;
+            });
+            let series = DFUInt64Array::new_from_aligned_vec(av).into_series();
+            let block = DataBlock::create_by_array(self.schema.clone(), vec![series]);
+            Some(block)
         })
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

- [x] use AlignVector to generate arrow buffers
- [x] improve UIntXX % Constant UInt8 cases
- [x] simplify some codes. 

The performance gains about 50%.

without snallocate
```
SELECT max(number),sum(number) FROM numbers_mt(1000000000) GROUP BY number % 3, number % 4, number % 5

60 rows in set. Elapsed: 5.058 sec. Processed 1.00 billion rows, 8.01 GB (197.71 million rows/s., 1.58 GB/s.)
```


with snallocate
```
SELECT max(number),sum(number) FROM numbers_mt(1000000000) GROUP BY number % 3, number % 4, number % 5

60 rows in set. Elapsed: 3.860 sec. Processed 1.00 billion rows, 8.01 GB (259.06 million rows/s., 2.07 GB/s.)
```


## Changelog

- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

