### PR TITLE
[store] fix: do not fsync sled data in unittets. File::sync_all() takes 10 ~ 30 ms, at worst 500 ms on a Mac

### DIFF
--- a/fusestore/store/src/configs/config.rs
+++ b/fusestore/store/src/configs/config.rs
@@ -81,6 +81,16 @@ pub struct Config {
     )]
     pub meta_dir: String,
 
+    #[structopt(
+        long,
+        env = "FUSE_STORE_META_NO_SYNC",
+        help = concat!("Whether to fsync meta to disk for every meta write(raft log, state machine etc).",
+                      " No-sync brings risks of data loss during a crash.",
+                      " You should only use this in a testing environment, unless YOU KNOW WHAT YOU ARE DOING."
+        ),
+    )]
+    pub meta_no_sync: bool,
+
     // raft config
     #[structopt(
         long,
@@ -119,5 +129,10 @@ impl Config {
 
     pub fn meta_api_addr(&self) -> String {
         format!("{}:{}", self.meta_api_host, self.meta_api_port)
+    }
+
+    /// Returns true to fsync after a write operation to meta.
+    pub fn meta_sync(&self) -> bool {
+        !self.meta_no_sync
     }
 }

--- a/fusestore/store/src/meta_service/raft_log.rs
+++ b/fusestore/store/src/meta_service/raft_log.rs
@@ -8,6 +8,7 @@ use std::ops::RangeBounds;
 use async_raft::raft::Entry;
 use common_tracing::tracing;
 
+use crate::configs;
 use crate::meta_service::LogEntry;
 use crate::meta_service::LogIndex;
 use crate::meta_service::SledSerde;
