### PR TITLE
fix: use display_name for siphash

### DIFF
--- a/common/functions/src/scalars/hashes/siphash.rs
+++ b/common/functions/src/scalars/hashes/siphash.rs
@@ -29,7 +29,7 @@ impl SipHashFunction {
 
 impl Function for SipHashFunction {
     fn name(&self) -> &str {
-        "siphash"
+        &*self.display_name
     }
 
     fn num_arguments(&self) -> usize {
@@ -53,7 +53,8 @@ impl Function for SipHashFunction {
             | DataType::Utf8
             | DataType::Binary => Ok(DataType::UInt64),
             _ => Result::Err(ErrorCode::BadArguments(format!(
-                "Function Error: Siphash does not support {} type parameters",
+                "Function Error: {} does not support {} type parameters",
+                self.display_name,
                 args[0]
             ))),
         }
@@ -73,6 +74,6 @@ impl Function for SipHashFunction {
 
 impl fmt::Display for SipHashFunction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "siphash")
+        write!(f, "{}", self.display_name)
     }
 }

--- a/common/functions/src/scalars/hashes/siphash.rs
+++ b/common/functions/src/scalars/hashes/siphash.rs
@@ -54,8 +54,7 @@ impl Function for SipHashFunction {
             | DataType::Binary => Ok(DataType::UInt64),
             _ => Result::Err(ErrorCode::BadArguments(format!(
                 "Function Error: {} does not support {} type parameters",
-                self.display_name,
-                args[0]
+                self.display_name, args[0]
             ))),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Since SipHash have alias, it should use the `display_name`.

## Changelog
- Fix SipHash display name

## Related Issues
None

## Test Plan
None

