### PR TITLE
STORE-1157: add admin REST api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,6 +1767,7 @@ dependencies = [
  "common-infallible",
  "common-metatypes",
  "common-planners",
+ "common-profling",
  "common-runtime",
  "common-tracing",
  "env_logger 0.9.0",
@@ -1797,6 +1798,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "uuid",
+ "warp",
 ]
 
 [[package]]

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -26,6 +26,7 @@ common-functions = {path = "../../common/functions"}
 common-infallible = {path = "../../common/infallible"}
 common-metatypes = {path = "../../common/metatypes"}
 common-planners = {path = "../../common/planners"}
+common-profling = { path = "../../common/profiling" }
 common-runtime = {path = "../../common/runtime"}
 common-tracing = {path = "../../common/tracing"}
 
@@ -59,8 +60,9 @@ thiserror = "1.0.26"
 threadpool = "1.8.1"
 tokio-stream = "0.1"
 tonic = "0.4.3"
-uuid = { version = "0.8", features = ["serde", "v4"] }
 sha2 = "0.9.5"
+uuid = { version = "0.8", features = ["serde", "v4"] }
+warp = { version = "0.3.1", features = ["tls"] }
 
 [dev-dependencies]
 env_logger = "*"

--- a/fusestore/store/src/api/http/debug/home.rs
+++ b/fusestore/store/src/api/http/debug/home.rs
@@ -1,0 +1,43 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::num::NonZeroI32;
+
+use warp::Filter;
+
+use crate::api::http::debug::pprof::pprof_handler;
+use crate::configs::Config;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct PProfRequest {
+    #[serde(default = "PProfRequest::default_seconds")]
+    pub(crate) seconds: u64,
+    #[serde(default = "PProfRequest::default_frequency")]
+    pub(crate) frequency: NonZeroI32,
+}
+
+impl PProfRequest {
+    fn default_seconds() -> u64 {
+        5
+    }
+    fn default_frequency() -> NonZeroI32 {
+        NonZeroI32::new(99).unwrap()
+    }
+}
+
+pub fn debug_handler(
+    cfg: Config,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    debug_home_handler().or(pprof_handler(cfg))
+}
+
+fn debug_home_handler() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone
+{
+    warp::path!("debug").map(move || {
+        warp::reply::html(format!(
+            r#"<a href="/debug/pprof/profile?seconds={}">pprof/profile</a>"#,
+            PProfRequest::default_seconds()
+        ))
+    })
+}

--- a/fusestore/store/src/api/http/debug/mod.rs
+++ b/fusestore/store/src/api/http/debug/mod.rs
@@ -1,0 +1,8 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+pub mod home;
+pub mod pprof;
+
+pub use home::PProfRequest;

--- a/fusestore/store/src/api/http/debug/pprof.rs
+++ b/fusestore/store/src/api/http/debug/pprof.rs
@@ -1,0 +1,50 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use warp::Filter;
+
+use crate::api::http::debug::PProfRequest;
+use crate::configs::Config;
+
+pub fn pprof_handler(
+    _cfg: Config,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("debug" / "pprof" / "profile")
+        .and(warp::get())
+        .and(warp::header::optional::<String>("Accept"))
+        .and(warp::query::<PProfRequest>())
+        .and_then(handlers::pprof)
+}
+
+mod handlers {
+    use std::time::Duration;
+
+    use common_profling::Profiling;
+    use common_tracing::tracing;
+
+    use crate::api::http::debug::pprof::PProfRequest;
+
+    pub async fn pprof(
+        header: Option<String>,
+        req: PProfRequest,
+    ) -> Result<impl warp::Reply, std::convert::Infallible> {
+        let body;
+        let duration = Duration::from_secs(req.seconds);
+        let profile = Profiling::create(duration, req.frequency.get());
+
+        tracing::info!("start pprof request:{:?}", req);
+        if let Some(accept) = header {
+            // Browser.
+            if accept.contains("text/html") {
+                body = profile.dump_flamegraph().await.unwrap();
+            } else {
+                body = profile.dump_proto().await.unwrap();
+            }
+        } else {
+            body = profile.dump_proto().await.unwrap();
+        }
+        tracing::info!("finished pprof request:{:?}", req);
+        Ok(warp::reply::html(body))
+    }
+}

--- a/fusestore/store/src/api/http/mod.rs
+++ b/fusestore/store/src/api/http/mod.rs
@@ -1,0 +1,7 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+pub mod debug;
+pub mod router;
+pub mod v1;

