### PR TITLE
[store] feature: reopen a MetaStore

### DIFF
--- a/fusestore/store/src/meta_service/meta_store_test.rs
+++ b/fusestore/store/src/meta_service/meta_store_test.rs
@@ -1,0 +1,55 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use async_raft::storage::HardState;
+use async_raft::RaftStorage;
+use common_runtime::tokio;
+use common_tracing::tracing;
+
+use crate::meta_service::MetaStore;
+use crate::tests::service::new_test_context;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_store_restart() -> anyhow::Result<()> {
+    // - Create a MetaStore
+    // - Update MetaStore
+    // - Close and reopen it
+    // - Test state is restored
+
+    // TODO check log
+    // TODO check state machine
+
+    let id = 3;
+    let tc = new_test_context();
+
+    tracing::info!("--- new MetaStore");
+    {
+        let ms = MetaStore::new(id, &tc.config).await?;
+        assert_eq!(id, ms.id);
+        assert_eq!(None, ms.read_hard_state().await?);
+
+        tracing::info!("--- update MetaStore");
+
+        ms.save_hard_state(&HardState {
+            current_term: 10,
+            voted_for: Some(5),
+        })
+        .await?;
+    }
+
+    tracing::info!("--- reopen MetaStore");
+    {
+        let ms = MetaStore::open(&tc.config).await?;
+        assert_eq!(id, ms.id);
+        assert_eq!(
+            Some(HardState {
+                current_term: 10,
+                voted_for: Some(5),
+            }),
+            ms.read_hard_state().await?
+        );
+    }
+
+    Ok(())
+}

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -41,6 +41,8 @@ pub use crate::protobuf::RaftMes;
 #[cfg(test)]
 mod meta_service_impl_test;
 #[cfg(test)]
+mod meta_store_test;
+#[cfg(test)]
 mod placement_test;
 mod raft_state;
 #[cfg(test)]


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: clean up todo

##### [store] feature: reopen a MetaStore
MetaStore is the store of a raft node.
In this commit it oly impl RaftState reopen. Log and state machine are
still pure in-memory impl.

## Changelog

- New Feature


- Improvement


## Related Issues

#271