### PR TITLE
[store] feature: add RaftLog: a sled db backed raft log storage

### DIFF
--- a/fusestore/store/src/meta_service/cmd.rs
+++ b/fusestore/store/src/meta_service/cmd.rs
@@ -13,7 +13,7 @@ use crate::meta_service::Node;
 
 /// A Cmd describes what a user want to do to raft state machine
 /// and is the essential part of a raft log.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum Cmd {
     /// AKA put-if-absent. add a key-value record only when key is absent.
     AddFile {

--- a/fusestore/store/src/meta_service/log_entry.rs
+++ b/fusestore/store/src/meta_service/log_entry.rs
@@ -17,7 +17,7 @@ use crate::meta_service::RaftTxId;
 /// The client and the serial together provides external consistency:
 /// If a client failed to recv the response, it  re-send another RaftRequest with the same
 /// "client" and "serial", thus the raft engine is able to distinguish if a request is duplicated.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct LogEntry {
     /// When not None, it is used to filter out duplicated logs, which are caused by retries by client.
     pub txid: Option<RaftTxId>,

--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -10,6 +10,8 @@ pub mod meta_service_impl;
 pub mod network;
 pub mod node_id;
 pub mod placement;
+pub mod raft_log;
+pub mod raft_state;
 pub mod raft_txid;
 pub mod raftmeta;
 pub mod sled_serde;
@@ -49,7 +51,8 @@ mod meta_store_test;
 mod node_id_test;
 #[cfg(test)]
 mod placement_test;
-mod raft_state;
+#[cfg(test)]
+mod raft_log_test;
 #[cfg(test)]
 mod raft_state_test;
 #[cfg(test)]

--- a/fusestore/store/src/meta_service/raft_log.rs
+++ b/fusestore/store/src/meta_service/raft_log.rs
@@ -1,0 +1,141 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::ops::RangeBounds;
+
+use async_raft::raft::Entry;
+use common_exception::ErrorCode;
+use common_exception::ToErrorCode;
+
+use crate::meta_service::sled_serde::SledOrderedSerde;
+use crate::meta_service::sled_serde::SledRangeSerde;
+use crate::meta_service::LogEntry;
+use crate::meta_service::SledSerde;
+
+const K_RAFT_LOG: &str = "raft_log";
+
+/// RaftLog stores the logs of a raft node.
+/// It is part of MetaStore.
+pub struct RaftLog {
+    tree: sled::Tree,
+}
+
+impl SledSerde for Entry<LogEntry> {}
+
+impl RaftLog {
+    /// Open RaftLog
+    pub async fn open(db: &sled::Db) -> common_exception::Result<RaftLog> {
+        let t = db
+            .open_tree(K_RAFT_LOG)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "open tree raft_log")?;
+
+        let rl = RaftLog { tree: t };
+        Ok(rl)
+    }
+
+    /// Retrieve the last log index and the log entry.
+    pub fn last(&self) -> common_exception::Result<Option<(u64, Entry<LogEntry>)>> {
+        //  TODO(xp): rename LogEntry: Entry<LogEntry> is weird.
+        let last = self
+            .tree
+            .last()
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "read last log")?;
+
+        match last {
+            Some((k, v)) => {
+                let log_index = u64::de(&k)?;
+                let ent = Entry::<LogEntry>::de(&v)?;
+                Ok(Some((log_index, ent)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Delete logs that are in `range`.
+    ///
+    /// When this function returns the logs are guaranteed to be fsync-ed.
+    ///
+    /// TODO(xp): in raft deleting logs may not need to be fsync-ed.
+    ///
+    /// 1. Deleting happens when cleaning applied logs, in which case, these logs will never be read:
+    ///    The logs to clean are all included in a snapshot and state machine.
+    ///    Replication will use the snapshot for sync, or create a new snapshot from the state machine for sync.
+    ///    Thus these logs will never be read. If an un-fsync-ed delete is lost during server crash, it just wait for next delete to clean them up.
+    ///
+    /// 2. Overriding uncommitted logs of an old term by some new leader that did not see these logs:
+    ///    In this case, atomic delete is quite enough(to not leave a hole).
+    ///    If the system allows logs hole, non-atomic delete is quite enough(depends on the upper layer).
+    ///
+    pub async fn range_delete<R>(&self, range: R) -> common_exception::Result<()>
+    where R: RangeBounds<u64> {
+        let mut batch = sled::Batch::default();
+
+        // Convert u64 range into sled::IVec range
+        let range = range.ser()?;
+
+        for item in self.tree.range(range) {
+            let (k, _) = item.map_err_to_code(ErrorCode::MetaStoreDamaged, || "range_delete")?;
+            batch.remove(k);
+        }
+
+        self.tree
+            .apply_batch(batch)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "batch log delete")?;
+
+        self.tree
+            .flush_async()
+            .await
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "flush log delete")?;
+
+        Ok(())
+    }
+
+    /// Get logs of index in `range`
+    pub fn range_get<R>(&self, range: R) -> common_exception::Result<Vec<Entry<LogEntry>>>
+    where R: RangeBounds<u64> {
+        // TODO(xp): pre alloc vec space
+        let mut res = vec![];
+
+        // Convert u64 range into sled::IVec range
+        let range = range.ser()?;
+        for item in self.tree.range(range) {
+            let (_, v) = item.map_err_to_code(ErrorCode::MetaStoreDamaged, || "range_get")?;
+
+            let ent = Entry::<LogEntry>::de(&v)?;
+            res.push(ent);
+        }
+
+        Ok(res)
+    }
+
+    /// Append logs into RaftLog.
+    /// There is no consecutiveness check. It is the caller's responsibility to leave no holes(if it runs a standard raft:DDD).
+    /// There is no overriding check either. It always overrides the existent ones.
+    ///
+    /// When this function returns the logs are guaranteed to be fsync-ed.
+    pub async fn append(&self, logs: &[Entry<LogEntry>]) -> common_exception::Result<()> {
+        let mut batch = sled::Batch::default();
+
+        for log in logs.iter() {
+            let index = log.log_id.index;
+
+            let k = index.ser()?;
+            let v = log.ser()?;
+            // let v = SledSerde::ser(log)?;
+
+            batch.insert(k, v);
+        }
+
+        self.tree
+            .apply_batch(batch)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "batch log insert")?;
+
+        self.tree
+            .flush_async()
+            .await
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "flush log insert")?;
+
+        Ok(())
+    }
+}

