### PR TITLE
fix show processlist not show extra_info in ClickHouse client

### DIFF
--- a/fusequery/query/src/servers/clickhouse/interactive_worker.rs
+++ b/fusequery/query/src/servers/clickhouse/interactive_worker.rs
@@ -34,6 +34,7 @@ impl ClickHouseSession for InteractiveWorker {
         let start = Instant::now();
 
         let context = self.session.create_context();
+        context.attach_query_info(&ctx.state.query);
         let mut query_writer = QueryWriter::create(ctx.client_revision, conn, context.clone());
 
         let get_query_result = InteractiveWorkerBase::do_query(&ctx.state.query, context);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

attach query info to ClickHouse session context

## Changelog

- Bug Fix

## Related Issues

Fixes #1074

## Test Plan

Unit Tests
