### PR TITLE
[store] test: when creating MetaNode, the guard(in StoreTestContext) for the temp dir storing raft state must be kept during every case

### DIFF
--- a/fusestore/store/src/api/rpc/flight_service_test.rs
+++ b/fusestore/store/src/api/rpc/flight_service_test.rs
@@ -22,7 +22,7 @@ async fn test_flight_create_database() -> anyhow::Result<()> {
     common_tracing::init_default_tracing();
 
     // 1. Service starts.
-    let addr = crate::tests::start_store_server().await?;
+    let (_tc, addr) = crate::tests::start_store_server().await?;
 
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -99,7 +99,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
     tracing::info!("init logging");
 
     // 1. Service starts.
-    let addr = crate::tests::start_store_server().await?;
+    let (_tc, addr) = crate::tests::start_store_server().await?;
 
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -213,7 +213,7 @@ async fn test_do_append() -> anyhow::Result<()> {
     use common_planners::DatabaseEngineType;
     use common_planners::TableEngineType;
 
-    let addr = crate::tests::start_store_server().await?;
+    let (_tc, addr) = crate::tests::start_store_server().await?;
 
     let schema = Arc::new(DataSchema::new(vec![
         DataField::new("col_i", DataType::Int64, false),
@@ -283,7 +283,7 @@ async fn test_scan_partition() -> anyhow::Result<()> {
     use common_planners::DatabaseEngineType;
     use common_planners::TableEngineType;
 
-    let addr = crate::tests::start_store_server().await?;
+    let (_tc, addr) = crate::tests::start_store_server().await?;
 
     let schema = Arc::new(DataSchema::new(vec![
         DataField::new("col_i", DataType::Int64, false),
@@ -359,7 +359,7 @@ async fn test_scan_partition() -> anyhow::Result<()> {
 async fn test_flight_generic_kv() -> anyhow::Result<()> {
     common_tracing::init_default_tracing();
 
-    let addr = crate::tests::start_store_server().await?;
+    let (_tc, addr) = crate::tests::start_store_server().await?;
 
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 

--- a/fusestore/store/src/executor/action_handler_test.rs
+++ b/fusestore/store/src/executor/action_handler_test.rs
@@ -29,6 +29,7 @@ use crate::fs::FileSystem;
 use crate::localfs::LocalFS;
 use crate::meta_service::MetaNode;
 use crate::tests::service::new_test_context;
+use crate::tests::service::StoreTestContext;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_action_handler_do_pull_file() -> anyhow::Result<()> {
@@ -40,7 +41,7 @@ async fn test_action_handler_do_pull_file() -> anyhow::Result<()> {
     let dir = tempdir()?;
     let root = dir.path();
 
-    let hdlr = bring_up_dfs_action_handler(root, hashmap! {
+    let (_tc, hdlr) = bring_up_dfs_action_handler(root, hashmap! {
         "foo" => "bar",
     })
     .await?;
@@ -110,7 +111,7 @@ async fn test_action_handler_add_database() -> anyhow::Result<()> {
     {
         let dir = tempdir()?;
         let root = dir.path();
-        let hdlr = bring_up_dfs_action_handler(root, hashmap! {}).await?;
+        let (_tc, hdlr) = bring_up_dfs_action_handler(root, hashmap! {}).await?;
 
         for (i, c) in cases.iter().enumerate() {
             let mes = format!("{}-th: plan: {:?}, want: {:?}", i, c.plan, c.want);
@@ -166,7 +167,7 @@ async fn test_action_handler_get_database() -> anyhow::Result<()> {
     {
         let dir = tempdir()?;
         let root = dir.path();
-        let hdlr = bring_up_dfs_action_handler(root, hashmap! {}).await?;
+        let (_tc, hdlr) = bring_up_dfs_action_handler(root, hashmap! {}).await?;
 
         {
             // create db
@@ -212,12 +213,13 @@ async fn test_action_handler_get_database() -> anyhow::Result<()> {
 async fn bring_up_dfs_action_handler(
     root: &Path,
     files: HashMap<&str, &str>,
-) -> anyhow::Result<ActionHandler> {
+) -> anyhow::Result<(StoreTestContext, ActionHandler)> {
     let fs = LocalFS::try_create(root.to_str().unwrap().to_string())?;
 
-    let tc = new_test_context();
+    let mut tc = new_test_context();
 
     let mn = MetaNode::boot(0, &tc.config).await?;
+    tc.meta_nodes.push(mn.clone());
 
     let dfs = Dfs::create(fs, mn.clone());
 
@@ -228,5 +230,5 @@ async fn bring_up_dfs_action_handler(
 
     let ah = ActionHandler::create(Arc::new(dfs), mn);
 
-    Ok(ah)
+    Ok((tc, ah))
 }


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] test: when creating MetaNode, the guard(in StoreTestContext) for the temp dir storing raft state must be kept during every case

## Changelog




- Improvement
- Build/Testing/CI

## Related Issues

#271