### PR TITLE
[Doc/Build/Testing] rename fuse-query to datafuse

### DIFF
--- a/.github/workflows/datafuse-docker.yml
+++ b/.github/workflows/datafuse-docker.yml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_NAMESPACE }}/fuse-query:latest
+          tags: ${{ secrets.DOCKERHUB_NAMESPACE }}/datafuse:master # assume latest tag is the latest release tag
           context: .
           file: ./docker/Dockerfile
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-HUB ?= datafusedev
+HUB ?= datafuselabs
 TAG ?= latest
 PLATFORM ?= linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
-VERSION ?= ""
+
 # Setup dev toolchain
 setup:
 	bash ./scripts/setup/dev_setup.sh

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -9,7 +9,8 @@ RUN /install.sh
 # double check whether binaries could run on host architecture
 RUN timeout 3 /root/.datafuse/bin/fuse-query || true
 RUN timeout 3 /root/.datafuse/bin/fuse-store || true
-FROM debian:buster
+# CI environment build image under GLIBC 2.29 and debian:buster only run GLIBC 2.28
+FROM debian:bullseye
 COPY --from=installer /root/.datafuse/bin/fuse-query  /fuse-query
 COPY --from=installer /root/.datafuse/bin/fuse-store /fuse-store
 COPY ./docker/bootstrap.sh /bootstrap.sh

--- a/website/datafuse/docs/overview/building-and-running.md
+++ b/website/datafuse/docs/overview/building-and-running.md
@@ -18,11 +18,8 @@ This document describes how to build and run [FuseQuery](https://github.com/data
 === "Release binary"
 
     ```markdown
-    Install latest datafuse release on local path ~/.datafuse/bin/
     $ curl -fsS https://raw.githubusercontent.com/datafuselabs/datafuse/master/scripts/installer/install-datafuse.sh | bash
-    Install given version of datafuse
-    $ curl -fsS https://raw.githubusercontent.com/datafuselabs/datafuse/master/scripts/installer/install-datafuse.sh | bash 
-    ```
+   ```
 
 === "From source"
 

--- a/website/datafuse/docs/overview/building-and-running.md
+++ b/website/datafuse/docs/overview/building-and-running.md
@@ -11,13 +11,18 @@ This document describes how to build and run [FuseQuery](https://github.com/data
 === "Run with Docker(Recommended)"
 
     ```markdown
-    $ docker pull datafusedev/fuse-query
-    $ docker run --init --rm -p 3307:3307 datafusedev/fuse-query
+    $ docker pull datafuselabs/datafuse
+    $ docker run --init --rm -p 3307:3307 datafuselabs/datafuse
     ```
 
 === "Release binary"
 
-    Download: [datafuse/releases](https://github.com/datafuselabs/datafuse/releases)
+    ```markdown
+    Install latest datafuse release on local path ~/.datafuse/bin/
+    $ curl -fsS https://raw.githubusercontent.com/datafuselabs/datafuse/master/scripts/installer/install-datafuse.sh | bash
+    Install given version of datafuse
+    $ curl -fsS https://raw.githubusercontent.com/datafuselabs/datafuse/master/scripts/installer/install-datafuse.sh | bash 
+    ```
 
 === "From source"
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Currently, we have already build release in multi-arch platform(linux/arm64, linux/amd64, linux/arm/v7, linux/arm/v6) and support to install fuse-query and fuse-store in one install script(https://github.com/datafuselabs/datafuse/pull/1121), thus far we can migrate from original datafusedev to datafuselabs docker host with those platform supports.

We should check the following part integrate well with this update
1. website installation page should update
2. Makefile should change default docker host to datafuselabs
3. CI part should change secret.DOCKERHUB_NAMESPACE conform to the renaming

## Changelog

- Build/Testing/CI
- Documentation
- Website
- Other 
- Not for changelog (changelog entry is not required)

## Related Issues

fixes https://github.com/datafuselabs/datafuse/issues/1132
fixes https://github.com/datafuselabs/datafuse/issues/1048
fixes https://github.com/datafuselabs/datafuse/issues/893
Should also
fixes https://github.com/datafuselabs/datafuse/issues/1109
## Test Plan

Unit Tests

Stateless Tests

