### PR TITLE
[store]: upgrade to async-raft 0.6.2-alpha.4, fix bugs and improve:

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.1#24d9e9280725b2da39b27dde3d7b393477b496e2"
+source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.4#c6418cbfedb20252f691ae44fd5c1b7fed513d27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -169,7 +169,7 @@ dependencies = [
  "derive_more",
  "futures",
  "log 0.4.14",
- "rand 0.7.3",
+ "rand 0.8.4",
  "serde",
  "thiserror",
  "tokio",

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -34,7 +34,7 @@ common-tracing = {path = "../../common/tracing"}
 
 # Crates.io dependencies
 anyhow = "1.0.41"
-async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.1" }
+async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.4" }
 async-trait = "0.1"
 env_logger = "0.8"
 futures = "0.3"

--- a/fusestore/store/src/configs/config.rs
+++ b/fusestore/store/src/configs/config.rs
@@ -66,6 +66,14 @@ pub struct Config {
 
     #[structopt(
         long,
+        env = "FUSE_STORE_META_DIR",
+        default_value = "./_meta",
+        help = "The dir to store persisted meta state, including raft logs, state machine etc."
+    )]
+    pub meta_dir: String,
+
+    #[structopt(
+        long,
         env = "FUSE_STORE_BOOT",
         help = "Whether to boot up a new cluster. If already booted, it is ignored"
     )]

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -23,11 +23,13 @@ use async_raft::storage::CurrentSnapshotData;
 use async_raft::storage::HardState;
 use async_raft::storage::InitialState;
 use async_raft::ClientWriteError;
+use async_raft::LogId;
 use async_raft::NodeId;
 use async_raft::Raft;
 use async_raft::RaftMetrics;
 use async_raft::RaftNetwork;
 use async_raft::RaftStorage;
+use async_raft::SnapshotId;
 use common_exception::prelude::ErrorCode;
 use common_exception::prelude::ToErrorCode;
 use common_metatypes::Database;
@@ -100,12 +102,14 @@ impl From<RetryableError> for RaftMes {
 /// The application snapshot type which the `MetaStore` works with.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct MetaStoreSnapshot {
-    /// The last index covered by this snapshot.
-    pub index: u64,
-    /// The term of the last index covered by this snapshot.
-    pub term: u64,
+    /// The last log covered by this snapshot.
+    pub last_log_id: LogId,
+
     /// The last memberhsip config included in this snapshot.
     pub membership: MembershipConfig,
+
+    pub snapshot_id: SnapshotId,
+
     /// The data of the state machine at the time of this snapshot.
     pub data: Vec<u8>,
 }
@@ -120,6 +124,9 @@ pub struct MetaStore {
     sm: RwLock<StateMachine>,
     /// The current hard state.
     hs: RwLock<Option<HardState>>,
+
+    snapshot_idx: Arc<Mutex<u64>>,
+
     /// The current snapshot.
     current_snapshot: RwLock<Option<MetaStoreSnapshot>>,
 }
@@ -137,6 +144,7 @@ impl MetaStore {
             log,
             sm,
             hs,
+            snapshot_idx: Arc::new(Mutex::new(0)),
             current_snapshot,
         }
     }
@@ -159,6 +167,7 @@ impl MetaStore {
             log,
             sm,
             hs,
+            snapshot_idx: Arc::new(Mutex::new(0)),
             current_snapshot,
         }
     }
