### PR TITLE
db meta versioning & Store API for syncing db meta

### DIFF
--- a/common/flights/src/impls/meta_api_impl.rs
+++ b/common/flights/src/impls/meta_api_impl.rs
@@ -9,6 +9,7 @@ use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
 pub use common_store_api::CreateDatabaseActionResult;
 pub use common_store_api::CreateTableActionResult;
+pub use common_store_api::DatabaseMetaReply;
 pub use common_store_api::DropDatabaseActionResult;
 pub use common_store_api::DropTableActionResult;
 pub use common_store_api::GetDatabaseActionResult;
@@ -69,6 +70,14 @@ impl MetaApi for StoreClient {
         table: String,
     ) -> common_exception::Result<GetTableActionResult> {
         self.do_action(GetTableAction { db, table }).await
+    }
+
+    async fn get_database_meta(
+        &mut self,
+        ver_lower_bound: Option<u64>,
+    ) -> common_exception::Result<DatabaseMetaReply> {
+        self.do_action(GetDatabaseMetaAction { ver_lower_bound })
+            .await
     }
 }
 
@@ -138,4 +147,17 @@ action_declare!(
     GetTableAction,
     GetTableActionResult,
     StoreDoAction::GetTable
+);
+
+// - get database meta
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
+pub struct GetDatabaseMetaAction {
+    pub ver_lower_bound: Option<u64>,
+}
+
+action_declare!(
+    GetDatabaseMetaAction,
+    DatabaseMetaReply,
+    StoreDoAction::GetDatabaseMeta
 );

--- a/common/flights/src/store_do_action.rs
+++ b/common/flights/src/store_do_action.rs
@@ -19,6 +19,7 @@ use crate::impls::meta_api_impl::CreateTableAction;
 use crate::impls::meta_api_impl::DropDatabaseAction;
 use crate::impls::meta_api_impl::DropTableAction;
 use crate::impls::meta_api_impl::GetDatabaseAction;
+use crate::impls::meta_api_impl::GetDatabaseMetaAction;
 use crate::impls::meta_api_impl::GetTableAction;
 use crate::impls::storage_api_impl::ReadPlanAction;
 use crate::protobuf::FlightStoreRequest;
