### PR TITLE
Add drop database test for action_handler

### DIFF
--- a/fusestore/store/src/meta_service/state_machine.rs
+++ b/fusestore/store/src/meta_service/state_machine.rs
@@ -242,9 +242,13 @@ impl StateMachine {
 
             Cmd::DropDatabase { ref name } => {
                 let prev = self.databases.get(name).cloned();
-                self.databases.remove(name);
-                tracing::debug!("applied DropDatabase: {}", name);
-                Ok((prev, None).into())
+                if prev.is_some() {
+                    self.databases.remove(name);
+                    tracing::debug!("applied DropDatabase: {}", name);
+                    Ok((prev, None).into())
+                } else {
+                    Ok((None::<Database>, None::<Database>).into())
+                }
             }
 
             Cmd::CreateTable {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Add missing drop database test for action_handler

## Changelog

- Improvement

## Related Issues

Fixes https://github.com/datafuselabs/datafuse/issues/774

## Test Plan

Unit Tests

Stateless Tests

