### PR TITLE
[store] test: add new_sled_test_context() to create a context for sled related test

### DIFF
--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -70,6 +70,24 @@ pub fn new_test_context() -> StoreTestContext {
     }
 }
 
+pub struct SledTestContext {
+    #[allow(dead_code)]
+    temp_dir: TempDir,
+    pub db: sled::Db,
+}
+
+/// Create a new context for testing sled
+pub fn new_sled_test_context() -> SledTestContext {
+    let t = tempdir().expect("create temp dir to store meta");
+    let tmpdir = t.path().to_str().unwrap().to_string();
+
+    SledTestContext {
+        // hold the TempDir until being dropped.
+        temp_dir: t,
+        db: sled::open(tmpdir).expect("open sled db"),
+    }
+}
+
 pub fn rand_local_addr() -> String {
     let mut rng = rand::thread_rng();
     let port: u32 = rng.gen_range(10000..11000);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] test: add new_sled_test_context() to create a context for sled related test

## Changelog




- Improvement
- Build/Testing/CI

## Related Issues

#271
#1065 