### PR TITLE
[store] feature: add SledVarTypeTree to store more than one types of key-value in one sled::Tree.

### DIFF
--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -16,6 +16,8 @@ pub mod raft_types;
 pub mod raftmeta;
 pub mod sled_serde;
 pub mod sled_tree;
+pub mod sled_vartype_tree;
+pub mod sledkv;
 pub mod snapshot;
 pub mod state_machine;
 
@@ -33,9 +35,11 @@ pub use raft_types::NodeId;
 pub use raft_types::Term;
 pub use raftmeta::MetaNode;
 pub use raftmeta::MetaStore;
+pub use sled_serde::SledOrderedSerde;
 pub use sled_serde::SledSerde;
 pub use sled_tree::SledTree;
 pub use sled_tree::SledValueToKey;
+pub use sled_vartype_tree::SledVarTypeTree;
 pub use snapshot::Snapshot;
 pub use state_machine::Node;
 pub use state_machine::Slot;
@@ -66,5 +70,7 @@ mod raftmeta_test;
 mod sled_serde_test;
 #[cfg(test)]
 mod sled_tree_test;
+#[cfg(test)]
+mod sled_vartype_tree_test;
 #[cfg(test)]
 mod state_machine_test;

--- a/fusestore/store/src/meta_service/raft_types.rs
+++ b/fusestore/store/src/meta_service/raft_types.rs
@@ -2,11 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use async_raft::LogId;
 pub use async_raft::NodeId;
 use byteorder::BigEndian;
 use byteorder::ByteOrder;
+use common_exception::ErrorCode;
+use sled::IVec;
 
 use crate::meta_service::sled_serde::SledOrderedSerde;
+use crate::meta_service::SledSerde;
 
 pub type LogIndex = u64;
 pub type Term = u64;
@@ -21,3 +25,26 @@ impl SledOrderedSerde for u64 {
         BigEndian::read_u64(buf)
     }
 }
+
+/// For LogId to be able to stored in sled::Tree as a key.
+impl SledOrderedSerde for String {
+    fn ser(&self) -> Result<IVec, ErrorCode> {
+        Ok(IVec::from(self.as_str()))
+    }
+
+    fn de<V: AsRef<[u8]>>(v: V) -> Result<Self, ErrorCode>
+    where Self: Sized {
+        Ok(String::from_utf8(v.as_ref().to_vec())?)
+    }
+
+    fn order_preserved_serialize(&self, _buf: &mut [u8]) {
+        todo!()
+    }
+
+    fn order_preserved_deserialize(_buf: &[u8]) -> Self {
+        todo!()
+    }
+}
+
+/// For LogId to be able to stored in sled::Tree as a value.
+impl SledSerde for LogId {}