--- a/fusestore/store/src/meta_service/raft_log_test.rs
+++ b/fusestore/store/src/meta_service/raft_log_test.rs
@@ -1,0 +1,187 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use async_raft::raft::Entry;
+use async_raft::raft::EntryNormal;
+use async_raft::raft::EntryPayload;
+use async_raft::LogId;
+use common_runtime::tokio;
+
+use crate::meta_service::raft_log::RaftLog;
+use crate::meta_service::Cmd;
+use crate::meta_service::LogEntry;
+use crate::tests::service::new_sled_test_context;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_raft_log_open() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    RaftLog::open(db).await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let rl = RaftLog::open(db).await?;
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 10 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId {
+                term: 1,
+                index: 256,
+            },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    rl.append(&logs).await?;
+
+    let got = rl.range_get(0..)?;
+    assert_eq!(logs, got);
+
+    let got = rl.range_get(0..=2)?;
+    assert_eq!(logs[0..1], got);
+
+    let got = rl.range_get(0..3)?;
+    assert_eq!(logs[0..1], got);
+
+    let got = rl.range_get(0..5)?;
+    assert_eq!(logs[0..2], got);
+
+    let got = rl.range_get(0..10)?;
+    assert_eq!(logs[0..3], got);
+
+    let got = rl.range_get(0..11)?;
+    assert_eq!(logs[0..4], got);
+
+    let got = rl.range_get(9..11)?;
+    assert_eq!(logs[2..4], got);
+
+    let got = rl.range_get(10..256)?;
+    assert_eq!(logs[3..4], got);
+
+    let got = rl.range_get(10..257)?;
+    assert_eq!(logs[3..5], got);
+
+    let got = rl.range_get(257..)?;
+    assert_eq!(logs[5..], got);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_raft_log_last() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let rl = RaftLog::open(db).await?;
+
+    assert_eq!(None, rl.last()?);
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    rl.append(&logs).await?;
+    assert_eq!(Some((4, logs[1].clone())), rl.last()?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_raft_log_range_delete() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let rl = RaftLog::open(db).await?;
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 10 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId {
+                term: 1,
+                index: 256,
+            },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    rl.append(&logs).await?;
+    rl.range_delete(0..).await?;
+    assert_eq!(logs[5..], rl.range_get(0..)?);
+
+    rl.append(&logs).await?;
+    rl.range_delete(1..).await?;
+    assert_eq!(logs[5..], rl.range_get(0..)?);
+
+    rl.append(&logs).await?;
+    rl.range_delete(3..).await?;
+    assert_eq!(logs[0..1], rl.range_get(0..)?);
+
+    rl.append(&logs).await?;
+    rl.range_delete(3..10).await?;
+    assert_eq!(logs[0..1], rl.range_get(0..5)?);
+    assert_eq!(logs[3..], rl.range_get(5..)?);
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: add RaftLog: a sled db backed raft log storage
- Add: RaftLog, which uses a sled::Tree as backend storage and provides
  several log access API: last(), append(), range_get() and
  range_delete()

- Refactor: impl PartialEq for make a Entry<_> to simplify testing.

## Changelog

- New Feature





## Related Issues

#271
#1065