### PR TITLE
[store] feature: SledVarTypeTree::as_type() borrows the tree and limit accesses to a specified namespace

### DIFF
--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -39,6 +39,7 @@ pub use sled_serde::SledOrderedSerde;
 pub use sled_serde::SledSerde;
 pub use sled_tree::SledTree;
 pub use sled_tree::SledValueToKey;
+pub use sled_vartype_tree::AsType;
 pub use sled_vartype_tree::SledVarTypeTree;
 pub use snapshot::Snapshot;
 pub use state_machine::Node;

--- a/fusestore/store/src/meta_service/sled_vartype_tree_test.rs
+++ b/fusestore/store/src/meta_service/sled_vartype_tree_test.rs
@@ -496,3 +496,475 @@ async fn test_sled_vartype_tree_multi_types() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+// --- AsType test ---
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_as_append() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let aslog = tree.as_type::<sledkv::Logs>();
+
+    let logs: Vec<(LogIndex, Entry<LogEntry>)> = vec![
+        (8, Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        }),
+        (5, Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        }),
+    ];
+
+    aslog.append(&logs).await?;
+
+    let want: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    let got = aslog.range_get(0..)?;
+    assert_eq!(want, got);
+
+    let got = aslog.range_get(0..=5)?;
+    assert_eq!(want[0..1], got);
+
+    let got = aslog.range_get(6..9)?;
+    assert_eq!(want[1..], got);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_as_append_values_and_range_get() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let aslog = tree.as_type::<sledkv::Logs>();
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 10 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId {
+                term: 1,
+                index: 256,
+            },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    aslog.append_values(&logs).await?;
+
+    let got = aslog.range_get(0..)?;
+    assert_eq!(logs, got);
+
+    let got = aslog.range_get(0..=2)?;
+    assert_eq!(logs[0..1], got);
+
+    let got = aslog.range_get(0..3)?;
+    assert_eq!(logs[0..1], got);
+
+    let got = aslog.range_get(0..5)?;
+    assert_eq!(logs[0..2], got);
+
+    let got = aslog.range_get(0..10)?;
+    assert_eq!(logs[0..3], got);
+
+    let got = aslog.range_get(0..11)?;
+    assert_eq!(logs[0..4], got);
+
+    let got = aslog.range_get(9..11)?;
+    assert_eq!(logs[2..4], got);
+
+    let got = aslog.range_get(10..256)?;
+    assert_eq!(logs[3..4], got);
+
+    let got = aslog.range_get(10..257)?;
+    assert_eq!(logs[3..5], got);
+
+    let got = aslog.range_get(257..)?;
+    assert_eq!(logs[5..], got);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_as_range_keys() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let aslog = tree.as_type::<sledkv::Logs>();
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 10 },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    aslog.append_values(&logs).await?;
+
+    let got = aslog.range_keys(0..)?;
+    assert_eq!(vec![2, 9, 10], got);
+
+    let got = aslog.range_keys(0..=2)?;
+    assert_eq!(vec![2], got);
+
+    let got = aslog.range_keys(0..3)?;
+    assert_eq!(vec![2], got);
+
+    let got = aslog.range_keys(0..10)?;
+    assert_eq!(vec![2, 9], got);
+
+    let got = aslog.range_keys(0..11)?;
+    assert_eq!(vec![2, 9, 10], got);
+
+    let got = aslog.range_keys(9..11)?;
+    assert_eq!(vec![9, 10], got);
+
+    let got = aslog.range_keys(10..256)?;
+    assert_eq!(vec![10], got);
+
+    let got = aslog.range_keys(11..)?;
+    assert_eq!(Vec::<LogIndex>::new(), got);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_as_insert() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let aslog = tree.as_type::<sledkv::Logs>();
+
+    assert_eq!(None, aslog.get(&5)?);
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    for log in logs.iter() {
+        aslog.insert_value(log).await?;
+    }
+
+    assert_eq!(logs, aslog.range_get(..)?);
+
+    // insert and override
+
+    let override_2 = Entry {
+        log_id: LogId { term: 10, index: 2 },
+        payload: EntryPayload::Blank,
+    };
+
+    let prev = aslog.insert_value(&override_2).await?;
+    assert_eq!(Some(logs[0].clone()), prev);
+
+    // insert and override nothing
+
+    let override_nothing = Entry {
+        log_id: LogId {
+            term: 10,
+            index: 100,
+        },
+        payload: EntryPayload::Blank,
+    };
+
+    let prev = aslog.insert_value(&override_nothing).await?;
+    assert_eq!(None, prev);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_as_contains_key() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let aslog = tree.as_type::<sledkv::Logs>();
+
+    assert_eq!(None, aslog.get(&5)?);
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    aslog.append_values(&logs).await?;
+
+    assert!(!aslog.contains_key(&1)?);
+    assert!(aslog.contains_key(&2)?);
+    assert!(!aslog.contains_key(&3)?);
+    assert!(aslog.contains_key(&4)?);
+    assert!(!aslog.contains_key(&5)?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_as_get() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let aslog = tree.as_type::<sledkv::Logs>();
+
+    assert_eq!(None, aslog.get(&5)?);
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    aslog.append_values(&logs).await?;
+
+    assert_eq!(None, aslog.get(&1)?);
+    assert_eq!(Some(logs[0].clone()), aslog.get(&2)?);
+    assert_eq!(None, aslog.get(&3)?);
+    assert_eq!(Some(logs[1].clone()), aslog.get(&4)?);
+    assert_eq!(None, aslog.get(&5)?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_as_last() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let aslog = tree.as_type::<sledkv::Logs>();
+
+    assert_eq!(None, aslog.last()?);
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    aslog.append_values(&logs).await?;
+    assert_eq!(Some((4, logs[1].clone())), aslog.last()?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_as_range_delete() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let aslog = tree.as_type::<sledkv::Logs>();
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 10 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId {
+                term: 1,
+                index: 256,
+            },
+            payload: EntryPayload::Blank,
+        },
+    ];
+
+    aslog.append_values(&logs).await?;
+    aslog.range_delete(0.., false).await?;
+    assert_eq!(logs[5..], aslog.range_get(0..)?);
+
+    aslog.append_values(&logs).await?;
+    aslog.range_delete(1.., false).await?;
+    assert_eq!(logs[5..], aslog.range_get(0..)?);
+
+    aslog.append_values(&logs).await?;
+    aslog.range_delete(3.., true).await?;
+    assert_eq!(logs[0..1], aslog.range_get(0..)?);
+
+    aslog.append_values(&logs).await?;
+    aslog.range_delete(3..10, true).await?;
+    assert_eq!(logs[0..1], aslog.range_get(0..5)?);
+    assert_eq!(logs[3..], aslog.range_get(5..)?);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_as_multi_types() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let aslog = tree.as_type::<sledkv::Logs>();
+    let asmeta = tree.as_type::<sledkv::SMMeta>();
+
+    let logs: Vec<Entry<LogEntry>> = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::Blank,
+        },
+        Entry {
+            log_id: LogId { term: 3, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "foo".to_string(),
+                    },
+                },
+            }),
+        },
+    ];
+
+    aslog.append_values(&logs).await?;
+
+    let metas = vec![
+        ("meta1".to_string(), LogId { term: 1, index: 2 }),
+        ("meta2".to_string(), LogId { term: 2, index: 2 }),
+    ];
+    asmeta.append(&metas).await?;
+
+    // range get/keys are limited to its own namespace.
+    {
+        let got = aslog.range_get(..)?;
+        assert_eq!(logs, got);
+
+        let got = asmeta.range_get(..="meta1".to_string())?;
+        assert_eq!(vec![LogId { term: 1, index: 2 }], got);
+
+        let got = asmeta.range_get("meta2".to_string()..)?;
+        assert_eq!(vec![LogId { term: 2, index: 2 }], got);
+
+        let got = asmeta.range_keys("meta2".to_string()..)?;
+        assert_eq!(vec!["meta2".to_string()], got);
+    }
+
+    // range delete are limited to its own namespace.
+    {
+        asmeta.range_delete(.., false).await?;
+
+        let got = aslog.range_get(..)?;
+        assert_eq!(logs, got);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: SledVarTypeTree::as_type() borrows the tree and limit accesses to a specified namespace

## Changelog

- New Feature





## Related Issues

#271

#1080 