--- a/fusestore/store/src/meta_service/sled_vartype_tree.rs
+++ b/fusestore/store/src/meta_service/sled_vartype_tree.rs
@@ -1,0 +1,302 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::fmt::Display;
+use std::ops::Bound;
+use std::ops::RangeBounds;
+
+use common_exception::ErrorCode;
+use common_exception::ToErrorCode;
+
+use crate::meta_service::sledkv::SledKV;
+use crate::meta_service::SledValueToKey;
+
+/// SledVarTypeTree is a wrapper of sled::Tree that provides access of more than one key-value
+/// types.
+/// A `SledKVType` defines a key-value type to be stored.
+/// The key type `K` must be serializable with order preserved, i.e. impl trait `SledOrderedSerde`.
+/// The value type `V` can be any serialize impl, i.e. for most cases, to impl trait `SledSerde`.
+pub struct SledVarTypeTree {
+    pub name: String,
+    pub(crate) tree: sled::Tree,
+}
+
+impl SledVarTypeTree {
+    /// Open SledVarTypeTree
+    pub async fn open<N: AsRef<[u8]> + Display>(
+        db: &sled::Db,
+        tree_name: N,
+    ) -> common_exception::Result<Self> {
+        let t = db
+            .open_tree(&tree_name)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("open tree: {}", tree_name)
+            })?;
+
+        let rl = SledVarTypeTree {
+            name: format!("{}", tree_name),
+            tree: t,
+        };
+        Ok(rl)
+    }
+
+    /// Return true if the tree contains the key.
+    pub fn contains_key<KV: SledKV>(&self, key: &KV::K) -> common_exception::Result<bool>
+    where KV: SledKV {
+        let got = self
+            .tree
+            .contains_key(KV::serialize_key(key)?)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("contains_key: {}:{}", self.name, key)
+            })?;
+
+        Ok(got)
+    }
+
+    /// Retrieve the value of key.
+    pub fn get<KV: SledKV>(&self, key: &KV::K) -> common_exception::Result<Option<KV::V>>
+    where KV: SledKV {
+        let got = self
+            .tree
+            .get(KV::serialize_key(key)?)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("get: {}:{}", self.name, key)
+            })?;
+
+        let v = match got {
+            None => None,
+            Some(v) => Some(KV::deserialize_value(v)?),
+        };
+
+        Ok(v)
+    }
+
+    /// Retrieve the last key value pair.
+    pub fn last<KV>(&self) -> common_exception::Result<Option<(KV::K, KV::V)>>
+    where KV: SledKV {
+        // TODO(xp): last should be limited to the value range
+
+        let range = (
+            Bound::Unbounded,
+            KV::serialize_bound(Bound::Unbounded, "right")?,
+        );
+
+        let mut it = self.tree.range(range).rev();
+        let last = it.next();
+        let last = match last {
+            None => {
+                return Ok(None);
+            }
+            Some(res) => res,
+        };
+
+        let last = last.map_err_to_code(ErrorCode::MetaStoreDamaged, || "last")?;
+
+        let (k, v) = last;
+        let key = KV::deserialize_key(k)?;
+        let value = KV::deserialize_value(v)?;
+        Ok(Some((key, value)))
+    }
+
+    /// Delete kvs that are in `range`.
+    pub async fn range_delete<KV, R>(&self, range: R, flush: bool) -> common_exception::Result<()>
+    where
+        KV: SledKV,
+        R: RangeBounds<KV::K>,
+    {
+        let mut batch = sled::Batch::default();
+
+        // Convert K range into sled::IVec range
+        let sled_range = KV::serialize_range(&range)?;
+
+        let range_mes = self.range_message::<KV, _>(&range);
+
+        for item in self.tree.range(sled_range) {
+            let (k, _) = item.map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("range_delete: {}", range_mes,)
+            })?;
+            batch.remove(k);
+        }
+
+        self.tree
+            .apply_batch(batch)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("batch delete: {}", range_mes,)
+            })?;
+
+        if flush {
+            self.tree
+                .flush_async()
+                .await
+                .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                    format!("flush range delete: {}", range_mes,)
+                })?;
+        }
+
+        Ok(())
+    }
+
+    /// Get keys in `range`
+    pub fn range_keys<KV, R>(&self, range: R) -> common_exception::Result<Vec<KV::K>>
+    where
+        KV: SledKV,
+        R: RangeBounds<KV::K>,
+    {
+        let mut res = vec![];
+
+        let range_mes = self.range_message::<KV, _>(&range);
+
+        // Convert K range into sled::IVec range
+        let range = KV::serialize_range(&range)?;
+        for item in self.tree.range(range) {
+            let (k, _) = item.map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("range_get: {}", range_mes,)
+            })?;
+
+            let key = KV::deserialize_key(k)?;
+            res.push(key);
+        }
+
+        Ok(res)
+    }
+
+    /// Get values of key in `range`
+    pub fn range_get<KV, R>(&self, range: R) -> common_exception::Result<Vec<KV::V>>
+    where
+        KV: SledKV,
+        R: RangeBounds<KV::K>,
+    {
+        let mut res = vec![];
+
+        let range_mes = self.range_message::<KV, _>(&range);
+
+        // Convert K range into sled::IVec range
+        let range = KV::serialize_range(&range)?;
+
+        for item in self.tree.range(range) {
+            let (_, v) = item.map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("range_get: {}", range_mes,)
+            })?;
+
+            let ent = KV::deserialize_value(v)?;
+            res.push(ent);
+        }
+
+        Ok(res)
+    }
+
+    /// Append many key-values into SledVarTypeTree.
+    pub async fn append<KV>(&self, kvs: &[(KV::K, KV::V)]) -> common_exception::Result<()>
+    where KV: SledKV {
+        let mut batch = sled::Batch::default();
+
+        for (key, value) in kvs.iter() {
+            let k = KV::serialize_key(key)?;
+            let v = KV::serialize_value(value)?;
+
+            batch.insert(k, v);
+        }
+
+        self.tree
+            .apply_batch(batch)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "batch append")?;
+
+        self.tree
+            .flush_async()
+            .await
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "flush append")?;
+
+        Ok(())
+    }
+
+    /// Append many values into SledVarTypeTree.
+    /// This could be used in cases the key is included in value and a value should impl trait `IntoKey` to retrieve the key from a value.
+    pub async fn append_values<KV>(&self, values: &[KV::V]) -> common_exception::Result<()>
+    where
+        KV: SledKV,
+        KV::V: SledValueToKey<KV::K>,
+    {
+        let mut batch = sled::Batch::default();
+
+        for value in values.iter() {
+            let key: KV::K = value.to_key();
+
+            let k = KV::serialize_key(&key)?;
+            let v = KV::serialize_value(value)?;
+
+            batch.insert(k, v);
+        }
+
+        self.tree
+            .apply_batch(batch)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "batch append_values")?;
+
+        self.tree
+            .flush_async()
+            .await
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "flush append_values")?;
+
+        Ok(())
+    }
+
+    /// Insert a single kv.
+    /// Returns the last value if it is set.
+    pub async fn insert<KV>(
+        &self,
+        key: &KV::K,
+        value: &KV::V,
+    ) -> common_exception::Result<Option<KV::V>>
+    where
+        KV: SledKV,
+    {
+        let k = KV::serialize_key(key)?;
+        let v = KV::serialize_value(value)?;
+
+        let prev = self
+            .tree
+            .insert(k, v)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("insert_value {}", key)
+            })?;
+
+        let prev = match prev {
+            None => None,
+            Some(x) => Some(KV::deserialize_value(x)?),
+        };
+
+        self.tree
+            .flush_async()
+            .await
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
+                format!("flush insert_value {}", key)
+            })?;
+
+        Ok(prev)
+    }
+
+    /// Insert a single kv, Retrieve the key from value.
+    pub async fn insert_value<KV>(&self, value: &KV::V) -> common_exception::Result<Option<KV::V>>
+    where
+        KV: SledKV,
+        KV::V: SledValueToKey<KV::K>,
+    {
+        let key = value.to_key();
+        self.insert::<KV>(&key, value).await
+    }
+
+    /// Build a string describing the range for a range operation.
+    fn range_message<KV, R>(&self, range: &R) -> String
+    where
+        KV: SledKV,
+        R: RangeBounds<KV::K>,
+    {
+        format!(
+            "{}:{}/[{:?}, {:?}]",
+            self.name,
+            KV::NAME,
+            range.start_bound(),
+            range.end_bound()
+        )
+    }
+}

