### PR TITLE
[common/tracing] fix: enable setting tracing level from env: RUST_LOG=debug

### DIFF
--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -20,18 +20,20 @@ pub fn init_default_tracing() {
     static START: Once = Once::new();
 
     START.call_once(|| {
-        init_tracing_stdout("error");
+        init_tracing_stdout();
     });
 }
 
-fn init_tracing_stdout(level: &str) {
+fn init_tracing_stdout() {
     let fmt_layer = fmt::Layer::default()
         .with_thread_ids(true)
+        .with_thread_names(true)
+        .pretty()
         .with_ansi(true)
         .with_span_events(fmt::format::FmtSpan::FULL);
 
     let subscriber = Registry::default()
-        .with(EnvFilter::new(level))
+        .with(EnvFilter::from_default_env())
         .with(fmt_layer);
 
     tracing::subscriber::set_global_default(subscriber)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [common/tracing] fix: enable setting tracing level from env: RUST_LOG=debug

Currently the log level is hard coded in common/tracing.

It need to be turned on by env variable `RUST_LOG`.

When output to stdout, use pretty format:
![image](https://user-images.githubusercontent.com/44069/127113316-cf96bad0-0438-493b-8c42-bd97ebbad794.png)


## Changelog


- Bug Fix




