### PR TITLE
ISSUE 1228: Use batch mode to speed up tracing data sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,6 +3134,8 @@ dependencies = [
  "pin-project",
  "rand 0.8.4",
  "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/common/tracing/Cargo.toml
+++ b/common/tracing/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies] # In alphabetical order
 common-runtime = {path = "../runtime"}
 
-opentelemetry = { version = "0.15", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.15", default-features = false, features = ["trace", "rt-tokio"] }
 opentelemetry-jaeger = "0.14"
 tonic = "0.4.3"
 tracing = "0.1.26"

--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -48,7 +48,7 @@ fn init_tracing_stdout() {
 
         let tracer = opentelemetry_jaeger::new_pipeline()
             .with_service_name("fuse-store")
-            .install_simple()
+            .install_batch(opentelemetry::runtime::Tokio)
             .expect("install");
 
         let ot_layer = tracing_opentelemetry::layer().with_tracer(tracer);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

solve #1228
use batch mode to speed up tracing data sending

## Changelog

- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

