### PR TITLE
[store] feature: ser/de with value order preserved

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,7 @@ dependencies = [
  "anyhow",
  "async-raft",
  "async-trait",
+ "byteorder",
  "common-arrow",
  "common-building",
  "common-datablocks",

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -36,6 +36,7 @@ common-tracing = {path = "../../common/tracing"}
 anyhow = "1.0.42"
 async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.5" }
 async-trait = "0.1"
+byteorder = "1.1.0"
 env_logger = "0.9"
 futures = "0.3"
 indexmap = "1.7.0"

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -8,6 +8,7 @@ pub mod errors;
 pub mod log_entry;
 pub mod meta_service_impl;
 pub mod network;
+pub mod node_id;
 pub mod placement;
 pub mod raft_txid;
 pub mod raftmeta;
@@ -16,13 +17,13 @@ pub mod snapshot;
 pub mod state_machine;
 
 pub use applied_state::AppliedState;
-pub use async_raft::NodeId;
 pub use cmd::Cmd;
 pub use errors::RetryableError;
 pub use errors::ShutdownError;
 pub use log_entry::LogEntry;
 pub use meta_service_impl::MetaServiceImpl;
 pub use network::Network;
+pub use node_id::NodeId;
 pub use placement::Placement;
 pub use raft_txid::RaftTxId;
 pub use raftmeta::MetaNode;
@@ -45,11 +46,15 @@ mod meta_service_impl_test;
 #[cfg(test)]
 mod meta_store_test;
 #[cfg(test)]
+mod node_id_test;
+#[cfg(test)]
 mod placement_test;
 mod raft_state;
 #[cfg(test)]
 mod raft_state_test;
 #[cfg(test)]
 mod raftmeta_test;
+#[cfg(test)]
+mod sled_serde_test;
 #[cfg(test)]
 mod state_machine_test;

--- a/fusestore/store/src/meta_service/node_id.rs
+++ b/fusestore/store/src/meta_service/node_id.rs
@@ -1,0 +1,21 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+pub use async_raft::NodeId;
+use byteorder::BigEndian;
+use byteorder::ByteOrder;
+
+use crate::meta_service::sled_serde::SledOrderedSerde;
+
+/// NodeId need to be serialized with order preserved, for listing.
+/// This is required by `SledSerde` when saving node id into sled db.
+impl SledOrderedSerde for NodeId {
+    fn order_preserved_serialize(&self, buf: &mut [u8]) {
+        BigEndian::write_u64(buf, *self);
+    }
+
+    fn order_preserved_deserialize(buf: &[u8]) -> Self {
+        BigEndian::read_u64(buf)
+    }
+}

--- a/fusestore/store/src/meta_service/node_id_test.rs
+++ b/fusestore/store/src/meta_service/node_id_test.rs
@@ -1,0 +1,39 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::ops::Bound;
+
+use crate::meta_service::sled_serde::SledOrderedSerde;
+use crate::meta_service::sled_serde::SledRangeSerde;
+use crate::meta_service::NodeId;
+
+#[test]
+fn test_node_id_serde() -> anyhow::Result<()> {
+    let id9: NodeId = 9;
+    let id10: NodeId = 10;
+
+    let got9 = id9.ser()?;
+    let got10 = id10.ser()?;
+    assert!(got9 < got10);
+
+    let got9 = NodeId::de(got9)?;
+    let got10 = NodeId::de(got10)?;
+    assert_eq!(id9, got9);
+    assert_eq!(id10, got10);
+
+    Ok(())
+}
+
+#[test]
+fn test_node_id_range_serde() -> anyhow::Result<()> {
+    let a: NodeId = 8;
+    let b: NodeId = 11;
+    let got = (a..b).ser()?;
+    let want = (
+        Bound::Included(sled::IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 8])),
+        Bound::Excluded(sled::IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 11])),
+    );
+    assert_eq!(want, got);
+    Ok(())
+}

--- a/fusestore/store/src/meta_service/raft_state.rs
+++ b/fusestore/store/src/meta_service/raft_state.rs
@@ -6,6 +6,7 @@ use async_raft::storage::HardState;
 use common_exception::ErrorCode;
 use common_exception::ToErrorCode;
 
+use crate::meta_service::sled_serde::SledOrderedSerde;
 use crate::meta_service::NodeId;
 use crate::meta_service::SledSerde;
 
