### PR TITLE
RUST: back to 2018

### DIFF
--- a/common/allocators/Cargo.toml
+++ b/common/allocators/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [features]
 # Enable jemalloc for binaries

--- a/common/arrow/Cargo.toml
+++ b/common/arrow/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [features]
 simd = ["arrow/simd"]

--- a/common/building/Cargo.toml
+++ b/common/building/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 vergen = "5.1.14"

--- a/common/datablocks/Cargo.toml
+++ b/common/datablocks/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/datavalues/Cargo.toml
+++ b/common/datavalues/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/exception/Cargo.toml
+++ b/common/exception/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 common-arrow = { path = "../arrow" }

--- a/common/flights/Cargo.toml
+++ b/common/flights/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/functions/Cargo.toml
+++ b/common/functions/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/infallible/Cargo.toml
+++ b/common/infallible/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/io/Cargo.toml
+++ b/common/io/Cargo.toml
@@ -3,7 +3,7 @@ cargo-features = ["edition2021"]
 [package]
 name = "common-io"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/common/management/Cargo.toml
+++ b/common/management/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/common/metatypes/Cargo.toml
+++ b/common/metatypes/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/common/planners/Cargo.toml
+++ b/common/planners/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/profiling/Cargo.toml
+++ b/common/profiling/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/progress/Cargo.toml
+++ b/common/progress/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/runtime/Cargo.toml
+++ b/common/runtime/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/stoppable/Cargo.toml
+++ b/common/stoppable/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/store-api/Cargo.toml
+++ b/common/store-api/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/common/streams/Cargo.toml
+++ b/common/streams/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies

--- a/common/tracing/Cargo.toml
+++ b/common/tracing/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [dependencies] # In alphabetical order
 common-runtime = {path = "../runtime"}

--- a/fusecli/cli/Cargo.toml
+++ b/fusecli/cli/Cargo.toml
@@ -7,7 +7,7 @@ description = "All-in-one tool for setting up, managing with Datafuse"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [[bin]]
 name = "datafuse-cli"

--- a/fusequery/fuzz/Cargo.toml
+++ b/fusequery/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ cargo-features = ["edition2021"]
 [package]
 name = "fuzz"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [[bin]]

--- a/fusequery/query/Cargo.toml
+++ b/fusequery/query/Cargo.toml
@@ -7,7 +7,7 @@ description = "A real-time Cloud Distributed Query Engine"
 authors = ["Datafuse Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [[bin]]
 name = "fuse-query"

--- a/fusestore/store/Cargo.toml
+++ b/fusestore/store/Cargo.toml
@@ -7,7 +7,7 @@ description = "A Cloud Distributed MergeTree Storage Engine"
 authors = ["FuseStore Authors <opensource@datafuselabs.com>"]
 license = "Apache-2.0"
 publish = false
-edition = "2021"
+edition = "2018"
 
 [[bin]]
 name = "fuse-store"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Unit test has some errors with the 2021 edtion.
Revert to 2018 and make the unit test works.
[Error Log](https://pipelines.actions.githubusercontent.com/Zgqden0KhWGRXpIXPBTtTR2O0h9dPB76KbDLD2GlEOYbcWXWjs/_apis/pipelines/1/runs/22858/signedlogcontent/3?urlExpires=2021-08-04T00%3A18%3A04.7946270Z&urlSigningMethod=HMACV1&urlSignature=pop6jg%2B0NKyE01hJHfolKa6hC6sNynK4QYkYGSTnJJs%3D)


## Changelog


- Build/Testing/CI


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

