### PR TITLE
[store] feature: MetaStore uses sled db backed RaftLog to store logs

### DIFF
--- a/fusestore/store/src/meta_service/raft_log.rs
+++ b/fusestore/store/src/meta_service/raft_log.rs
@@ -19,7 +19,7 @@ const K_RAFT_LOG: &str = "raft_log";
 /// RaftLog stores the logs of a raft node.
 /// It is part of MetaStore.
 pub struct RaftLog {
-    tree: sled::Tree,
+    pub(crate) tree: sled::Tree,
 }
 
 impl SledSerde for Entry<LogEntry> {}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: MetaStore uses sled db backed RaftLog to store logs

## Changelog

- New Feature





## Related Issues

#271

fix: #1065