### PR TITLE
[store] refactor: upgrade async-raft to 0.6.2-alpha.7: reduce log level to warn for RPC failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.6#7e18c2c80d5a54a59e1681f4af8c3e81618095fc"
+source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.7#8e0cca5241fa423430920ab5c409494569bacb01"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/common/stoppable/src/stoppable_test.rs
+++ b/common/stoppable/src/stoppable_test.rs
@@ -142,8 +142,6 @@ async fn test_stop_handle_drop() -> anyhow::Result<()> {
 
     common_tracing::init_default_tracing();
 
-    let (tx, _rx) = broadcast::channel::<()>(1024);
-
     let mut t1 = FooTask::default();
 
     // Start the task

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -35,7 +35,7 @@ common-tracing = {path = "../../common/tracing"}
 
 # Crates.io dependencies
 anyhow = "1.0.42"
-async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.6" }
+async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.7" }
 async-trait = "0.1"
 byteorder = "1.1.0"
 env_logger = "0.9"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: upgrade async-raft to 0.6.2-alpha.7: reduce log level to warn for RPC failures

## Changelog




- Improvement

