### PR TITLE
[store] feature: fuse-store support restart

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -192,6 +192,11 @@ build_exceptions! {
 
     MetaStoreDamaged(2401),
     MetaStoreAlreadyExists(2402),
+    MetaStoreNotFound(2403),
+
+    // FuseStore server error
+
+    FuseStoreError(2501),
 
 
     // TODO

--- a/fusestore/store/src/api/rpc_service.rs
+++ b/fusestore/store/src/api/rpc_service.rs
@@ -4,8 +4,13 @@
 
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use common_arrow::arrow_flight::flight_service_server::FlightServiceServer;
+use common_exception::ErrorCode;
+use common_exception::ToErrorCode;
+use common_runtime::tokio;
+use common_runtime::tokio::sync::oneshot;
+use common_runtime::tokio::sync::oneshot::Receiver;
+use common_runtime::tokio::sync::oneshot::Sender;
 use common_tracing::tracing;
 use tonic::transport::Server;
 
@@ -24,8 +29,25 @@ impl StoreServer {
         Self { conf }
     }
 
+    /// Start store server and returns two channel to send shutdown signal and receive signal when shutdown finished.
+    pub async fn start(self) -> Result<(oneshot::Sender<()>, oneshot::Receiver<()>), ErrorCode> {
+        let (stop_tx, stop_rx) = oneshot::channel::<()>();
+        let (fin_tx, fin_rx) = oneshot::channel::<()>();
+
+        let fut = self.serve(stop_rx, fin_tx);
+        tokio::spawn(async move {
+            // TODO(xp): handle errors.
+            // TODO(xp): move server building up actions out of serve(). errors should be caught.
+            let res = fut.await;
+            tracing::info!("StoreServer serve res: {:?}", res);
+        });
+
+        Ok((stop_tx, fin_rx))
+    }
+
+    /// Start serving FuseStore. It does not return until StoreServer is stopped.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn serve(&self) -> anyhow::Result<()> {
+    pub async fn serve(self, stop_rx: Receiver<()>, fin_tx: Sender<()>) -> Result<(), ErrorCode> {
         let addr = self
             .conf
             .flight_api_address
@@ -37,27 +59,50 @@ impl StoreServer {
         let p = tempfile::tempdir()?;
         let fs = LocalFS::try_create(p.path().to_str().unwrap().into())?;
 
-        // TODO(xp): support non-boot mode.
-        //           for now it can only be run in single-node cluster mode.
-        // if !self.conf.boot {
-        //     todo!("non-boot mode is not impl yet")
-        // }
+        // - boot mode: create the first node in a new cluster.
+        // - TODO(xp): join mode: create a new node to join a cluster.
+        // - open mode: open an existent node.
+        tracing::info!(
+            "Starting MetaNode boot:{} single: {} with config: {:?}",
+            self.conf.boot,
+            self.conf.single,
+            self.conf
+        );
 
-        tracing::info!("--- starting MetaNode with config: {:?}", self.conf);
-
-        let mn = MetaNode::boot(0, &self.conf).await?;
-
-        tracing::info!("boot done");
+        let mn = if self.conf.boot {
+            MetaNode::boot(0, &self.conf).await?
+        } else if self.conf.single {
+            let (mn, _is_open) =
+                MetaNode::open_create_boot(&self.conf, Some(()), Some(()), Some(())).await?;
+            mn
+        } else {
+            MetaNode::open(&self.conf).await?
+        };
+        tracing::info!("Done starting MetaNode");
 
         let dfs = Dfs::create(fs, mn.clone());
 
-        let flight_impl = StoreFlightImpl::create(self.conf.clone(), Arc::new(dfs), mn);
+        let flight_impl = StoreFlightImpl::create(self.conf.clone(), Arc::new(dfs), mn.clone());
         let flight_srv = FlightServiceServer::new(flight_impl);
 
-        Server::builder()
+        let res = Server::builder()
             .add_service(flight_srv)
-            .serve(addr)
-            .await
-            .map_err(|e| anyhow!("Flight service error: {:?}", e))
+            .serve_with_shutdown(addr, async move {
+                tracing::info!("StoreServer start to wait for stop signal");
+                let _ = stop_rx.await;
+                tracing::info!("StoreServer receives stop signal");
+            })
+            .await;
+
+        let _ = mn.stop().await;
+        let s = fin_tx.send(());
+        tracing::info!(
+            "StoreServer sending signal of finishing shutdown: res: {:?}",
+            s
+        );
+
+        tracing::info!("StoreServer returning");
+
+        res.map_err_to_code(ErrorCode::FuseStoreError, || "StoreServer error")
     }
 }

--- a/fusestore/store/src/bin/fuse-store.rs
+++ b/fusestore/store/src/bin/fuse-store.rs
@@ -49,8 +49,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // RPC API service.
     {
         let srv = StoreServer::create(conf.clone());
-        info!("RPC API server listening on {}", conf.flight_api_address);
-        srv.serve().await.expect("RPC service error");
+        info!(
+            "FuseStore API server listening on {}",
+            conf.flight_api_address
+        );
+        let (_stop_tx, fin_rx) = srv.start().await.expect("FuseStore service error");
+        fin_rx.await?;
     }
 
     Ok(())

--- a/fusestore/store/src/configs/config.rs
+++ b/fusestore/store/src/configs/config.rs
@@ -2,9 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use common_exception::ErrorCode;
 use lazy_static::lazy_static;
 use structopt::StructOpt;
 use structopt_toml::StructOptToml;
+
+use crate::meta_service::NodeId;
 
 lazy_static! {
     pub static ref FUSE_COMMIT_VERSION: String = {
@@ -115,6 +118,25 @@ pub struct Config {
         help = "Whether to boot up a new cluster. If already booted, it is ignored"
     )]
     pub boot: bool,
+
+    #[structopt(
+        long,
+        env = "FUSE_STORE_SINGLE",
+        help = concat!("Single node store. It creates a single node cluster if meta data is not initialized.",
+                      " Otherwise it opens the previous one.",
+                      " This is mainly for testing purpose.")
+    )]
+    pub single: bool,
+
+    #[structopt(
+        long,
+        env = "FUSE_STORE_ID",
+        default_value = "0",
+        help = concat!("The node id. Only used when this server is not initialized,",
+                      " e.g. --boot or --single for the first time.",
+                      " Otherwise this argument is ignored.")
+    )]
+    pub id: NodeId,
 }
 
 impl Config {
@@ -134,5 +156,15 @@ impl Config {
     /// Returns true to fsync after a write operation to meta.
     pub fn meta_sync(&self) -> bool {
         !self.meta_no_sync
+    }
+
+    pub fn check(&self) -> common_exception::Result<()> {
+        if self.boot && self.single {
+            return Err(ErrorCode::InvalidConfig(
+                "--boot and --single can not be both set",
+            ));
+        }
+
+        Ok(())
     }
 }

--- a/fusestore/store/src/meta_service/raft_log.rs
+++ b/fusestore/store/src/meta_service/raft_log.rs
@@ -34,6 +34,7 @@ impl SledValueToKey<LogIndex> for Entry<LogEntry> {
 
 impl RaftLog {
     /// Open RaftLog
+    #[tracing::instrument(level = "info", skip(db))]
     pub async fn open(
         db: &sled::Db,
         config: &configs::Config,

--- a/fusestore/store/src/meta_service/raft_state_test.rs
+++ b/fusestore/store/src/meta_service/raft_state_test.rs
@@ -5,8 +5,16 @@
 use async_raft::storage::HardState;
 use common_runtime::tokio;
 
+use crate::configs;
 use crate::meta_service::raft_state::RaftState;
+use crate::meta_service::NodeId;
 use crate::tests::service::new_sled_test_context;
+
+fn conf_of_id(id: NodeId) -> configs::Config {
+    let mut c = configs::Config::empty();
+    c.id = id;
+    c
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_state_create() -> anyhow::Result<()> {
@@ -15,25 +23,27 @@ async fn test_raft_state_create() -> anyhow::Result<()> {
 
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rs = RaftState::create(db, &3).await?;
+    let (rs, is_open) = RaftState::open_create(db, None, Some(&conf_of_id(3))).await?;
 
     assert_eq!(3, rs.id);
+    assert!(!is_open);
 
-    let res = RaftState::create(db, &4).await;
+    let res = RaftState::open_create(db, None, Some(&conf_of_id(4))).await;
     assert!(res.is_err());
     assert_eq!(
-        "Code: 2402, displayText = exist: id=Ok(3).",
+        "Code: 2402, displayText = raft state present id=3, can not create.",
         res.unwrap_err().to_string()
     );
 
-    let res = RaftState::create(db, &3).await;
+    let res = RaftState::open_create(db, None, Some(&conf_of_id(3))).await;
     assert!(res.is_err());
     assert_eq!(
-        "Code: 2402, displayText = exist: id=Ok(3).",
+        "Code: 2402, displayText = raft state present id=3, can not create.",
         res.unwrap_err().to_string()
     );
     Ok(())
 }
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_state_open() -> anyhow::Result<()> {
     // - create a raft state
@@ -41,12 +51,26 @@ async fn test_raft_state_open() -> anyhow::Result<()> {
 
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rs = RaftState::create(db, &3).await?;
+    let (rs, is_open) = RaftState::open_create(db, None, Some(&conf_of_id(3))).await?;
 
     assert_eq!(3, rs.id);
+    assert!(!is_open);
 
-    let rs = RaftState::open(db)?;
+    let (rs, is_open) = RaftState::open_create(db, Some(()), None).await?;
     assert_eq!(3, rs.id);
+    assert!(is_open);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_raft_state_open_or_create() -> anyhow::Result<()> {
+    let tc = new_sled_test_context();
+    let db = &tc.db;
+    let (rs, is_open) = RaftState::open_create(db, Some(()), Some(&conf_of_id(3))).await?;
+
+    assert_eq!(3, rs.id);
+    assert!(!is_open);
+
     Ok(())
 }
 
@@ -57,7 +81,7 @@ async fn test_raft_state_write_read_hard_state() -> anyhow::Result<()> {
 
     let tc = new_sled_test_context();
     let db = &tc.db;
-    let rs = RaftState::create(db, &3).await?;
+    let (rs, _) = RaftState::open_create(db, None, Some(&conf_of_id(3))).await?;
 
     assert_eq!(3, rs.id);
 

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -132,49 +132,56 @@ impl MetaStore {
     }
 
     /// Create a new `MetaStore` instance.
+    #[tracing::instrument(level = "info")]
     pub async fn new(id: NodeId, config: &configs::Config) -> common_exception::Result<MetaStore> {
-        let p = Self::log_dir(config);
-        let db = sled_open(&p)?;
+        // TODO: move id into config.
+        let mut config = config.clone();
+        config.id = id;
 
-        // TODO(xp): merge the duplicated snippets in new() and open(), when I got time :DDD
-
-        let raft_state = RaftState::create(&db, &id).await?;
-        let log = RaftLog::open(&db, config).await?;
-
-        let sm = RwLock::new(StateMachine::open(config).await?);
-        let current_snapshot = RwLock::new(None);
-
-        Ok(Self {
-            id,
-            _db: db,
-            raft_state,
-            log,
-            state_machine: sm,
-            snapshot_index: Arc::new(Mutex::new(0)),
-            current_snapshot,
-        })
+        let (ms, _is_open) = Self::open_create(&config, None, Some(())).await?;
+        Ok(ms)
     }
 
     /// Open an existent `MetaStore` instance.
     pub async fn open(config: &configs::Config) -> common_exception::Result<MetaStore> {
+        let (ms, _is_open) = Self::open_create(config, Some(()), None).await?;
+        Ok(ms)
+    }
+
+    /// Open an existent `MetaStore` instance or create an new one:
+    /// 1. If `open` is `Some`, try to open an existent one.
+    /// 2. If `create` is `Some`, try to create one.
+    /// Otherwise it panic
+    pub async fn open_create(
+        config: &configs::Config,
+        open: Option<()>,
+        create: Option<()>,
+    ) -> common_exception::Result<(MetaStore, bool)> {
         let p = Self::log_dir(config);
         let db = sled_open(&p)?;
 
-        let raft_state = RaftState::open(&db)?;
+        let (raft_state, is_open) =
+            RaftState::open_create(&db, open.map(|_| ()), create.map(|_| config)).await?;
+        tracing::info!("RaftState opened is_open: {}", is_open);
+
         let log = RaftLog::open(&db, config).await?;
+        tracing::info!("RaftLog opened");
 
         let sm = RwLock::new(StateMachine::open(config).await?);
         let current_snapshot = RwLock::new(None);
 
-        Ok(Self {
-            id: raft_state.id,
-            _db: db,
-            raft_state,
-            log,
-            state_machine: sm,
-            snapshot_index: Arc::new(Mutex::new(0)),
-            current_snapshot,
-        })
+        Ok((
+            Self {
+                id: raft_state.id,
+                _db: db,
+                raft_state,
+                log,
+                state_machine: sm,
+                snapshot_index: Arc::new(Mutex::new(0)),
+                current_snapshot,
+            },
+            is_open,
+        ))
     }
 
     /// Get a handle to the state machine for testing purposes.
@@ -524,6 +531,7 @@ pub struct MetaNodeBuilder {
     sto: Option<Arc<MetaStore>>,
     monitor_metrics: bool,
     start_grpc_service: bool,
+    addr: Option<String>,
 }
 
 impl MetaNodeBuilder {
@@ -564,8 +572,13 @@ impl MetaNodeBuilder {
         }
 
         if self.start_grpc_service {
-            let addr = sto.get_node_addr(&node_id).await?;
+            let addr = if let Some(a) = self.addr.take() {
+                a
+            } else {
+                sto.get_node_addr(&node_id).await?
+            };
             tracing::info!("about to start grpc on {}", addr);
+
             MetaNode::start_grpc(mn.clone(), &addr).await?;
         }
         Ok(mn)
@@ -581,6 +594,10 @@ impl MetaNodeBuilder {
     }
     pub fn start_grpc_service(mut self, b: bool) -> Self {
         self.start_grpc_service = b;
+        self
+    }
+    pub fn addr(mut self, a: String) -> Self {
+        self.addr = Some(a);
         self
     }
     pub fn monitor_metrics(mut self, b: bool) -> Self {
@@ -599,6 +616,7 @@ impl MetaNode {
             sto: None,
             monitor_metrics: true,
             start_grpc_service: true,
+            addr: None,
         }
     }
 
@@ -656,11 +674,43 @@ impl MetaNode {
     /// Start a MetaStore node from initialized store.
     #[tracing::instrument(level = "info")]
     pub async fn open(config: &configs::Config) -> common_exception::Result<Arc<MetaNode>> {
-        let sto = MetaStore::open(config).await?;
-        let sto = Arc::new(sto);
-        let b = MetaNode::builder(config).node_id(sto.id).sto(sto);
+        let (mn, _is_open) = Self::open_create_boot(config, Some(()), None, None).await?;
+        Ok(mn)
+    }
 
-        b.build().await
+    /// Open or create a MetaStore node.
+    /// Optionally boot a single node cluster.
+    /// 1. If `open` is `Some`, try to open an existent one.
+    /// 2. If `create` is `Some`, try to create an one in non-voter mode.
+    /// 3. If `boot` is `Some` and it is just created, try to initialize a single-node cluster.
+    #[tracing::instrument(level = "info")]
+    pub async fn open_create_boot(
+        config: &configs::Config,
+        open: Option<()>,
+        create: Option<()>,
+        boot: Option<()>,
+    ) -> common_exception::Result<(Arc<MetaNode>, bool)> {
+        let (sto, is_open) = MetaStore::open_create(config, open, create).await?;
+        let sto = Arc::new(sto);
+        let mut b = MetaNode::builder(config).sto(sto.clone());
+
+        if is_open {
+            // read id from sto, read listening addr from sto
+            b = b.node_id(sto.id);
+        } else {
+            // read id from config, read listening addr from config.
+            b = b.node_id(config.id).addr(config.meta_api_addr());
+        }
+
+        let mn = b.build().await?;
+
+        tracing::info!("MetaNode started: {:?}", config);
+
+        if !is_open && boot.is_some() {
+            mn.init_cluster(config.meta_api_addr()).await?;
+        }
+
+        Ok((mn, is_open))
     }
 
     #[tracing::instrument(level = "info", skip(self))]
@@ -759,22 +809,32 @@ impl MetaNode {
         // 3. Add itself to the cluster storage by committing an `add-node` log so that the cluster members(only this node) is persisted.
 
         let mn = MetaNode::boot_non_voter(node_id, config).await?;
+        mn.init_cluster(config.meta_api_addr()).await?;
+
+        Ok(mn)
+    }
+
+    // Initialized a single node cluster by:
+    // - Initializing raft membership.
+    // - Adding current node into the meta data.
+    #[tracing::instrument(level = "info", skip(self))]
+    pub async fn init_cluster(&self, addr: String) -> common_exception::Result<()> {
+        let node_id = self.sto.id;
 
         let mut cluster_node_ids = HashSet::new();
         cluster_node_ids.insert(node_id);
 
-        let rst = mn
+        let rst = self
             .raft
             .initialize(cluster_node_ids)
             .await
             .map_err(|x| ErrorCode::MetaServiceError(format!("{:?}", x)))?;
 
-        tracing::info!("booted, rst: {:?}", rst);
+        tracing::info!("initialized cluster, rst: {:?}", rst);
 
-        let addr = config.meta_api_addr();
-        mn.add_node(node_id, addr).await?;
+        self.add_node(node_id, addr).await?;
 
-        Ok(mn)
+        Ok(())
     }
 
     /// Boot a node that is going to join an existent cluster.
@@ -786,27 +846,14 @@ impl MetaNode {
         config: &configs::Config,
     ) -> common_exception::Result<Arc<MetaNode>> {
         // TODO test MetaNode::new() on a booted store.
-        // TODO: Before calling this func, the node should be added as a non-voter to leader.
         // TODO(xp): what if fill in the node info into an empty state-machine, then MetaNode can be started without delaying grpc.
 
-        // When booting, there is addr stored in local store.
-        // Thus we need to start grpc manually.
-        let sto = MetaStore::new(node_id, config).await?;
+        let mut config = config.clone();
+        config.id = node_id;
 
-        let b = MetaNode::builder(config)
-            .node_id(node_id)
-            .start_grpc_service(false)
-            .sto(Arc::new(sto));
+        let (mn, _is_open) = Self::open_create_boot(&config, None, Some(()), None).await?;
 
-        let mn = b.build().await?;
-
-        let addr = config.meta_api_addr();
-
-        // Manually start the grpc, since no addr is stored yet.
-        // We can not use the startup routine for initialized node.
-        MetaNode::start_grpc(mn.clone(), &addr).await?;
-
-        tracing::info!("booted non-voter: {}={}", node_id, &addr);
+        tracing::info!("booted non-voter: {:?}", config);
 
         Ok(mn)
     }

--- a/fusestore/store/src/meta_service/raftmeta_test.rs
+++ b/fusestore/store/src/meta_service/raftmeta_test.rs
@@ -158,10 +158,7 @@ async fn test_meta_node_boot() -> anyhow::Result<()> {
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
 
-    let resp = MetaNode::boot(0, &tc.config).await;
-    assert!(resp.is_ok());
-
-    let mn = resp.unwrap();
+    let mn = MetaNode::boot(0, &tc.config).await?;
 
     let got = mn.get_node(&0).await;
     assert_eq!(addr, got.unwrap().address);

--- a/fusestore/store/src/meta_service/sled_util.rs
+++ b/fusestore/store/src/meta_service/sled_util.rs
@@ -8,6 +8,7 @@ use common_exception::ErrorCode;
 use common_exception::ToErrorCode;
 
 /// Same as sled::open except it returns common_exception::Result<sled::Db>.
+/// `sled::open()` open an existent one, otherwise it creates a new one.
 pub fn sled_open<P: AsRef<Path>>(p: P) -> common_exception::Result<sled::Db> {
     let db = sled::open(&p).map_err_to_code(ErrorCode::MetaStoreDamaged, || {
         format!("opening sled db: {}", p.as_ref().display())

--- a/fusestore/store/src/tests/mod.rs
+++ b/fusestore/store/src/tests/mod.rs
@@ -10,3 +10,4 @@ pub use seq::Seq;
 pub use service::assert_meta_connection;
 pub use service::next_port;
 pub use service::start_store_server;
+pub use service::start_store_server_with_context;

--- a/scripts/ci/wait_tcp.py
+++ b/scripts/ci/wait_tcp.py
@@ -13,13 +13,13 @@ def tcp_ping(port, timeout):
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect(('0.0.0.0', port))
-            print("OK {} is listening".format(port))
+            print("OK :{} is listening".format(port))
             return
         except:
-            print("fail")
+            print("not connected to :{}".format(port))
             time.sleep(0.5)
 
-    raise Exception("fail to connect to {}".format(port))
+    raise Exception("fail to connect to :{}".format(port))
 
 
 if __name__ == "__main__":

--- a/scripts/deploy/fusequery-cluster-3-nodes.sh
+++ b/scripts/deploy/fusequery-cluster-3-nodes.sh
@@ -10,7 +10,7 @@ killall fuse-store
 sleep 1
 
 echo 'Start one FuseStore...'
-nohup target/debug/fuse-store &
+nohup target/debug/fuse-store --single true &
 echo "Waiting on fuse-store 10 seconds..."
 python scripts/ci/wait_tcp.py --timeout 5 --port 9191
 

--- a/scripts/deploy/fusequery-standalone.sh
+++ b/scripts/deploy/fusequery-standalone.sh
@@ -12,7 +12,7 @@ sleep 1
 BIN=${1:-debug}
 
 echo 'Start FuseStore...'
-nohup target/${BIN}/fuse-store &
+nohup target/${BIN}/fuse-store --single true &
 echo "Waiting on fuse-store 10 seconds..."
 python scripts/ci/wait_tcp.py --timeout 5 --port 9191
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: fuse-store support restart
- Feature: support 3 server startup mode:
  For production:
    - `fuse-store --boot true`: initialized a store server and init a cluster of only 1 node.
    - `fuse-store`: start an initialized fuse-store.

  For testing:
    - `fuse-store --single true`: testing mode: open an initialized fuse store or create a new one. Most single-store test should use this mode.

  Most unittests run in `single` mode.

  Fix: #1134

- Test: test restarting a fuse-store.
  When testing, a fuse-store should not try to boot an already booted
  node.

- Fix: potential corruption in test: holds TempDir guard.

- Feature: StoreServer::start spawns another task to serve.

- Feature: Stop a StoreServer by sending a message to a channel. Part of #1186

- Refactor: internal: add several `open_create()` method to `MetaNode`,
  `MetaStore` etc, to support 3 startup mode: open, create and
  create-if-can-not-open.

## Changelog

- New Feature





## Related Issues

- #271