### PR TITLE
[store] feature: SledTree::insert() returns the last set one if it overrides

### DIFF
--- a/fusestore/store/src/meta_service/raft_log.rs
+++ b/fusestore/store/src/meta_service/raft_log.rs
@@ -77,7 +77,10 @@ impl RaftLog {
     }
 
     /// Insert a single log.
-    pub async fn insert(&self, log: &Entry<LogEntry>) -> common_exception::Result<()> {
+    pub async fn insert(
+        &self,
+        log: &Entry<LogEntry>,
+    ) -> common_exception::Result<Option<Entry<LogEntry>>> {
         self.inner.insert_value(log).await
     }
 }

--- a/fusestore/store/src/meta_service/sled_tree_test.rs
+++ b/fusestore/store/src/meta_service/sled_tree_test.rs
@@ -234,6 +234,29 @@ async fn test_sled_tree_insert() -> anyhow::Result<()> {
 
     assert_eq!(logs, rl.range_get(..)?);
 
+    // insert and override
+
+    let override_2 = Entry {
+        log_id: LogId { term: 10, index: 2 },
+        payload: EntryPayload::Blank,
+    };
+
+    let prev = rl.insert_value(&override_2).await?;
+    assert_eq!(Some(logs[0].clone()), prev);
+
+    // insert and override nothing
+
+    let override_nothing = Entry {
+        log_id: LogId {
+            term: 10,
+            index: 100,
+        },
+        payload: EntryPayload::Blank,
+    };
+
+    let prev = rl.insert_value(&override_nothing).await?;
+    assert_eq!(None, prev);
+
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: SledTree::insert() returns the last set one if it overrides

## Changelog

- New Feature





## Related Issues

#271
#1080