@@ -41,9 +42,12 @@ impl SledValueToKey<LogIndex> for Entry<LogEntry> {
 
 impl RaftLog {
     /// Open RaftLog
-    pub async fn open(db: &sled::Db) -> common_exception::Result<RaftLog> {
+    pub async fn open(
+        db: &sled::Db,
+        config: &configs::Config,
+    ) -> common_exception::Result<RaftLog> {
         let rl = RaftLog {
-            inner: SledTree::open(db, TREE_RAFT_LOG).await?,
+            inner: SledTree::open(db, TREE_RAFT_LOG, config.meta_sync()).await?,
         };
         Ok(rl)
     }

--- a/fusestore/store/src/meta_service/raft_log_test.rs
+++ b/fusestore/store/src/meta_service/raft_log_test.rs
@@ -17,7 +17,7 @@ use crate::tests::service::new_sled_test_context;
 async fn test_raft_log_open() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    RaftLog::open(db).await?;
+    RaftLog::open(db, &tc.config).await?;
 
     Ok(())
 }
@@ -26,7 +26,7 @@ async fn test_raft_log_open() -> anyhow::Result<()> {
 async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = RaftLog::open(db).await?;
+    let rl = RaftLog::open(db, &tc.config).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -99,7 +99,7 @@ async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
 async fn test_raft_log_insert() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = RaftLog::open(db).await?;
+    let rl = RaftLog::open(db, &tc.config).await?;
 
     assert_eq!(None, rl.get(&5)?);
 
@@ -134,7 +134,7 @@ async fn test_raft_log_insert() -> anyhow::Result<()> {
 async fn test_raft_log_get() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = RaftLog::open(db).await?;
+    let rl = RaftLog::open(db, &tc.config).await?;
 
     assert_eq!(None, rl.get(&5)?);
 
@@ -171,7 +171,7 @@ async fn test_raft_log_get() -> anyhow::Result<()> {
 async fn test_raft_log_last() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = RaftLog::open(db).await?;
+    let rl = RaftLog::open(db, &tc.config).await?;
 
     assert_eq!(None, rl.last()?);
 
@@ -203,7 +203,7 @@ async fn test_raft_log_last() -> anyhow::Result<()> {
 async fn test_raft_log_range_delete() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = RaftLog::open(db).await?;
+    let rl = RaftLog::open(db, &tc.config).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -127,7 +127,7 @@ impl MetaStore {
         // TODO(xp): merge the duplicated snippets in new() and open(), when I got time :DDD
 
         let raft_state = RaftState::create(&db, &id).await?;
-        let log = RaftLog::open(&db).await?;
+        let log = RaftLog::open(&db, config).await?;
 
         let sm = RwLock::new(StateMachine::default());
         let current_snapshot = RwLock::new(None);
@@ -151,7 +151,7 @@ impl MetaStore {
             })?;
 
         let raft_state = RaftState::open(&db)?;
-        let log = RaftLog::open(&db).await?;
+        let log = RaftLog::open(&db, config).await?;
 
         let sm = RwLock::new(StateMachine::default());
         let current_snapshot = RwLock::new(None);

--- a/fusestore/store/src/meta_service/sled_tree_test.rs
+++ b/fusestore/store/src/meta_service/sled_tree_test.rs
@@ -18,7 +18,7 @@ use crate::tests::service::new_sled_test_context;
 async fn test_sled_tree_open() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    SledTree::<LogIndex, Entry<LogEntry>>::open(db, "foo").await?;
+    SledTree::<LogIndex, Entry<LogEntry>>::open(db, "foo", true).await?;
 
     Ok(())
 }
@@ -27,7 +27,7 @@ async fn test_sled_tree_open() -> anyhow::Result<()> {
 async fn test_sled_tree_append() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log", true).await?;
 
     let logs: Vec<(LogIndex, Entry<LogEntry>)> = vec![
         (8, Entry {
@@ -83,7 +83,7 @@ async fn test_sled_tree_append() -> anyhow::Result<()> {
 async fn test_sled_tree_append_values_and_range_get() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log", true).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -156,7 +156,7 @@ async fn test_sled_tree_append_values_and_range_get() -> anyhow::Result<()> {
 async fn test_sled_tree_range_keys() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log", true).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -206,7 +206,7 @@ async fn test_sled_tree_range_keys() -> anyhow::Result<()> {
 async fn test_sled_tree_insert() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log", true).await?;
 
     assert_eq!(None, rl.get(&5)?);
 
@@ -264,7 +264,7 @@ async fn test_sled_tree_insert() -> anyhow::Result<()> {
 async fn test_sled_tree_contains_key() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log", true).await?;
 
     assert_eq!(None, rl.get(&5)?);
 
@@ -301,7 +301,7 @@ async fn test_sled_tree_contains_key() -> anyhow::Result<()> {
 async fn test_sled_tree_get() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log", true).await?;
 
     assert_eq!(None, rl.get(&5)?);
 
@@ -338,7 +338,7 @@ async fn test_sled_tree_get() -> anyhow::Result<()> {
 async fn test_sled_tree_last() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log", true).await?;
 
     assert_eq!(None, rl.last()?);
 
@@ -370,7 +370,7 @@ async fn test_sled_tree_last() -> anyhow::Result<()> {
 async fn test_sled_tree_range_delete() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log").await?;
+    let rl = SledTree::<LogIndex, Entry<LogEntry>>::open(db, "log", true).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {

--- a/fusestore/store/src/meta_service/sled_vartype_tree_test.rs
+++ b/fusestore/store/src/meta_service/sled_vartype_tree_test.rs
@@ -19,7 +19,7 @@ use crate::tests::service::new_sled_test_context;
 async fn test_sled_vartype_tree_open() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    SledVarTypeTree::open(db, "foo").await?;
+    SledVarTypeTree::open(db, "foo", true).await?;
 
     Ok(())
 }
@@ -28,7 +28,7 @@ async fn test_sled_vartype_tree_open() -> anyhow::Result<()> {
 async fn test_sled_vartype_tree_append() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
 
     let logs: Vec<(LogIndex, Entry<LogEntry>)> = vec![
         (8, Entry {
@@ -84,7 +84,7 @@ async fn test_sled_vartype_tree_append() -> anyhow::Result<()> {
 async fn test_sled_vartype_tree_append_values_and_range_get() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -157,7 +157,7 @@ async fn test_sled_vartype_tree_append_values_and_range_get() -> anyhow::Result<
 async fn test_sled_vartype_tree_range_keys() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -207,7 +207,7 @@ async fn test_sled_vartype_tree_range_keys() -> anyhow::Result<()> {
 async fn test_sled_vartype_tree_insert() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
 
     assert!(tree.get::<sledkv::Logs>(&5)?.is_none());
 
@@ -265,7 +265,7 @@ async fn test_sled_vartype_tree_insert() -> anyhow::Result<()> {
 async fn test_sled_vartype_tree_contains_key() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
 
     assert!(tree.get::<sledkv::Logs>(&5)?.is_none());
 
@@ -302,7 +302,7 @@ async fn test_sled_vartype_tree_contains_key() -> anyhow::Result<()> {
 async fn test_sled_vartype_tree_get() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
 
     assert!(tree.get::<sledkv::Logs>(&5)?.is_none());
 
@@ -339,7 +339,7 @@ async fn test_sled_vartype_tree_get() -> anyhow::Result<()> {
 async fn test_sled_vartype_tree_last() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
 
     assert!(tree.last::<sledkv::Logs>()?.is_none());
 
@@ -384,7 +384,7 @@ async fn test_sled_vartype_tree_last() -> anyhow::Result<()> {
 async fn test_sled_vartype_tree_range_delete() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -443,7 +443,7 @@ async fn test_sled_vartype_tree_range_delete() -> anyhow::Result<()> {
 async fn test_sled_vartype_tree_multi_types() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -503,7 +503,7 @@ async fn test_sled_vartype_tree_multi_types() -> anyhow::Result<()> {
 async fn test_as_append() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
     let aslog = tree.as_type::<sledkv::Logs>();
 
     let logs: Vec<(LogIndex, Entry<LogEntry>)> = vec![
@@ -560,7 +560,7 @@ async fn test_as_append() -> anyhow::Result<()> {
 async fn test_as_append_values_and_range_get() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
     let aslog = tree.as_type::<sledkv::Logs>();
 
     let logs: Vec<Entry<LogEntry>> = vec![
@@ -634,7 +634,7 @@ async fn test_as_append_values_and_range_get() -> anyhow::Result<()> {
 async fn test_as_range_keys() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
     let aslog = tree.as_type::<sledkv::Logs>();
 
     let logs: Vec<Entry<LogEntry>> = vec![
@@ -685,7 +685,7 @@ async fn test_as_range_keys() -> anyhow::Result<()> {
 async fn test_as_insert() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
     let aslog = tree.as_type::<sledkv::Logs>();
 
     assert_eq!(None, aslog.get(&5)?);
@@ -744,7 +744,7 @@ async fn test_as_insert() -> anyhow::Result<()> {
 async fn test_as_contains_key() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
     let aslog = tree.as_type::<sledkv::Logs>();
 
     assert_eq!(None, aslog.get(&5)?);
@@ -782,7 +782,7 @@ async fn test_as_contains_key() -> anyhow::Result<()> {
 async fn test_as_get() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
     let aslog = tree.as_type::<sledkv::Logs>();
 
     assert_eq!(None, aslog.get(&5)?);
@@ -820,7 +820,7 @@ async fn test_as_get() -> anyhow::Result<()> {
 async fn test_as_last() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
     let aslog = tree.as_type::<sledkv::Logs>();
 
     assert_eq!(None, aslog.last()?);
@@ -853,7 +853,7 @@ async fn test_as_last() -> anyhow::Result<()> {
 async fn test_as_range_delete() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
     let aslog = tree.as_type::<sledkv::Logs>();
 
     let logs: Vec<Entry<LogEntry>> = vec![
@@ -913,7 +913,7 @@ async fn test_as_range_delete() -> anyhow::Result<()> {
 async fn test_as_multi_types() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let tree = SledVarTypeTree::open(db, "foo").await?;
+    let tree = SledVarTypeTree::open(db, "foo", true).await?;
     let aslog = tree.as_type::<sledkv::Logs>();
     let asmeta = tree.as_type::<sledkv::SMMeta>();
 

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -51,6 +51,9 @@ pub struct StoreTestContext {
 pub fn new_test_context() -> StoreTestContext {
     let mut config = configs::Config::empty();
 
+    // On mac File::sync_all() takes 10 ms ~ 30 ms, 500 ms at worst, which very likely to fail a test.
+    config.meta_no_sync = true;
+
     config.meta_api_port = next_port();
 
     let host = "127.0.0.1";
@@ -86,6 +89,7 @@ pub fn new_test_context() -> StoreTestContext {
 pub struct SledTestContext {
     #[allow(dead_code)]
     temp_dir: TempDir,
+    pub config: configs::Config,
     pub db: sled::Db,
 }
 
@@ -94,9 +98,14 @@ pub fn new_sled_test_context() -> SledTestContext {
     let t = tempdir().expect("create temp dir to store meta");
     let tmpdir = t.path().to_str().unwrap().to_string();
 
+    // config for unit test of sled db, meta_sync() is true by default.
+    let config = configs::Config::empty();
+
     SledTestContext {
         // hold the TempDir until being dropped.
         temp_dir: t,
+        config,
+        // TODO(xp): one db per process.
         db: sled::open(tmpdir).expect("open sled db"),
     }
 }

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -52,7 +52,10 @@ pub fn new_test_context() -> StoreTestContext {
     let mut config = configs::Config::empty();
 
     // On mac File::sync_all() takes 10 ms ~ 30 ms, 500 ms at worst, which very likely to fail a test.
-    config.meta_no_sync = true;
+    if cfg!(target_os = "macos") {
+        tracing::warn!("Disabled fsync for meta data tests. fsync on mac is quite slow");
+        config.meta_no_sync = true;
+    }
 
     config.meta_api_port = next_port();
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] fix: do not fsync sled data in unittets. File::sync_all() takes 10 ~ 30 ms, at worst 500 ms on a Mac
Sled tree wrappers provides an option to not to fsync after write
operation.
This should only be used in testing environment.

For more details about the slow fsync issue:
https://github.com/drmingdrmer/sledtest

## Changelog


- Bug Fix




## Related Issues

- [ ] #271

- [ ] #1080 