### PR TITLE
[store] refine: upgrade async-raft to 0.6.2-alpha.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.4#c6418cbfedb20252f691ae44fd5c1b7fed513d27"
+source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.5#eff11d6a6841c01f99ba7aa046b34b195f8c0558"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -34,7 +34,7 @@ common-tracing = {path = "../../common/tracing"}
 
 # Crates.io dependencies
 anyhow = "1.0.42"
-async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.4" }
+async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.5" }
 async-trait = "0.1"
 env_logger = "0.8"
 futures = "0.3"


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refine: upgrade async-raft to 0.6.2-alpha.5
Simplify snapshot API, data types, fix snapshot bug:
https://github.com/datafuse-extras/async-raft/compare/v0.6.2-alpha.4...datafuse-extras:v0.6.2-alpha.5

**Fix**:

- fix: after 2 log compaction, membership should be able to be extract from prev compaction log

- fix: when `finalize_snapshot_installation`, memstore should not load membership from its old log that are going to be overridden by snapshot.

**Change**:

- change: reduce one unnecessary snapshot serialization
    - Change: `get_current_snapshot()`: remove double-serialization:
      convert MemStoreSnapshot to CurrentSnapshotData instead of serializing
      MemStoreSnapshot:

      Before:
      ```
      MemStoreSnapshot.data = serialize(state-machine)
      CurrentSnapshotData.data = serialize(MemStoreSnapshot)
      ```

      After:
      ```
      MemStoreSnapshot.data = serialize(state-machine)
      CurrentSnapshotData.data = MemStoreSnapshot.data
      ```

      when `finalize_snapshot_installation`, extract snapshot meta info from
      `InstallSnapshotRequest`. Reduce one unnecessary deserialization.

    - Change: InstallSnapshotRequest: merge `snapshot_id`, `last_log_id`,
      `membership` into one field `meta`.

    - Refactor: use SnapshotMeta(`snapshot_id`, `last_log_id`, `membership`) as
      a container of metadata of a snapshot.
      Reduce parameters.

    - Refactor: remove redundent param `delete_through` from
      `finalize_snapshot_installation`.

- change: add CurrentSnapshotData.meta: SnapshotMeta, which is a container of all meta data of a snapshot: last log id included, membership etc.

## Changelog




- Improvement


## Related Issues

#271