@@ -24,6 +25,8 @@ pub struct RaftState {
 const K_RAFT_STATE: &str = "raft_state";
 const K_ID: &str = "id";
 const K_HARD_STATE: &str = "hard_state";
+
+impl SledSerde for HardState {}
 
 impl RaftState {
     /// Create a new sled db backed RaftState.

--- a/fusestore/store/src/meta_service/sled_serde.rs
+++ b/fusestore/store/src/meta_service/sled_serde.rs
@@ -2,19 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::mem::size_of_val;
+use std::ops::Bound;
+use std::ops::RangeBounds;
+
 use common_exception::ErrorCode;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sled::IVec;
 
 /// Serialize/deserialize(ser/de) to/from sled values.
-pub trait SledSerde {
-    fn ser(&self) -> Result<IVec, ErrorCode>;
-    fn de<T: AsRef<[u8]>>(v: T) -> Result<Self, ErrorCode>
-    where Self: Sized;
-}
-
-impl<SD: Serialize + DeserializeOwned + Sized> SledSerde for SD {
+pub trait SledSerde: Serialize + DeserializeOwned + Sized {
     /// (ser)ialize a value to `sled::IVec`.
     fn ser(&self) -> Result<IVec, ErrorCode> {
         let x = serde_json::to_vec(self)?;
@@ -22,8 +20,83 @@ impl<SD: Serialize + DeserializeOwned + Sized> SledSerde for SD {
     }
 
     /// (de)serialize a value from `sled::IVec`.
-    fn de<T: AsRef<[u8]>>(v: T) -> Result<Self, ErrorCode> {
+    fn de<T: AsRef<[u8]>>(v: T) -> Result<Self, ErrorCode>
+    where Self: Sized {
         let s = serde_json::from_slice(v.as_ref())?;
         Ok(s)
     }
+}
+
+/// Serialize/deserialize(ser/de) to/from sled values and keeps order after serializing.
+///
+/// E.g. serde_json does not preserve the order of u64:
+/// 9 -> [57], 10 -> [49, 48]
+/// While BigEndian encoding preserve the order.
+///
+/// A type that is used as a sled db key should be serialized with order preserved, such as log index.
+pub trait SledOrderedSerde: Serialize + DeserializeOwned + Sized {
+    /// (ser)ialize a value to `sled::IVec`.
+    fn ser(&self) -> Result<IVec, ErrorCode> {
+        let size = size_of_val(self);
+        let mut buf = vec![0; size];
+
+        self.order_preserved_serialize(&mut buf);
+        Ok(buf.into())
+    }
+
+    /// (de)serialize a value from `sled::IVec`.
+    fn de<V: AsRef<[u8]>>(v: V) -> Result<Self, ErrorCode>
+    where Self: Sized {
+        let v = Self::order_preserved_deserialize(v.as_ref());
+        Ok(v)
+    }
+
+    /// serialize keep the same ordering as original value
+    fn order_preserved_serialize(&self, buf: &mut [u8]);
+
+    /// deserialize from the order preserved bytes
+    fn order_preserved_deserialize(buf: &[u8]) -> Self;
+}
+
+/// Serialize/deserialize(ser/de) to/from range to sled IVec range.
+/// The type must impl SledOrderedSerde so that after serialization the order is preserved.
+pub trait SledRangeSerde<SD, V, R>
+where
+    SD: SledOrderedSerde,
+    V: RangeBounds<SD>,
+    R: RangeBounds<IVec>,
+{
+    /// (ser)ialize a range to range of `sled::IVec`.
+    fn ser(&self) -> Result<R, ErrorCode>;
+
+    // TODO(xp): do we need this?
+    // /// (de)serialize a value from `sled::IVec`.
+    // fn de<T: AsRef<[u8]>>(v: T) -> Result<Self, ErrorCode>
+    //     where Self: Sized;
+}
+
+/// Impl ser/de for range of value that can be ser/de to `sled::IVec`
+impl<SD, V> SledRangeSerde<SD, V, (Bound<IVec>, Bound<IVec>)> for V
+where
+    SD: SledOrderedSerde,
+    V: RangeBounds<SD>,
+{
+    fn ser(&self) -> Result<(Bound<IVec>, Bound<IVec>), ErrorCode> {
+        let s = self.start_bound();
+        let e = self.end_bound();
+
+        let s = bound_ser(s)?;
+        let e = bound_ser(e)?;
+
+        Ok((s, e))
+    }
+}
+
+fn bound_ser<SD: SledOrderedSerde>(v: Bound<&SD>) -> Result<Bound<sled::IVec>, ErrorCode> {
+    let res = match v {
+        Bound::Included(v) => Bound::Included(v.ser()?),
+        Bound::Excluded(v) => Bound::Excluded(v.ser()?),
+        Bound::Unbounded => Bound::Unbounded,
+    };
+    Ok(res)
 }

--- a/fusestore/store/src/meta_service/sled_serde_test.rs
+++ b/fusestore/store/src/meta_service/sled_serde_test.rs
@@ -1,0 +1,20 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use crate::meta_service::sled_serde::SledOrderedSerde;
+use crate::meta_service::NodeId;
+
+#[test]
+fn test_serde_node_id() -> anyhow::Result<()> {
+    let ids: Vec<NodeId> = vec![9, 10, 11];
+
+    let want: Vec<sled::IVec> = vec![
+        sled::IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 9]),
+        sled::IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 10]),
+        sled::IVec::from(vec![0, 0, 0, 0, 0, 0, 0, 11]),
+    ];
+    let got = ids.iter().map(|id| id.ser().unwrap()).collect::<Vec<_>>();
+    assert_eq!(want, got);
+    Ok(())
+}


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: ser/de with value order preserved
- Add: SledOrderedSerde to impl a ser/de that respect the original value order.

   E.g. serde_json does not preserve the order of u64:
   9 -> [57], 10 -> [49, 48]
   While BigEndian encoding preserve the order.

   A value that is used as sled db key must be serialized with order
   preserved.

   `SledSerde` impl the ser/de that does not require order preservation.

- Add: SledRangeSerde to serialize a `Range` to sled db range, in order
  to simplify range query or range modification.

- Change: ser/de NodeId with order preserved.

- Move NodeId into standalone file `node_id.rs`, impl order-preserved
  serialization for NodeId.

## Changelog

- New Feature





## Related Issues

#271