--- a/fusestore/store/src/api/http/router.rs
+++ b/fusestore/store/src/api/http/router.rs
@@ -1,0 +1,27 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use common_exception::Result;
+use warp::Filter;
+
+use crate::configs::Config;
+
+pub struct Router {
+    cfg: Config,
+}
+
+impl Router {
+    pub fn create(cfg: Config) -> Self {
+        Router { cfg }
+    }
+
+    pub fn router(
+        &self,
+    ) -> Result<impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone> {
+        let v1 = super::v1::config::config_handler(self.cfg.clone())
+            .or(super::debug::home::debug_handler(self.cfg.clone()));
+        let routes = v1.with(warp::log("v1"));
+        Ok(routes)
+    }
+}

--- a/fusestore/store/src/api/http/v1/config.rs
+++ b/fusestore/store/src/api/http/v1/config.rs
@@ -1,0 +1,13 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use warp::Filter;
+
+use crate::configs::Config;
+
+pub fn config_handler(
+    cfg: Config,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("v1" / "configs").map(move || format!("{:?}", cfg))
+}

--- a/fusestore/store/src/api/http/v1/mod.rs
+++ b/fusestore/store/src/api/http/v1/mod.rs
@@ -1,0 +1,5 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+pub mod config;

--- a/fusestore/store/src/api/http_service.rs
+++ b/fusestore/store/src/api/http_service.rs
@@ -1,0 +1,43 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use common_exception::Result;
+
+use crate::api::http::router::Router;
+use crate::configs::Config;
+
+pub struct HttpService {
+    cfg: Config,
+}
+
+impl HttpService {
+    pub fn create(cfg: Config) -> Self {
+        HttpService { cfg }
+    }
+
+    pub async fn start(&mut self) -> Result<()> {
+        let router = Router::create(self.cfg.clone());
+        let server = warp::serve(router.router()?);
+
+        let conf = self.cfg.clone();
+        let tls_cert = conf.tls_server_cert;
+        let tls_key = conf.tls_server_key;
+
+        let address = conf.http_api_address.parse::<std::net::SocketAddr>()?;
+
+        if !tls_cert.is_empty() && !tls_key.is_empty() {
+            log::info!("Http API TLS enabled");
+            server
+                .tls()
+                .cert_path(tls_cert)
+                .key_path(tls_key)
+                .run(address)
+                .await;
+        } else {
+            log::warn!("Http API TLS not set");
+            server.run(address).await;
+        }
+        Ok(())
+    }
+}

--- a/fusestore/store/src/api/mod.rs
+++ b/fusestore/store/src/api/mod.rs
@@ -4,7 +4,10 @@
 
 // The api module only used for internal communication, such as GRPC between cluster and the managed HTTP REST API.
 
+mod http;
+mod http_service;
 pub mod rpc;
 mod rpc_service;
 
+pub use http_service::HttpService;
 pub use rpc_service::StoreServer;

--- a/fusestore/store/src/bin/fuse-store.rs
+++ b/fusestore/store/src/bin/fuse-store.rs
@@ -4,6 +4,7 @@
 
 use common_runtime::tokio;
 use common_tracing::init_tracing_with_file;
+use fuse_store::api::HttpService;
 use fuse_store::api::StoreServer;
 use fuse_store::configs::Config;
 use fuse_store::metrics::MetricService;
@@ -34,6 +35,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             srv.make_server().expect("Metrics service error");
         });
         info!("Metric API server listening on {}", conf.metric_api_address);
+    }
+
+    // HTTP API service.
+    {
+        let mut srv = HttpService::create(conf.clone());
+        info!("HTTP API server listening on {}", conf.http_api_address);
+        tokio::spawn(async move {
+            srv.start().await.expect("HTTP: admin api error");
+        });
     }
 
     // RPC API service.

--- a/fusestore/store/src/configs/config.rs
+++ b/fusestore/store/src/configs/config.rs
@@ -41,6 +41,15 @@ pub struct Config {
     )]
     pub metric_api_address: String,
 
+    #[structopt(long, env = "HTTP_API_ADDRESS", default_value = "127.0.0.1:8181")]
+    pub http_api_address: String,
+
+    #[structopt(long, env = "TLS_SERVER_CERT", default_value = "")]
+    pub tls_server_cert: String,
+
+    #[structopt(long, env = "TLS_SERVER_KEY", default_value = "")]
+    pub tls_server_key: String,
+
     #[structopt(
         long,
         env = "FUSE_STORE_FLIGHT_API_ADDRESS",


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Add admin REST api:
1. debug: http://127.0.0.1:8181/debug
2. configs: http://127.0.0.1:8181/v1/configs

Others could be add if required.

## Changelog

- New Feature


## Related Issues

Fixes #1157

## Test Plan

Unit Tests

Stateless Tests