--- a/fusestore/store/src/meta_service/sled_vartype_tree_test.rs
+++ b/fusestore/store/src/meta_service/sled_vartype_tree_test.rs
@@ -1,0 +1,498 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use async_raft::raft::Entry;
+use async_raft::raft::EntryNormal;
+use async_raft::raft::EntryPayload;
+use async_raft::LogId;
+use common_runtime::tokio;
+
+use crate::meta_service::sledkv;
+use crate::meta_service::Cmd;
+use crate::meta_service::LogEntry;
+use crate::meta_service::LogIndex;
+use crate::meta_service::SledVarTypeTree;
+use crate::tests::service::new_sled_test_context;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_vartype_tree_open() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    SledVarTypeTree::open(db, "foo").await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_vartype_tree_append() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+
+    let logs: Vec<(LogIndex, Entry<LogEntry>)> = vec![
+        (8, Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        }),
+        (5, Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        }),
+    ];
+
+    tree.append::<sledkv::Logs>(&logs).await?;
+
+    let want: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    let got = tree.range_get::<sledkv::Logs, _>(0..)?;
+    assert_eq!(want, got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(0..=5)?;
+    assert_eq!(want[0..1], got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(6..9)?;
+    assert_eq!(want[1..], got);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_vartype_tree_append_values_and_range_get() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 10 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId {
+                term: 1,
+                index: 256,
+            },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    tree.append_values::<sledkv::Logs>(&logs).await?;
+
+    let got = tree.range_get::<sledkv::Logs, _>(0..)?;
+    assert_eq!(logs, got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(0..=2)?;
+    assert_eq!(logs[0..1], got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(0..3)?;
+    assert_eq!(logs[0..1], got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(0..5)?;
+    assert_eq!(logs[0..2], got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(0..10)?;
+    assert_eq!(logs[0..3], got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(0..11)?;
+    assert_eq!(logs[0..4], got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(9..11)?;
+    assert_eq!(logs[2..4], got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(10..256)?;
+    assert_eq!(logs[3..4], got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(10..257)?;
+    assert_eq!(logs[3..5], got);
+
+    let got = tree.range_get::<sledkv::Logs, _>(257..)?;
+    assert_eq!(logs[5..], got);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_vartype_tree_range_keys() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 10 },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    tree.append_values::<sledkv::Logs>(&logs).await?;
+
+    let got = tree.range_keys::<sledkv::Logs, _>(0..)?;
+    assert_eq!(vec![2, 9, 10], got);
+
+    let got = tree.range_keys::<sledkv::Logs, _>(0..=2)?;
+    assert_eq!(vec![2], got);
+
+    let got = tree.range_keys::<sledkv::Logs, _>(0..3)?;
+    assert_eq!(vec![2], got);
+
+    let got = tree.range_keys::<sledkv::Logs, _>(0..10)?;
+    assert_eq!(vec![2, 9], got);
+
+    let got = tree.range_keys::<sledkv::Logs, _>(0..11)?;
+    assert_eq!(vec![2, 9, 10], got);
+
+    let got = tree.range_keys::<sledkv::Logs, _>(9..11)?;
+    assert_eq!(vec![9, 10], got);
+
+    let got = tree.range_keys::<sledkv::Logs, _>(10..256)?;
+    assert_eq!(vec![10], got);
+
+    let got = tree.range_keys::<sledkv::Logs, _>(11..)?;
+    assert_eq!(Vec::<LogIndex>::new(), got);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_vartype_tree_insert() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+
+    assert!(tree.get::<sledkv::Logs>(&5)?.is_none());
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    for log in logs.iter() {
+        tree.insert_value::<sledkv::Logs>(log).await?;
+    }
+
+    assert_eq!(logs, tree.range_get::<sledkv::Logs, _>(..)?);
+
+    // insert and override
+
+    let override_2 = Entry {
+        log_id: LogId { term: 10, index: 2 },
+        payload: EntryPayload::Blank,
+    };
+
+    let prev = tree.insert_value::<sledkv::Logs>(&override_2).await?;
+    assert_eq!(Some(logs[0].clone()), prev);
+
+    // insert and override nothing
+
+    let override_nothing = Entry {
+        log_id: LogId {
+            term: 10,
+            index: 100,
+        },
+        payload: EntryPayload::Blank,
+    };
+
+    let prev = tree.insert_value::<sledkv::Logs>(&override_nothing).await?;
+    assert_eq!(None, prev);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_vartype_tree_contains_key() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+
+    assert!(tree.get::<sledkv::Logs>(&5)?.is_none());
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    tree.append_values::<sledkv::Logs>(&logs).await?;
+
+    assert!(!tree.contains_key::<sledkv::Logs>(&1)?);
+    assert!(tree.contains_key::<sledkv::Logs>(&2)?);
+    assert!(!tree.contains_key::<sledkv::Logs>(&3)?);
+    assert!(tree.contains_key::<sledkv::Logs>(&4)?);
+    assert!(!tree.contains_key::<sledkv::Logs>(&5)?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_vartype_tree_get() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+
+    assert!(tree.get::<sledkv::Logs>(&5)?.is_none());
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    tree.append_values::<sledkv::Logs>(&logs).await?;
+
+    assert_eq!(None, tree.get::<sledkv::Logs>(&1)?);
+    assert_eq!(Some(logs[0].clone()), tree.get::<sledkv::Logs>(&2)?);
+    assert_eq!(None, tree.get::<sledkv::Logs>(&3)?);
+    assert_eq!(Some(logs[1].clone()), tree.get::<sledkv::Logs>(&4)?);
+    assert_eq!(None, tree.get::<sledkv::Logs>(&5)?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_vartype_tree_last() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+
+    assert!(tree.last::<sledkv::Logs>()?.is_none());
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    tree.append_values::<sledkv::Logs>(&logs).await?;
+    assert_eq!(None, tree.last::<sledkv::SMMeta>()?);
+
+    let metas = vec![
+        ("meta1".to_string(), LogId { term: 1, index: 2 }),
+        ("meta2".to_string(), LogId { term: 2, index: 2 }),
+    ];
+
+    tree.append::<sledkv::SMMeta>(&metas).await?;
+
+    assert_eq!(Some((4, logs[1].clone())), tree.last::<sledkv::Logs>()?);
+    assert_eq!(
+        Some(("meta2".to_string(), LogId { term: 2, index: 2 })),
+        tree.last::<sledkv::SMMeta>()?
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_vartype_tree_range_delete() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 10 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId {
+                term: 1,
+                index: 256,
+            },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    tree.append_values::<sledkv::Logs>(&logs).await?;
+    tree.range_delete::<sledkv::Logs, _>(0.., false).await?;
+    assert_eq!(logs[5..], tree.range_get::<sledkv::Logs, _>(0..)?);
+
+    tree.append_values::<sledkv::Logs>(&logs).await?;
+    tree.range_delete::<sledkv::Logs, _>(1.., false).await?;
+    assert_eq!(logs[5..], tree.range_get::<sledkv::Logs, _>(0..)?);
+
+    tree.append_values::<sledkv::Logs>(&logs).await?;
+    tree.range_delete::<sledkv::Logs, _>(3.., true).await?;
+    assert_eq!(logs[0..1], tree.range_get::<sledkv::Logs, _>(0..)?);
+
+    tree.append_values::<sledkv::Logs>(&logs).await?;
+    tree.range_delete::<sledkv::Logs, _>(3..10, true).await?;
+    assert_eq!(logs[0..1], tree.range_get::<sledkv::Logs, _>(0..5)?);
+    assert_eq!(logs[3..], tree.range_get::<sledkv::Logs, _>(5..)?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_sled_vartype_tree_multi_types() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    tree.append_values::<sledkv::Logs>(&logs).await?;
+
+    let metas = vec![
+        ("meta1".to_string(), LogId { term: 1, index: 2 }),
+        ("meta2".to_string(), LogId { term: 2, index: 2 }),
+    ];
+    tree.append::<sledkv::SMMeta>(&metas).await?;
+
+    // range get/keys are limited to its own namespace.
+    {
+        let got = tree.range_get::<sledkv::Logs, _>(..)?;
+        assert_eq!(logs, got);
+
+        let got = tree.range_get::<sledkv::SMMeta, _>(..="meta1".to_string())?;
+        assert_eq!(vec![LogId { term: 1, index: 2 }], got);
+
+        let got = tree.range_get::<sledkv::SMMeta, _>("meta2".to_string()..)?;
+        assert_eq!(vec![LogId { term: 2, index: 2 }], got);
+
+        let got = tree.range_keys::<sledkv::SMMeta, _>("meta2".to_string()..)?;
+        assert_eq!(vec!["meta2".to_string()], got);
+    }
+
+    // range delete are limited to its own namespace.
+    {
+        tree.range_delete::<sledkv::SMMeta, _>(.., false).await?;
+
+        let got = tree.range_get::<sledkv::Logs, _>(..)?;
+        assert_eq!(logs, got);
+    }
+
+    Ok(())
+}

--- a/fusestore/store/src/meta_service/sledkv.rs
+++ b/fusestore/store/src/meta_service/sledkv.rs
@@ -1,0 +1,122 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+//! sledkv defines several key-value types to be used in sled::Tree, as an raft storage impl.
+
+use std::fmt::Debug;
+use std::fmt::Display;
+use std::ops::Bound;
+use std::ops::RangeBounds;
+
+use async_raft::raft::Entry;
+use async_raft::LogId;
+use common_exception::ErrorCode;
+use sled::IVec;
+
+use crate::meta_service::LogEntry;
+use crate::meta_service::LogIndex;
+use crate::meta_service::Node;
+use crate::meta_service::NodeId;
+use crate::meta_service::SledOrderedSerde;
+use crate::meta_service::SledSerde;
+
+/// Defines a key-value type to be stored in SledVarTypeTree.
+pub trait SledKV {
+    /// Prefix is a unique u8 that is prepended before the serialized key, to identify a namespace in sled::Tree.
+    const PREFIX: u8;
+
+    /// The for human name of this key-value type.
+    const NAME: &'static str;
+
+    /// Type for key.
+    type K: SledOrderedSerde + Display + Debug;
+
+    /// Type for value.
+    type V: SledSerde;
+
+    fn serialize_key(k: &Self::K) -> Result<sled::IVec, ErrorCode> {
+        let b = k.ser()?;
+        let x = b.as_ref();
+
+        let mut buf = Vec::with_capacity(1 + x.len());
+        buf.push(Self::PREFIX);
+        buf.extend_from_slice(x);
+
+        Ok(buf.into())
+    }
+
+    fn deserialize_key<T: AsRef<[u8]>>(iv: T) -> Result<Self::K, ErrorCode> {
+        let b = iv.as_ref();
+        if b[0] != Self::PREFIX {
+            return Err(ErrorCode::MetaStoreDamaged("invalid prefix"));
+        }
+        Self::K::de(&b[1..])
+    }
+
+    fn serialize_value(v: &Self::V) -> Result<sled::IVec, ErrorCode> {
+        v.ser()
+    }
+
+    fn deserialize_value<T: AsRef<[u8]>>(iv: T) -> Result<Self::V, ErrorCode> {
+        Self::V::de(iv)
+    }
+
+    /// Convert range of user key to range of sled::IVec for query.
+    fn serialize_range<R>(range: &R) -> Result<(Bound<IVec>, Bound<IVec>), ErrorCode>
+    where R: RangeBounds<Self::K> {
+        let s = range.start_bound();
+        let e = range.end_bound();
+
+        let s = Self::serialize_bound(s, "left")?;
+        let e = Self::serialize_bound(e, "right")?;
+
+        Ok((s, e))
+    }
+
+    /// Convert user key range bound to sled::IVec bound.
+    /// A u8 prefix is prepended to the bound value and an open bound is converted to a namespaced bound.
+    /// E.g., use the [PREFIX] as the left side closed bound,
+    /// and use the [PREFIX+1] as the right side open bound.
+    fn serialize_bound(v: Bound<&Self::K>, dir: &str) -> Result<Bound<sled::IVec>, ErrorCode> {
+        let res = match v {
+            Bound::Included(v) => Bound::Included(Self::serialize_key(v)?),
+            Bound::Excluded(v) => Bound::Excluded(Self::serialize_key(v)?),
+            Bound::Unbounded => {
+                if dir == "left" {
+                    Bound::Included(IVec::from(&[Self::PREFIX]))
+                } else {
+                    Bound::Excluded(IVec::from(&[Self::PREFIX + 1]))
+                }
+            }
+        };
+        Ok(res)
+    }
+}
+
+/// Types for meta data of a raft state machine, e.g. the last applied log id.
+pub struct SMMeta {}
+impl SledKV for SMMeta {
+    const PREFIX: u8 = 0;
+    const NAME: &'static str = "meta";
+    type K = String;
+    type V = LogId;
+}
+
+/// Types for raft log in SledVarTypeTree
+pub struct Logs {}
+impl SledKV for Logs {
+    const PREFIX: u8 = 1;
+    const NAME: &'static str = "log";
+    type K = LogIndex;
+    type V = Entry<LogEntry>;
+}
+
+/// Types for Node in SledVarTypeTree
+pub struct Nodes {}
+impl SledKV for Nodes {
+    const PREFIX: u8 = 2;
+    const NAME: &'static str = "node";
+    type K = NodeId;
+    type V = Node;
+}

--- a/fusestore/store/src/meta_service/state_machine.rs
+++ b/fusestore/store/src/meta_service/state_machine.rs
@@ -28,6 +28,7 @@ use crate::meta_service::Cmd;
 use crate::meta_service::LogEntry;
 use crate::meta_service::NodeId;
 use crate::meta_service::Placement;
+use crate::meta_service::SledSerde;
 
 /// seq number key to generate seq for the value of a `generic_kv` record.
 const SEQ_GENERIC_KV: &str = "generic_kv";
@@ -489,6 +490,9 @@ impl Display for Node {
         write!(f, "{}={}", self.name, self.address)
     }
 }
+
+/// For Node to be able to be stored in sled::Tree as a value.
+impl SledSerde for Node {}
 
 impl Placement for StateMachine {
     fn get_slots(&self) -> &[Slot] {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: add SledVarTypeTree to store more than one types of key-value in one sled::Tree.
SledVarTypeTree is a candidate as raft state machine store.
Storing all state(such as last applied log index or internal seq number counter) in one tree makes transactional update or snapshot creation much easier.

## Changelog

- New Feature





## Related Issues

#271

#1080 