### PR TITLE
[store] refactor: when testing, generate unique address for services

### DIFF
--- a/fusestore/store/src/tests/mod.rs
+++ b/fusestore/store/src/tests/mod.rs
@@ -8,6 +8,5 @@ pub mod seq;
 
 pub use seq::Seq;
 pub use service::assert_meta_connection;
-pub use service::next_local_addr;
 pub use service::next_port;
 pub use service::start_store_server;

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use common_runtime::tokio;
+use common_tracing::tracing;
 use tempfile::tempdir;
 use tempfile::TempDir;
 
@@ -18,13 +19,9 @@ use crate::tests::Seq;
 
 // Start one random service and get the session manager.
 pub async fn start_store_server() -> Result<(StoreTestContext, String)> {
-    let mut tc = new_test_context();
+    let tc = new_test_context();
 
-    let addr = next_local_addr();
-
-    // TODO(xp): when testing, new_test_context() should build a random addr for flight
-    //           and fs storage dir
-    tc.config.flight_api_address = addr.clone();
+    let addr = tc.config.flight_api_address.clone();
 
     let srv = StoreServer::create(tc.config.clone());
     tokio::spawn(async move {
@@ -42,11 +39,6 @@ pub fn next_port() -> u32 {
     19000u32 + (*Seq::default() as u32)
 }
 
-pub fn next_local_addr() -> String {
-    let port: u32 = next_port();
-    format!("127.0.0.1:{}", port)
-}
-
 pub struct StoreTestContext {
     #[allow(dead_code)]
     meta_temp_dir: TempDir,
@@ -60,8 +52,27 @@ pub fn new_test_context() -> StoreTestContext {
 
     config.meta_api_port = next_port();
 
+    let host = "127.0.0.1";
+
+    {
+        let flight_port = next_port();
+        config.flight_api_address = format!("{}:{}", host, flight_port);
+    }
+
+    {
+        let http_port = next_port();
+        config.http_api_address = format!("{}:{}", host, http_port);
+    }
+
+    {
+        let metric_port = next_port();
+        config.metric_api_address = format!("{}:{}", host, metric_port);
+    }
+
     let t = tempdir().expect("create temp dir to store meta");
     config.meta_dir = t.path().to_str().unwrap().to_string();
+
+    tracing::info!("new test context config: {:?}", config);
 
     StoreTestContext {
         // hold the TempDir until being dropped.


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: when testing, generate unique address for services

## Changelog




- Improvement


## Related Issues

#271