### PR TITLE
[store] feature: add SledTree<K, V> to provided typed access to sled tree.

### DIFF
--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -15,6 +15,7 @@ pub mod raft_txid;
 pub mod raft_types;
 pub mod raftmeta;
 pub mod sled_serde;
+pub mod sled_tree;
 pub mod snapshot;
 pub mod state_machine;
 
@@ -33,6 +34,8 @@ pub use raft_types::Term;
 pub use raftmeta::MetaNode;
 pub use raftmeta::MetaStore;
 pub use sled_serde::SledSerde;
+pub use sled_tree::SledTree;
+pub use sled_tree::SledValueToKey;
 pub use snapshot::Snapshot;
 pub use state_machine::Node;
 pub use state_machine::Slot;
@@ -61,5 +64,7 @@ mod raft_types_test;
 mod raftmeta_test;
 #[cfg(test)]
 mod sled_serde_test;
+#[cfg(test)]
+mod sled_tree_test;
 #[cfg(test)]
 mod state_machine_test;

--- a/fusestore/store/src/meta_service/sled_tree.rs
+++ b/fusestore/store/src/meta_service/sled_tree.rs
@@ -1,0 +1,235 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::marker::PhantomData;
+use std::ops::RangeBounds;
+
+use common_exception::ErrorCode;
+use common_exception::ToErrorCode;
+
+use crate::meta_service::sled_serde::SledOrderedSerde;
+use crate::meta_service::sled_serde::SledRangeSerde;
+use crate::meta_service::SledSerde;
+
+/// Extract key from a value of sled tree that includes its key.
+pub trait SledValueToKey<K> {
+    fn to_key(&self) -> K;
+}
+
+/// SledTree is a wrapper of sled::Tree that provides typed access.
+/// The key type `K` must be serializable with order preserved, i.e. impl trait `SledOrderedSerde`.
+/// The value type `V` can be any serialize impl, i.e. for most cases, to impl trait `SledSerde`.
+pub struct SledTree<K: SledOrderedSerde + Display + Debug, V: SledSerde> {
+    pub name: String,
+    pub(crate) tree: sled::Tree,
+    phantom_k: PhantomData<K>,
+    phantom_v: PhantomData<V>,
+}
+
+impl<K: SledOrderedSerde + Display + Debug, V: SledSerde> SledTree<K, V> {
+    /// Open SledTree
+    pub async fn open<N: AsRef<[u8]> + Display>(
+        db: &sled::Db,
+        tree_name: N,
+    ) -> common_exception::Result<Self> {
+        let t = db
+            .open_tree(&tree_name)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("open tree: {}", tree_name)
+            })?;
+
+        let rl = SledTree {
+            name: format!("{}", tree_name),
+            tree: t,
+            phantom_k: PhantomData,
+            phantom_v: PhantomData,
+        };
+        Ok(rl)
+    }
+
+    /// Retrieve the value of key.
+    pub fn get(&self, key: &K) -> common_exception::Result<Option<V>> {
+        let got = self
+            .tree
+            .get(key.ser()?)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("get: {}:{}", self.name, key)
+            })?;
+
+        let v = match got {
+            None => None,
+            Some(v) => Some(V::de(&v)?),
+        };
+
+        Ok(v)
+    }
+
+    /// Retrieve the last key value pair.
+    pub fn last(&self) -> common_exception::Result<Option<(K, V)>> {
+        let last = self
+            .tree
+            .last()
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("read last: {}", self.name)
+            })?;
+
+        let kv = match last {
+            Some((k, v)) => {
+                let key = K::de(&k)?;
+                let value = V::de(&v)?;
+                Some((key, value))
+            }
+            None => None,
+        };
+
+        Ok(kv)
+    }
+
+    /// Delete kvs that are in `range`.
+    pub async fn range_delete<R>(&self, range: R, flush: bool) -> common_exception::Result<()>
+    where R: RangeBounds<K> {
+        let mut batch = sled::Batch::default();
+
+        // Convert K range into sled::IVec range
+        let sled_range = range.ser()?;
+
+        let range_mes = self.range_message(&range);
+
+        for item in self.tree.range(sled_range) {
+            let (k, _) = item.map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("range_delete: {}", range_mes,)
+            })?;
+            batch.remove(k);
+        }
+
+        self.tree
+            .apply_batch(batch)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("batch delete: {}", range_mes,)
+            })?;
+
+        if flush {
+            self.tree
+                .flush_async()
+                .await
+                .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                    format!("flush range delete: {}", range_mes,)
+                })?;
+        }
+
+        Ok(())
+    }
+
+    /// Get values of key in `range`
+    pub fn range_get<R>(&self, range: R) -> common_exception::Result<Vec<V>>
+    where R: RangeBounds<K> {
+        // TODO(xp): pre alloc vec space
+        let mut res = vec![];
+
+        let range_mes = self.range_message(&range);
+
+        // Convert K range into sled::IVec range
+        let range = range.ser()?;
+        for item in self.tree.range(range) {
+            let (_, v) = item.map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("range_get: {}", range_mes,)
+            })?;
+
+            let ent = V::de(&v)?;
+            res.push(ent);
+        }
+
+        Ok(res)
+    }
+
+    /// Append many key-values into SledTree.
+    pub async fn append(&self, kvs: &[(K, V)]) -> common_exception::Result<()> {
+        let mut batch = sled::Batch::default();
+
+        for (key, value) in kvs.iter() {
+            let k = K::ser(key)?;
+            let v = V::ser(value)?;
+
+            batch.insert(k, v);
+        }
+
+        self.tree
+            .apply_batch(batch)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "batch append")?;
+
+        self.tree
+            .flush_async()
+            .await
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "flush append")?;
+
+        Ok(())
+    }
+    /// Append many values into SledTree.
+    /// This could be used in cases the key is included in value and a value should impl trait `IntoKey` to retrieve the key from a value.
+    pub async fn append_values(&self, values: &[V]) -> common_exception::Result<()>
+    where V: SledValueToKey<K> {
+        let mut batch = sled::Batch::default();
+
+        for value in values.iter() {
+            let key: K = value.to_key();
+
+            let k = key.ser()?;
+            let v = V::ser(value)?;
+
+            batch.insert(k, v);
+        }
+
+        self.tree
+            .apply_batch(batch)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "batch append_values")?;
+
+        self.tree
+            .flush_async()
+            .await
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "flush append_values")?;
+
+        Ok(())
+    }
+
+    /// Insert a single kv.
+    pub async fn insert(&self, key: &K, value: &V) -> common_exception::Result<()> {
+        let k = key.ser()?;
+        let v = value.ser()?;
+
+        self.tree
+            .insert(k, v)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("insert_value {}", key)
+            })?;
+
+        self.tree
+            .flush_async()
+            .await
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("flush insert_value {}", key)
+            })?;
+
+        Ok(())
+    }
+
+    /// Insert a single kv, Retrieve the key from value.
+    pub async fn insert_value(&self, value: &V) -> common_exception::Result<()>
+    where V: SledValueToKey<K> {
+        let key = value.to_key();
+        self.insert(&key, value).await
+    }
+
+    /// Build a string describing the range for a range operation.
+    fn range_message<R>(&self, range: &R) -> String
+    where R: RangeBounds<K> {
+        format!(
+            "{}:{:?} to {:?}",
+            self.name,
+            range.start_bound(),
+            range.end_bound()
+        )
+    }
+}

