### PR TITLE
[common/tracing] feature: report distributed tracing stat to jaeger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,10 +882,15 @@ dependencies = [
 name = "common-tracing"
 version = "0.1.0"
 dependencies = [
+ "common-runtime",
+ "opentelemetry",
+ "opentelemetry-jaeger",
+ "tonic",
  "tracing",
  "tracing-appender",
  "tracing-bunyan-formatter",
  "tracing-futures",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -3115,6 +3120,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff27b33e30432e7b9854936693ca103d8591b0501f7ae9f633de48cda3bf2a67"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel 0.5.1",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand 0.8.4",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-jaeger"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a9fc8192722e7daa0c56e59e2336b797122fb8598383dcb11c8852733b435c"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "opentelemetry",
+ "thiserror",
+ "thrift",
+]
+
+[[package]]
 name = "ordered-float"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5068,6 +5103,19 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c47440f2979c4cd3138922840eec122e3c0ba2148bc290f756bd7fd60fc97fff"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/common/flights/src/impls/kv_api_impl.rs
+++ b/common/flights/src/impls/kv_api_impl.rs
@@ -10,6 +10,7 @@ pub use common_store_api::kv_api::PrefixListReply;
 pub use common_store_api::kv_api::UpsertKVActionResult;
 pub use common_store_api::GetKVActionResult;
 use common_store_api::KVApi;
+use common_tracing::tracing;
 
 use crate::action_declare;
 use crate::RequestFor;
@@ -18,6 +19,7 @@ use crate::StoreDoAction;
 
 #[async_trait::async_trait]
 impl KVApi for StoreClient {
+    #[tracing::instrument(level = "debug", skip(self, value))]
     async fn upsert_kv(
         &mut self,
         key: &str,
@@ -35,6 +37,7 @@ impl KVApi for StoreClient {
     /// Delete a kv record that matches key and seq.
     /// Returns the (seq, value) that is deleted.
     /// I.e., if key not found or seq does not match, it returns None.
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_kv(&mut self, key: &str, seq: Option<u64>) -> Result<Option<SeqValue>> {
         let res = self
             .do_action(DeleteKVReq {
@@ -52,6 +55,7 @@ impl KVApi for StoreClient {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_kv(&mut self, key: &str) -> Result<GetKVActionResult> {
         self.do_action(GetKVAction {
             key: key.to_string(),
@@ -59,12 +63,14 @@ impl KVApi for StoreClient {
         .await
     }
 
+    #[tracing::instrument(level = "debug", skip(self, keys))]
     async fn mget_kv(&mut self, keys: &[String]) -> common_exception::Result<MGetKVActionResult> {
         let keys = keys.to_vec();
         //keys.iter().map(|k| k.to_string()).collect();
         self.do_action(MGetKVAction { keys }).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn prefix_list_kv(&mut self, prefix: &str) -> common_exception::Result<PrefixListReply> {
         self.do_action(PrefixListReq(prefix.to_string())).await
     }

--- a/common/flights/src/store_client.rs
+++ b/common/flights/src/store_client.rs
@@ -10,6 +10,7 @@ use common_arrow::arrow_flight::Action;
 use common_arrow::arrow_flight::BasicAuth;
 use common_arrow::arrow_flight::HandshakeRequest;
 use common_exception::ErrorCode;
+use common_tracing::tracing;
 use futures::stream;
 use futures::StreamExt;
 use log::info;
@@ -34,6 +35,7 @@ pub struct StoreClient {
 static AUTH_TOKEN_KEY: &str = "auth-token-bin";
 
 impl StoreClient {
+    #[tracing::instrument(level = "debug", skip(password))]
     pub async fn try_create(addr: &str, username: &str, password: &str) -> anyhow::Result<Self> {
         // TODO configuration
         let timeout = Duration::from_secs(60);
@@ -65,6 +67,7 @@ impl StoreClient {
     }
 
     /// Handshake.
+    #[tracing::instrument(level = "debug", skip(client, password))]
     async fn handshake(
         client: &mut FlightServiceClient<Channel>,
         timeout: Duration,
@@ -94,6 +97,7 @@ impl StoreClient {
         Ok(token)
     }
 
+    #[tracing::instrument(level = "debug", skip(self, v))]
     pub(crate) async fn do_action<T, R>(&mut self, v: T) -> common_exception::Result<R>
     where
         T: RequestFor<Reply = R>,
@@ -101,7 +105,9 @@ impl StoreClient {
         R: DeserializeOwned,
     {
         let act: StoreDoAction = v.into();
-        let mut req: Request<Action> = (&act).try_into()?;
+        let req: Request<Action> = (&act).try_into()?;
+        let mut req = common_tracing::inject_span_to_tonic_request(req);
+
         req.set_timeout(self.timeout);
 
         let mut stream = self.client.do_action(req).await?.into_inner();

--- a/common/tracing/Cargo.toml
+++ b/common/tracing/Cargo.toml
@@ -7,8 +7,14 @@ publish = false
 edition = "2018"
 
 [dependencies] # In alphabetical order
+common-runtime = {path = "../runtime"}
+
+opentelemetry = { version = "0.15", default-features = false, features = ["trace"] }
+opentelemetry-jaeger = "0.14"
+tonic = "0.4.3"
 tracing = "0.1.26"
 tracing-appender = "0.1.2"
 tracing-bunyan-formatter = "0.2"
 tracing-futures = { version = "0.2.5", default-features = false }
+tracing-opentelemetry = "0.14.0"
 tracing-subscriber = "0.2.19"

--- a/common/tracing/src/lib.rs
+++ b/common/tracing/src/lib.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 mod logging;
+mod tracing_to_jaeger;
 
 pub use logging::init_default_tracing;
 pub use logging::init_tracing_with_file;
 pub use tracing;
+pub use tracing_to_jaeger::extract_remote_span_as_parent;
+pub use tracing_to_jaeger::inject_span_to_tonic_request;

--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -2,8 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use std::env;
 use std::sync::Once;
 
+use opentelemetry::global;
+use opentelemetry::sdk::propagation::TraceContextPropagator;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_appender::rolling::RollingFileAppender;
 use tracing_appender::rolling::Rotation;
@@ -32,9 +35,32 @@ fn init_tracing_stdout() {
         .with_ansi(true)
         .with_span_events(fmt::format::FmtSpan::FULL);
 
+    // Enable reporting tracing data to jaeger if FUSE_JAEGER is non-empty.
+    // Start a local jaeger server and report tracing data and view it:
+    //   docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
+    //   FUSE_JAEGER=on RUST_LOG=trace cargo test
+    //   open http://localhost:16686/
+
+    // TODO(xp): use FUSE_JAEGER to assign jaeger server address.
+    let fuse_jaeger = env::var("FUSE_JAEGER").unwrap_or_else(|_| "".to_string());
+    let ot_layer = if !fuse_jaeger.is_empty() {
+        global::set_text_map_propagator(TraceContextPropagator::new());
+
+        let tracer = opentelemetry_jaeger::new_pipeline()
+            .with_service_name("fuse-store")
+            .install_simple()
+            .expect("install");
+
+        let ot_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+        Some(ot_layer)
+    } else {
+        None
+    };
+
     let subscriber = Registry::default()
         .with(EnvFilter::from_default_env())
-        .with(fmt_layer);
+        .with(fmt_layer)
+        .with(ot_layer);
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("error setting global tracing subscriber");

--- a/common/tracing/src/tracing_to_jaeger.rs
+++ b/common/tracing/src/tracing_to_jaeger.rs
@@ -1,0 +1,79 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use opentelemetry::global;
+use opentelemetry::propagation::Extractor;
+use opentelemetry::propagation::Injector;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// Inject tracing info into tonic request meta.
+struct MetadataMapInjector<'a>(&'a mut tonic::metadata::MetadataMap);
+
+impl<'a> Injector for MetadataMapInjector<'a> {
+    /// Set a key and value in the MetadataMap.  Does nothing if the key or value are not valid inputs
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes()) {
+            if let Ok(val) = tonic::metadata::MetadataValue::from_str(&value) {
+                self.0.insert(key, val);
+            }
+        }
+    }
+}
+
+/// Extract tracing info from tonic request meta.
+struct MetadataMapExtractor<'a>(&'a tonic::metadata::MetadataMap);
+
+impl<'a> Extractor for MetadataMapExtractor<'a> {
+    /// Get a value for a key from the MetadataMap.  If the value can't be converted to &str, returns None
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|metadata| metadata.to_str().ok())
+    }
+
+    /// Collect all the keys from the MetadataMap.
+    fn keys(&self) -> Vec<&str> {
+        self.0
+            .keys()
+            .map(|key| match key {
+                tonic::metadata::KeyRef::Ascii(v) => v.as_str(),
+                tonic::metadata::KeyRef::Binary(v) => v.as_str(),
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+/// Inject current tracing::Span info into tonic request meta
+/// before sending request to a tonic server.
+/// Then the tonic server will be able to chain a distributed tracing.
+///
+/// A tonic client should call this function just before sending out the request.
+///
+/// The global propagater must be installed, e.g. by calling: TODO
+pub fn inject_span_to_tonic_request<T>(mes: impl tonic::IntoRequest<T>) -> tonic::Request<T> {
+    let curr = tracing::Span::current();
+    let cx = curr.context();
+
+    let mut request = mes.into_request();
+
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(&cx, &mut MetadataMapInjector(request.metadata_mut()))
+    });
+
+    request
+}
+
+/// Extract tracing context from tonic request meta
+/// and set current tracing::Span parent to the context from remote,
+/// to chain the client side span with current server side span.
+///
+/// A tonic request handler should call this before doing anything else.
+///
+/// The global propagater must be installed, e.g. by calling: TODO
+pub fn extract_remote_span_as_parent<T>(request: &tonic::Request<T>) {
+    let parent_cx = global::get_text_map_propagator(|prop| {
+        prop.extract(&MetadataMapExtractor(request.metadata()))
+    });
+
+    let span = tracing::Span::current();
+    span.set_parent(parent_cx);
+}

--- a/fusestore/store/src/meta_service/meta_service_impl.rs
+++ b/fusestore/store/src/meta_service/meta_service_impl.rs
@@ -36,6 +36,8 @@ impl MetaService for MetaServiceImpl {
         &self,
         request: tonic::Request<RaftMes>,
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
+        common_tracing::extract_remote_span_as_parent(&request);
+
         let mes = request.into_inner();
         let req: LogEntry = mes.try_into()?;
 
@@ -54,6 +56,8 @@ impl MetaService for MetaServiceImpl {
         &self,
         request: tonic::Request<GetReq>,
     ) -> Result<tonic::Response<GetReply>, tonic::Status> {
+        common_tracing::extract_remote_span_as_parent(&request);
+
         let req = request.into_inner();
         let resp = self.meta_node.get_file(&req.key).await;
         let rst = match resp {
@@ -77,6 +81,8 @@ impl MetaService for MetaServiceImpl {
         &self,
         request: tonic::Request<RaftMes>,
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
+        common_tracing::extract_remote_span_as_parent(&request);
+
         let req = request.into_inner();
 
         let ae_req =
@@ -102,6 +108,8 @@ impl MetaService for MetaServiceImpl {
         &self,
         request: tonic::Request<RaftMes>,
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
+        common_tracing::extract_remote_span_as_parent(&request);
+
         let req = request.into_inner();
 
         let is_req =
@@ -127,6 +135,8 @@ impl MetaService for MetaServiceImpl {
         &self,
         request: tonic::Request<RaftMes>,
     ) -> Result<tonic::Response<RaftMes>, tonic::Status> {
+        common_tracing::extract_remote_span_as_parent(&request);
+
         let req = request.into_inner();
 
         let v_req =

--- a/fusestore/store/src/meta_service/raft_log.rs
+++ b/fusestore/store/src/meta_service/raft_log.rs
@@ -6,6 +6,7 @@ use std::ops::Deref;
 use std::ops::RangeBounds;
 
 use async_raft::raft::Entry;
+use common_tracing::tracing;
 
 use crate::meta_service::LogEntry;
 use crate::meta_service::LogIndex;
@@ -77,6 +78,7 @@ impl RaftLog {
     }
 
     /// Insert a single log.
+    #[tracing::instrument(level = "debug", skip(self, log), fields(log_id=format!("{}",log.log_id).as_str()))]
     pub async fn insert(
         &self,
         log: &Entry<LogEntry>,

--- a/fusestore/store/src/tests/mod.rs
+++ b/fusestore/store/src/tests/mod.rs
@@ -8,6 +8,5 @@ pub mod seq;
 
 pub use seq::Seq;
 pub use service::assert_meta_connection;
-pub use service::next_local_addr;
 pub use service::next_port;
 pub use service::start_store_server;

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -18,6 +18,7 @@ use crate::meta_service::MetaServiceClient;
 use crate::tests::Seq;
 
 // Start one random service and get the session manager.
+#[tracing::instrument(level = "info")]
 pub async fn start_store_server() -> Result<(StoreTestContext, String)> {
     let tc = new_test_context();
 

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use common_runtime::tokio;
+use common_tracing::tracing;
 use tempfile::tempdir;
 use tempfile::TempDir;
 
@@ -18,13 +19,9 @@ use crate::tests::Seq;
 
 // Start one random service and get the session manager.
 pub async fn start_store_server() -> Result<(StoreTestContext, String)> {
-    let mut tc = new_test_context();
+    let tc = new_test_context();
 
-    let addr = next_local_addr();
-
-    // TODO(xp): when testing, new_test_context() should build a random addr for flight
-    //           and fs storage dir
-    tc.config.flight_api_address = addr.clone();
+    let addr = tc.config.flight_api_address.clone();
 
     let srv = StoreServer::create(tc.config.clone());
     tokio::spawn(async move {
@@ -42,11 +39,6 @@ pub fn next_port() -> u32 {
     19000u32 + (*Seq::default() as u32)
 }
 
-pub fn next_local_addr() -> String {
-    let port: u32 = next_port();
-    format!("127.0.0.1:{}", port)
-}
-
 pub struct StoreTestContext {
     #[allow(dead_code)]
     meta_temp_dir: TempDir,
@@ -60,8 +52,27 @@ pub fn new_test_context() -> StoreTestContext {
 
     config.meta_api_port = next_port();
 
+    let host = "127.0.0.1";
+
+    {
+        let flight_port = next_port();
+        config.flight_api_address = format!("{}:{}", host, flight_port);
+    }
+
+    {
+        let http_port = next_port();
+        config.http_api_address = format!("{}:{}", host, http_port);
+    }
+
+    {
+        let metric_port = next_port();
+        config.metric_api_address = format!("{}:{}", host, metric_port);
+    }
+
     let t = tempdir().expect("create temp dir to store meta");
     config.meta_dir = t.path().to_str().unwrap().to_string();
+
+    tracing::info!("new test context config: {:?}", config);
 
     StoreTestContext {
         // hold the TempDir until being dropped.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [common/tracing] feature: report distributed tracing stat to jaeger
Start a local jaeger server and report tracing data and view it:

```
docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
FUSE_JAEGER=on RUST_LOG=trace cargo test
open http://localhost:16686/
```

-   Add: report tracing data to opentelemetry server(jaeger) with env
    `FUSE_JAEGER=on`

-   Add tracing::instrument to store flight server and meta server.

-   Inject tracing span to tonic request on the client side
    and extract them on the server side to form a complete tracing.

-   Add tracing to SledTree

<img width="646" alt="截屏2021-07-29 下午1 57 40" src="https://user-images.githubusercontent.com/44069/127443277-378224a0-836d-429a-94d1-e199c5552b9b.png">

TODO: 

- Sometimes the spans messes up with the parent-child relationship. Maybe caused by abnormal thread switching?
- Chaining the span when a work was sent through channel etc.

## Changelog

- New Feature


- Improvement


## Related Issues

#271

