### PR TITLE
[store] refactor: upgrade to async-raft 0.6.2-alpha.6: use LogId to track last applied log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.5#eff11d6a6841c01f99ba7aa046b34b195f8c0558"
+source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.6#7e18c2c80d5a54a59e1681f4af8c3e81618095fc"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -34,7 +34,7 @@ common-tracing = {path = "../../common/tracing"}
 
 # Crates.io dependencies
 anyhow = "1.0.42"
-async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.5" }
+async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.6" }
 async-trait = "0.1"
 byteorder = "1.1.0"
 env_logger = "0.9"

--- a/fusestore/store/src/meta_service/state_machine_test.rs
+++ b/fusestore/store/src/meta_service/state_machine_test.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use async_raft::LogId;
 use common_metatypes::Database;
 use common_metatypes::MatchSeq;
 use common_metatypes::SeqValue;
@@ -141,7 +142,7 @@ async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
     let cases = crate::meta_service::raftmeta_test::cases_incr_seq();
 
     for (name, txid, k, want) in cases.iter() {
-        let resp = sm.apply(5, &LogEntry {
+        let resp = sm.apply(&LogId { term: 0, index: 5 }, &LogEntry {
             txid: txid.clone(),
             cmd: Cmd::IncrSeq { key: k.to_string() },
         });
@@ -387,7 +388,7 @@ async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {
     let cases = crate::meta_service::raftmeta_test::cases_add_file();
 
     for (name, txid, k, v, want_prev, want_result) in cases.iter() {
-        let resp = sm.apply(5, &LogEntry {
+        let resp = sm.apply(&LogId { term: 0, index: 5 }, &LogEntry {
             txid: txid.clone(),
             cmd: Cmd::AddFile {
                 key: k.to_string(),
@@ -417,7 +418,7 @@ async fn test_state_machine_apply_set_file() -> anyhow::Result<()> {
     let cases = crate::meta_service::raftmeta_test::cases_set_file();
 
     for (name, txid, k, v, want_prev, want_result) in cases.iter() {
-        let resp = sm.apply(5, &LogEntry {
+        let resp = sm.apply(&LogId { term: 0, index: 5 }, &LogEntry {
             txid: txid.clone(),
             cmd: Cmd::SetFile {
                 key: k.to_string(),


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: upgrade to async-raft 0.6.2-alpha.6: use LogId to track last applied log
By using `LogId{term, index}` instead of a single index, some
unnecessary log queries are reduce: such as when craeting snapshot,
no need to walk through logs to find the term of the last applied log.

## Changelog




- Improvement


## Related Issues

#271