--- a/fusestore/store/src/meta_service/sled_tree_test.rs
+++ b/fusestore/store/src/meta_service/sled_tree_test.rs
@@ -1,0 +1,316 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use async_raft::raft::Entry;
+use async_raft::raft::EntryNormal;
+use async_raft::raft::EntryPayload;
+use async_raft::LogId;
+use common_runtime::tokio;
+
+use crate::meta_service::Cmd;
+use crate::meta_service::LogEntry;
+use crate::meta_service::LogIndex;
+use crate::meta_service::SledTree;
+use crate::tests::service::new_sled_test_context;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_tree_open() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    SledTree::<LogIndex, Entry<LogEntry>>::open(db, "foo").await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_tree_append() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+
+    let logs: Vec<(LogIndex, Entry<LogEntry>)> = vec![
+        (8, Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        }),
+        (5, Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        }),
+    ];
+
+    rl.append(&logs).await?;
+
+    let want: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    let got = rl.range_get(0..)?;
+    assert_eq!(want, got);
+
+    let got = rl.range_get(0..=5)?;
+    assert_eq!(want[0..1], got);
+
+    let got = rl.range_get(6..9)?;
+    assert_eq!(want[1..], got);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_tree_append_values_and_range_get() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 10 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId {
+                term: 1,
+                index: 256,
+            },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    rl.append_values(&logs).await?;
+
+    let got = rl.range_get(0..)?;
+    assert_eq!(logs, got);
+
+    let got = rl.range_get(0..=2)?;
+    assert_eq!(logs[0..1], got);
+
+    let got = rl.range_get(0..3)?;
+    assert_eq!(logs[0..1], got);
+
+    let got = rl.range_get(0..5)?;
+    assert_eq!(logs[0..2], got);
+
+    let got = rl.range_get(0..10)?;
+    assert_eq!(logs[0..3], got);
+
+    let got = rl.range_get(0..11)?;
+    assert_eq!(logs[0..4], got);
+
+    let got = rl.range_get(9..11)?;
+    assert_eq!(logs[2..4], got);
+
+    let got = rl.range_get(10..256)?;
+    assert_eq!(logs[3..4], got);
+
+    let got = rl.range_get(10..257)?;
+    assert_eq!(logs[3..5], got);
+
+    let got = rl.range_get(257..)?;
+    assert_eq!(logs[5..], got);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_tree_insert() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+
+    assert_eq!(None, rl.get(&5)?);
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    for log in logs.iter() {
+        rl.insert_value(log).await?;
+    }
+
+    assert_eq!(logs, rl.range_get(..)?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_tree_get() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+
+    assert_eq!(None, rl.get(&5)?);
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    rl.append_values(&logs).await?;
+
+    assert_eq!(None, rl.get(&1)?);
+    assert_eq!(Some(logs[0].clone()), rl.get(&2)?);
+    assert_eq!(None, rl.get(&3)?);
+    assert_eq!(Some(logs[1].clone()), rl.get(&4)?);
+    assert_eq!(None, rl.get(&5)?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_tree_last() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+
+    assert_eq!(None, rl.last()?);
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    rl.append_values(&logs).await?;
+    assert_eq!(Some((4, logs[1].clone())), rl.last()?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_tree_range_delete() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 10 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId {
+                term: 1,
+                index: 256,
+            },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    rl.append_values(&logs).await?;
+    rl.range_delete(0.., false).await?;
+    assert_eq!(logs[5..], rl.range_get(0..)?);
+
+    rl.append_values(&logs).await?;
+    rl.range_delete(1.., false).await?;
+    assert_eq!(logs[5..], rl.range_get(0..)?);
+
+    rl.append_values(&logs).await?;
+    rl.range_delete(3.., true).await?;
+    assert_eq!(logs[0..1], rl.range_get(0..)?);
+
+    rl.append_values(&logs).await?;
+    rl.range_delete(3..10, true).await?;
+    assert_eq!(logs[0..1], rl.range_get(0..5)?);
+    assert_eq!(logs[3..], rl.range_get(5..)?);
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: add SledTree<K, V> to provided typed access to sled tree.
- Add: SledTree: sled::Tree only support serialized key and value.
  Since we have several tree-like data: raft log, nodes in state machine
  or DFS keys. A generalized typed tree SledTree will simplify the impl
  of all these sled tree based data structures.

- Refactor: re-impl RaftLog with SledTree.

## Changelog

- New Feature





## Related Issues

#271

#1080 