@@ -206,14 +215,13 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
         let sm = self.sm.read().await;
         match &mut *hs {
             Some(inner) => {
-                let (last_log_index, last_log_term) = match log.values().rev().next() {
-                    Some(log) => (log.index, log.term),
-                    None => (0, 0),
+                let last_log_id = match log.values().rev().next() {
+                    Some(log) => log.log_id,
+                    None => (0, 0).into(),
                 };
                 let last_applied_log = sm.last_applied_log;
                 let st = InitialState {
-                    last_log_index,
-                    last_log_term,
+                    last_log_id,
                     last_applied_log,
                     hard_state: inner.clone(),
                     membership,
@@ -270,7 +278,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
     #[tracing::instrument(level = "info", skip(self, entry), fields(myid=self.id))]
     async fn append_entry_to_log(&self, entry: &Entry<LogEntry>) -> anyhow::Result<()> {
         let mut log = self.log.write().await;
-        log.insert(entry.index, entry.clone());
+        log.insert(entry.log_id.index, entry.clone());
         Ok(())
     }
 
@@ -278,7 +286,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
     async fn replicate_to_log(&self, entries: &[Entry<LogEntry>]) -> anyhow::Result<()> {
         let mut log = self.log.write().await;
         for entry in entries {
-            log.insert(entry.index, entry.clone());
+            log.insert(entry.log_id.index, entry.clone());
         }
         Ok(())
     }
@@ -323,7 +331,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
             membership_config = log
                 .values()
                 .rev()
-                .skip_while(|entry| entry.index > last_applied_log)
+                .skip_while(|entry| entry.log_id.index > last_applied_log)
                 .find_map(|entry| match &entry.payload {
                     EntryPayload::ConfigChange(cfg) => Some(cfg.membership.clone()),
                     _ => None,
@@ -333,12 +341,19 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
 
         let snapshot_bytes: Vec<u8>;
         let term;
+        let snapshot_idx = {
+            let mut l = self.snapshot_idx.lock().await;
+            *l += 1;
+            *l
+        };
+        let snapshot_id;
+
         {
             let mut log = self.log.write().await;
             let mut current_snapshot = self.current_snapshot.write().await;
             term = log
                 .get(&last_applied_log)
-                .map(|entry| entry.term)
+                .map(|entry| entry.log_id.term)
                 .ok_or_else(|| anyhow::anyhow!(ERR_INCONSISTENT_LOG))?;
             *log = log.split_off(&last_applied_log);
             log.insert(
@@ -351,9 +366,14 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
                 ),
             );
 
+            snapshot_id = format!("{}-{}-{}", term, last_applied_log, snapshot_idx);
+
             let snapshot = MetaStoreSnapshot {
-                index: last_applied_log,
-                term,
+                last_log_id: LogId {
+                    term,
+                    index: last_applied_log,
+                },
+                snapshot_id: snapshot_id.clone(),
                 membership: membership_config.clone(),
                 data,
             };
@@ -366,16 +386,19 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
             "log compaction complete"
         );
         Ok(CurrentSnapshotData {
-            term,
-            index: last_applied_log,
+            last_log_id: LogId {
+                term,
+                index: last_applied_log,
+            },
             membership: membership_config.clone(),
+            snapshot_id,
             snapshot: Box::new(Cursor::new(snapshot_bytes)),
         })
     }
 
     #[tracing::instrument(level = "info", skip(self), fields(myid=self.id))]
-    async fn create_snapshot(&self) -> anyhow::Result<(String, Box<Self::Snapshot>)> {
-        Ok((String::from(""), Box::new(Cursor::new(Vec::new())))) // Snapshot IDs are insignificant to this storage engine.
+    async fn create_snapshot(&self) -> anyhow::Result<Box<Self::Snapshot>> {
+        Ok(Box::new(Cursor::new(Vec::new())))
     }
 
     #[tracing::instrument(level = "info", skip(self, snapshot), fields(myid=self.id))]
@@ -402,7 +425,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
             let membership_config = log
                 .values()
                 .rev()
-                .skip_while(|entry| entry.index > index)
+                .skip_while(|entry| entry.log_id.index > index)
                 .find_map(|entry| match &entry.payload {
                     EntryPayload::ConfigChange(cfg) => Some(cfg.membership.clone()),
                     _ => None,
@@ -442,9 +465,9 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
             Some(snapshot) => {
                 let reader = serde_json::to_vec(&snapshot)?;
                 Ok(Some(CurrentSnapshotData {
-                    index: snapshot.index,
-                    term: snapshot.term,
+                    last_log_id: snapshot.last_log_id,
                     membership: snapshot.membership.clone(),
+                    snapshot_id: snapshot.snapshot_id.clone(),
                     snapshot: Box::new(Cursor::new(reader)),
                 }))
             }

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -167,6 +167,7 @@ impl MetaStore {
             log,
             sm,
             hs,
+            // TODO(xp): need to reload state
             snapshot_idx: Arc::new(Mutex::new(0)),
             current_snapshot,
         }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store]: upgrade to async-raft 0.6.2-alpha.4, fix bugs and improve:

Changes are here: https://github.com/datafuse-extras/async-raft/compare/v0.6.2-alpha.1...datafuse-extras:v0.6.2-alpha.4


**Change**:

- change: merge term and index to `xxx_log_id`: LogId in several public types:

    - Entry
    - InitialState
    - AppendEntriesRequest
    - RaftCore
    - CurrentSnapshotData
    - SnapshotUpdate::SnapshotComplete
    - InstallSnapshotRequest

- change: use snapshot-id to identify a snapshot stream

    A snapshot stream should be identified by some id, since the server end
    should not assume messages are arrived in the correct order.
    Without an id, two `install_snapshot` request belonging to different
    snapshot data may corrupt the snapshot data, explicitly or even worse,
    silently.

    - Add SnapshotId to identify a snapshot stream.

    - Add SnapshotSegmentId to identify a segment in a snapshot stream.

    - Add field `snapshot_id` to snapshot related data structures.

    - Add error `RaftError::SnapshotMismatch`.

    - `Storage::create_snapshot()` does not need to return and id.
      Since the receiving end only keeps one snapshot stream session at
      most.
      Instead, `Storage::do_log_compaction()` should build a unique id
      everytime it is called.

    - When the raft node receives an `install_snapshot` request, the id must
      match to continue.
      A request with a different id should be rejected.
      A new id with offset=0 indicates the sender has started a new stream.
      In this case, the old unfinished stream is dropped and cleaned.

    - Add test for `install_snapshot` API.

**Fix**:

- fix: leader should re-create and send snapshot when `threshold/2 < last_log_index - snapshot < threshold`

    The problem:

    If `last_log_index` advances `snapshot.applied_index` too many, i.e.:
    `threshold/2 < last_log_index - snapshot < threshold`
    (e.g., `10/2 < 16-10 < 20` in the test that reproduce this bug), the leader
    tries to re-create a new snapshot. But when
    `last_log_index < threshold`, it won't create, which result in a dead
    loop.

    Solution:

    In such case, force to create a snapshot without considering the
    threshold.

- fix: `client_read` has used wrong quorum=majority-1

**Feature**:

- feature: add metrics about leader

    In LeaderState it also report metrics about the replication to other node when report metrics.

    When switched to other state, LeaderState will be destroyed as long as
    the cached replication metrics.

    Other state report an `None` to raft core to override the previous
    metrics data.

    At some point the raft core, without knonwning the state, just report
    metrics with an `Update::Ignore`, to indicate that leave replication
    metrics intact.

- feature: report snapshot metrics to RaftMetrics::snapshot, which is a LogId: (term, index) that a snapshot includes
    - Add: `Wait.snapshot()` to watch snapshot changes.
    - Test: replace `sleep()` with `wait_for_snapshot()` to speed up tests.

**Test**:

- test: add test of small chunk snapshot transfer

- test: compaction test does not need to change membership

- test: dynamic_membership: use wait() instead of sleep to reduce test time

**Refactor**:

- dep: upgrade tokio from 1.7 to 1.8

- refactor: merge term and index into xxx_log_id: LogId

## Changelog







## Related Issues

#271