### PR TITLE
[tests] refactor: use python script to wait for a listening port; improve portability on mac

### DIFF
--- a/scripts/ci/wait_tcp.py
+++ b/scripts/ci/wait_tcp.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import socket
+import argparse
+import time
+
+def tcp_ping(port, timeout):
+
+    now = time.time()
+
+    while time.time() - now < timeout:
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect(('0.0.0.0', port))
+            print("OK {} is listening".format(port))
+            return
+        except:
+            print("fail")
+            time.sleep(0.5)
+
+    raise Exception("fail to connect to {}".format(port))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='block until successfully connecting to a local tcp port')
+    parser.add_argument('-p', '--port',  type=int, help='local tcp port')
+    parser.add_argument('-t', '--timeout', type=int, default=5,  help='time to wait.')
+
+    args = parser.parse_args()
+
+    tcp_ping(args.port, args.timeout)
+

--- a/scripts/deploy/fusequery-cluster-3-nodes.sh
+++ b/scripts/deploy/fusequery-cluster-3-nodes.sh
@@ -12,25 +12,25 @@ sleep 1
 echo 'Start one FuseStore...'
 nohup target/debug/fuse-store &
 echo "Waiting on fuse-store 10 seconds..."
-timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' 0.0.0.0 9191
+python scripts/ci/wait_tcp.py --timeout 5 --port 9191
 
 echo 'Start FuseQuery node-1'
 nohup target/debug/fuse-query -c scripts/deploy/config/fusequery-node-1.toml &
 
 echo "Waiting on node-1..."
-timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' 0.0.0.0 9091
+python scripts/ci/wait_tcp.py --timeout 5 --port 9091
 
 echo 'Start FuseQuery node-2'
 nohup target/debug/fuse-query -c scripts/deploy/config/fusequery-node-2.toml &
 
 echo "Waiting on node-2..."
-timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' 0.0.0.0 9092
+python scripts/ci/wait_tcp.py --timeout 5 --port 9092
 
 echo 'Start FuseQuery node-3'
 nohup target/debug/fuse-query -c scripts/deploy/config/fusequery-node-3.toml &
 
 echo "Waiting on node-3..."
-timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' 0.0.0.0 9093
+python scripts/ci/wait_tcp.py --timeout 5 --port 9093
 
 curl http://127.0.0.1:8081/v1/cluster/add -X POST -H "Content-Type: application/json" -d '{"name":"cluster1","address":"127.0.0.1:9091", "priority":3, "cpus":8}'
 curl http://127.0.0.1:8081/v1/cluster/add -X POST -H "Content-Type: application/json" -d '{"name":"cluster2","address":"127.0.0.1:9092", "priority":3, "cpus":8}'

--- a/scripts/deploy/fusequery-standalone.sh
+++ b/scripts/deploy/fusequery-standalone.sh
@@ -14,9 +14,10 @@ BIN=${1:-debug}
 echo 'Start FuseStore...'
 nohup target/${BIN}/fuse-store &
 echo "Waiting on fuse-store 10 seconds..."
-timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' 0.0.0.0 9191
+python scripts/ci/wait_tcp.py --timeout 5 --port 9191
+
 
 echo 'Start FuseQuery...'
 nohup target/${BIN}/fuse-query -c scripts/deploy/config/fusequery-node-1.toml &
 echo "Waiting on fuse-query 10 seconds..."
-timeout 10 sh -c 'until nc -z $0 $1; do sleep 1; done' 0.0.0.0 3307
+python scripts/ci/wait_tcp.py --timeout 5 --port 3307


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [tests] refactor: use python script to wait for a listening port; improve portability on mac

## Changelog




- Improvement


