### PR TITLE
[fix] remove the unused module

### DIFF
--- a/fusequery/query/benches/suites/mod.rs
+++ b/fusequery/query/benches/suites/mod.rs
@@ -7,8 +7,6 @@ use common_planners::PlanNode;
 use common_runtime::tokio;
 use criterion::Criterion;
 use fuse_query::interpreters::SelectInterpreter;
-use fuse_query::servers::MySQLConnection;
-use fuse_query::sessions::session_ref::SessionRef;
 use fuse_query::sessions::SessionManager;
 use fuse_query::sql::PlanParser;
 use futures::StreamExt;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

I get some warnings in vscode, so I try to fix it by remove the unused module.

```
module `session_ref` is private  private module
unused import: `fuse_query::servers::MySQLConnection`\n\nnote: `#[warn(unused_imports)]` on by default
```


## Changelog

- Bug Fix

## Related Issues