@@ -45,15 +46,14 @@ macro_rules! action_declare {
 // Action wrapper for do_action.
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub enum StoreDoAction {
-    // meta-database
+    // database meta
     CreateDatabase(CreateDatabaseAction),
     GetDatabase(GetDatabaseAction),
     DropDatabase(DropDatabaseAction),
-    // meta-table
     CreateTable(CreateTableAction),
     DropTable(DropTableAction),
     GetTable(GetTableAction),
-    // storage
+    GetDatabaseMeta(GetDatabaseMetaAction),
     ReadPlan(ReadPlanAction),
 
     // general purpose kv

--- a/common/store-api/src/lib.rs
+++ b/common/store-api/src/lib.rs
@@ -13,6 +13,7 @@ pub use kv_api::PrefixListReply;
 pub use kv_api::UpsertKVActionResult;
 pub use meta_api::CreateDatabaseActionResult;
 pub use meta_api::CreateTableActionResult;
+pub use meta_api::DatabaseMetaReply;
 pub use meta_api::DropDatabaseActionResult;
 pub use meta_api::DropTableActionResult;
 pub use meta_api::GetDatabaseActionResult;

--- a/common/store-api/src/meta_api.rs
+++ b/common/store-api/src/meta_api.rs
@@ -4,6 +4,7 @@
 //
 
 use common_datavalues::DataSchemaRef;
+use common_metatypes::Database;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
@@ -39,6 +40,8 @@ pub struct GetTableActionResult {
     pub schema: DataSchemaRef,
 }
 
+pub type DatabaseMetaReply = Option<(u64, Vec<Database>)>;
+
 #[async_trait::async_trait]
 pub trait MetaApi {
     async fn create_database(
@@ -69,4 +72,9 @@ pub trait MetaApi {
         db: String,
         table: String,
     ) -> common_exception::Result<GetTableActionResult>;
+
+    async fn get_database_meta(
+        &mut self,
+        current_ver: Option<u64>,
+    ) -> common_exception::Result<Option<(u64, Vec<Database>)>>;
 }

--- a/fusestore/store/src/api/rpc/flight_service_test.rs
+++ b/fusestore/store/src/api/rpc/flight_service_test.rs
@@ -11,8 +11,12 @@ use common_flights::StorageApi;
 use common_flights::StoreClient;
 use common_metatypes::MatchSeq;
 use common_planners::CreateDatabasePlan;
+use common_planners::CreateTablePlan;
 use common_planners::DatabaseEngineType;
+use common_planners::DropDatabasePlan;
+use common_planners::DropTablePlan;
 use common_planners::ScanPlan;
+use common_planners::TableEngineType;
 use common_runtime::tokio;
 use common_tracing::tracing;
 use pretty_assertions::assert_eq;
@@ -580,6 +584,156 @@ async fn test_flight_generic_kv() -> anyhow::Result<()> {
         assert!(kv.result.is_some());
         assert_eq!(kv.result.unwrap().1, "brand new value".as_bytes());
     }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_flight_get_database_meta_empty_db() -> anyhow::Result<()> {
+    common_tracing::init_default_tracing();
+    let (_tc, addr) = crate::tests::start_store_server().await?;
+    let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    // Empty Database
+    let res = client.get_database_meta(None).await?;
+    assert_eq!(None, res);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_flight_get_database_meta_ddl_db() -> anyhow::Result<()> {
+    common_tracing::init_default_tracing();
+    let (_tc, addr) = crate::tests::start_store_server().await?;
+    let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    // create-db operation will increases meta_version
+    let plan = CreateDatabasePlan {
+        if_not_exists: false,
+        db: "db1".to_string(),
+        engine: DatabaseEngineType::Local,
+        options: Default::default(),
+    };
+    client.create_database(plan).await?;
+
+    let res = client.get_database_meta(None).await?;
+    assert!(res.is_some());
+    let (v, dbs) = res.unwrap();
+    assert_eq!(1, v);
+    assert_eq!(1, dbs.len());
+
+    // if lower_bound < current meta version, returns database meta
+    let res = client.get_database_meta(Some(0)).await?;
+    assert!(res.is_some());
+    let (v, dbs) = res.unwrap();
+    assert_eq!(1, v);
+    assert_eq!(1, dbs.len());
+
+    // if lower_bound equals current meta version, returns None
+    let res = client.get_database_meta(Some(1)).await?;
+    assert!(res.is_none());
+
+    // failed ddl do not effect meta version
+    let plan = CreateDatabasePlan {
+        if_not_exists: true, // <<--
+        db: "db1".to_string(),
+        engine: DatabaseEngineType::Local, // accepts a Local engine?
+        options: Default::default(),
+    };
+
+    client.create_database(plan).await?;
+    let res = client.get_database_meta(Some(1)).await?;
+    assert!(res.is_none());
+
+    // drop-db will increase meta version
+    let plan = DropDatabasePlan {
+        if_exists: true,
+        db: "db1".to_string(),
+    };
+
+    client.drop_database(plan).await?;
+    let res = client.get_database_meta(Some(1)).await?;
+    assert!(res.is_some());
+    let (v, dbs) = res.unwrap();
+    assert_eq!(2, v);
+    assert_eq!(0, dbs.len());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_flight_get_database_meta_ddl_table() -> anyhow::Result<()> {
+    common_tracing::init_default_tracing();
+    let (_, addr) = crate::tests::start_store_server().await?;
+    let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
+
+    let test_db = "db1";
+    let plan = CreateDatabasePlan {
+        if_not_exists: false,
+        db: test_db.to_string(),
+        engine: DatabaseEngineType::Local,
+        options: Default::default(),
+    };
+    client.create_database(plan).await?;
+
+    // After `create db`, meta_ver will be increased to 1
+
+    let schema = Arc::new(DataSchema::new(vec![DataField::new(
+        "number",
+        DataType::UInt64,
+        false,
+    )]));
+
+    // create-tbl operation will increases meta_version
+    let plan = CreateTablePlan {
+        if_not_exists: true,
+        db: test_db.to_string(),
+        table: "tbl1".to_string(),
+        schema: schema.clone(),
+        options: Default::default(),
+        engine: TableEngineType::JsonEachRaw,
+    };
+
+    client.create_table(plan.clone()).await?;
+
+    let res = client.get_database_meta(None).await?;
+    assert!(res.is_some());
+    let (v, dbs) = res.unwrap();
+    assert_eq!(2, v);
+    assert_eq!(1, dbs.len());
+    assert_eq!(1, dbs[0].tables.len());
+
+    // if lower_bound < current meta version, returns database meta
+    let res = client.get_database_meta(Some(0)).await?;
+    assert!(res.is_some());
+    let (v, dbs) = res.unwrap();
+    assert_eq!(2, v);
+    assert_eq!(1, dbs.len());
+
+    // if lower_bound equals current meta version, returns None
+    let res = client.get_database_meta(Some(2)).await?;
+    assert!(res.is_none());
+
+    // failed ddl do not effect meta version
+    //  recall: plan.if_not_exist == true
+    let r = client.create_table(plan).await?;
+    let res = client.get_database_meta(Some(2)).await?;
+    assert!(res.is_none());
+
+    // drop-table will increase meta version
+    let plan = DropTablePlan {
+        if_exists: true,
+        db: test_db.to_string(),
+        table: "tbl1".to_string(),
+    };
+
+    client.drop_table(plan).await;
+    let res = client.get_database_meta(Some(2)).await?;
+    assert!(res.is_some());
+    let (v, dbs) = res.unwrap();
+    assert_eq!(3, v);
+    assert_eq!(1, dbs.len());
+    assert_eq!(0, dbs[0].tables.len());
 
     Ok(())
 }

--- a/fusestore/store/src/executor/action_handler.rs
+++ b/fusestore/store/src/executor/action_handler.rs
@@ -110,6 +110,7 @@ impl ActionHandler {
             StoreDoAction::CreateDatabase(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::GetDatabase(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::DropDatabase(a) => s.serialize(self.handle(a).await?),
+            StoreDoAction::GetDatabaseMeta(a) => s.serialize(self.handle(a).await?),
 
             // table
             StoreDoAction::CreateTable(a) => s.serialize(self.handle(a).await?),

--- a/fusestore/store/src/executor/meta_handlers.rs
+++ b/fusestore/store/src/executor/meta_handlers.rs
@@ -15,12 +15,14 @@ use common_flights::meta_api_impl::CreateDatabaseAction;
 use common_flights::meta_api_impl::CreateDatabaseActionResult;
 use common_flights::meta_api_impl::CreateTableAction;
 use common_flights::meta_api_impl::CreateTableActionResult;
+use common_flights::meta_api_impl::DatabaseMetaReply;
 use common_flights::meta_api_impl::DropDatabaseAction;
 use common_flights::meta_api_impl::DropDatabaseActionResult;
 use common_flights::meta_api_impl::DropTableAction;
 use common_flights::meta_api_impl::DropTableActionResult;
 use common_flights::meta_api_impl::GetDatabaseAction;
 use common_flights::meta_api_impl::GetDatabaseActionResult;
+use common_flights::meta_api_impl::GetDatabaseMetaAction;
 use common_flights::meta_api_impl::GetTableAction;
 use common_flights::meta_api_impl::GetTableActionResult;
 use common_metatypes::Database;
@@ -290,5 +292,15 @@ impl RequestHandler<GetTableAction> for ActionHandler {
             }
             None => Err(ErrorCode::UnknownTable(table_name)),
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestHandler<GetDatabaseMetaAction> for ActionHandler {
+    async fn handle(
+        &self,
+        req: GetDatabaseMetaAction,
+    ) -> common_exception::Result<DatabaseMetaReply> {
+        Ok(self.meta_node.get_database_meta(req.ver_lower_bound).await)
     }
 }

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -858,6 +858,23 @@ impl MetaNode {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
+    pub async fn get_database_meta(
+        &self,
+        lower_bound: Option<u64>,
+    ) -> Option<(u64, Vec<Database>)> {
+        // inconsistent get: from local state machine
+
+        let sm = self.sto.state_machine.read().await;
+        let ver = sm.get_database_meta_ver();
+        if ver <= lower_bound {
+            None
+        } else {
+            let dbs = sm.get_databases();
+            Some((ver.unwrap_or(0), dbs.values().cloned().collect()))
+        }
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn get_table(&self, tid: &u64) -> Option<Table> {
         // inconsistent get: from local state machine
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

- adds version info to database metadata, which will be increased by one for each successful modification of the database metadata.
- extends store_api::meta_api for synchronizing database metadata by version

## Changelog

- New Feature


## Related Issues

Part of #992 
Closes #1168

## Test Plan

Unit Tests

Stateless Tests

