### PR TITLE
issue# 1278 Use default values of Config in unit test

### DIFF
--- a/fusecli/cli/src/cmds/config.rs
+++ b/fusecli/cli/src/cmds/config.rs
@@ -4,7 +4,7 @@
 
 use structopt::StructOpt;
 
-#[derive(Clone, Debug, PartialEq, StructOpt)]
+#[derive(Clone, Debug, PartialEq, StructOpt, Default)]
 pub struct Config {
     #[structopt(long, env = "NAMESPACE", default_value = "test")]
     pub namespace: String,
@@ -29,10 +29,18 @@ pub struct Config {
 
 impl Config {
     pub fn create() -> Self {
+        let conf = Config::from_args();
+        Self::build(conf)
+    }
+
+    pub fn default() -> Self {
+        let conf: Config = Default::default();
+        Self::build(conf)
+    }
+
+    fn build(mut conf: Config) -> Self {
         let home_dir = dirs::home_dir().unwrap();
         let datafuse_dir = home_dir.join(".datafuse");
-
-        let mut conf = Config::from_args();
         conf.datafuse_dir = format!("{}/{}", datafuse_dir.to_str().unwrap(), conf.namespace);
         conf
     }

--- a/fusecli/cli/src/cmds/status_test.rs
+++ b/fusecli/cli/src/cmds/status_test.rs
@@ -8,7 +8,7 @@ use crate::error::Result;
 
 #[test]
 fn test_status() -> Result<()> {
-    let mut conf = Config::create();
+    let mut conf = Config::default();
     conf.datafuse_dir = "/tmp/".to_string();
 
     let mut status = Status::read(conf)?;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/


## Summary

Use default values of `Config` in unit test instead of Config::from_args

## Changelog


- Improvement


## Related Issues

Fixes #1278

## Test Plan

Unit Tests

Stateless Tests

