### PR TITLE
[store] refactor: move trait RaftStateSerde to SledSerde and make it public for other component that needs to access sled db

### DIFF
--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -11,6 +11,7 @@ pub mod network;
 pub mod placement;
 pub mod raft_txid;
 pub mod raftmeta;
+pub mod sled_serde;
 pub mod snapshot;
 pub mod state_machine;
 
@@ -26,6 +27,7 @@ pub use placement::Placement;
 pub use raft_txid::RaftTxId;
 pub use raftmeta::MetaNode;
 pub use raftmeta::MetaStore;
+pub use sled_serde::SledSerde;
 pub use snapshot::Snapshot;
 pub use state_machine::Node;
 pub use state_machine::Slot;

--- a/fusestore/store/src/meta_service/raft_state.rs
+++ b/fusestore/store/src/meta_service/raft_state.rs
@@ -5,11 +5,9 @@
 use async_raft::storage::HardState;
 use common_exception::ErrorCode;
 use common_exception::ToErrorCode;
-use serde::de::DeserializeOwned;
-use serde::Serialize;
-use sled::IVec;
 
 use crate::meta_service::NodeId;
+use crate::meta_service::SledSerde;
 
 /// Raft state stores everything else other than log and state machine, which includes:
 /// id: NodeId,
@@ -26,25 +24,6 @@ pub struct RaftState {
 const K_RAFT_STATE: &str = "raft_state";
 const K_ID: &str = "id";
 const K_HARD_STATE: &str = "hard_state";
-
-/// Serialize/deserialize(ser/de) for RaftState.
-trait RaftStateSerde {
-    fn ser(&self) -> Result<IVec, ErrorCode>;
-    fn de<T: AsRef<[u8]>>(v: T) -> Result<Self, ErrorCode>
-    where Self: Sized;
-}
-
-impl<SD: Serialize + DeserializeOwned + Sized> RaftStateSerde for SD {
-    fn ser(&self) -> Result<IVec, ErrorCode> {
-        let x = serde_json::to_vec(self)?;
-        Ok(x.into())
-    }
-
-    fn de<T: AsRef<[u8]>>(v: T) -> Result<Self, ErrorCode> {
-        let s = serde_json::from_slice(v.as_ref())?;
-        Ok(s)
-    }
-}
 
 impl RaftState {
     /// Create a new sled db backed RaftState.

--- a/fusestore/store/src/meta_service/sled_serde.rs
+++ b/fusestore/store/src/meta_service/sled_serde.rs
@@ -1,0 +1,29 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use common_exception::ErrorCode;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use sled::IVec;
+
+/// Serialize/deserialize(ser/de) to/from sled values.
+pub trait SledSerde {
+    fn ser(&self) -> Result<IVec, ErrorCode>;
+    fn de<T: AsRef<[u8]>>(v: T) -> Result<Self, ErrorCode>
+    where Self: Sized;
+}
+
+impl<SD: Serialize + DeserializeOwned + Sized> SledSerde for SD {
+    /// (ser)ialize a value to `sled::IVec`.
+    fn ser(&self) -> Result<IVec, ErrorCode> {
+        let x = serde_json::to_vec(self)?;
+        Ok(x.into())
+    }
+
+    /// (de)serialize a value from `sled::IVec`.
+    fn de<T: AsRef<[u8]>>(v: T) -> Result<Self, ErrorCode> {
+        let s = serde_json::from_slice(v.as_ref())?;
+        Ok(s)
+    }
+}


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: move trait RaftStateSerde to SledSerde and make it public for other component that needs to access sled db

## Changelog




- Improvement


## Related Issues

#271