### PR TITLE
[Datafuse CLI] e2e framework for fusecli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Rust
 target/*
 distro/*
+fusecli/cli/e2e/datafuse-cli
 
 # cargo
 .cargo/

--- a/Makefile
+++ b/Makefile
@@ -74,4 +74,8 @@ clean:
 
 docker_release:
 	docker buildx build . -f ./docker/release/Dockerfile  --platform ${PLATFORM} --allow network.host --builder host -t ${HUB}/datafuse:${TAG} --push
+
+cli-e2e:
+	cargo build --bin datafuse-cli --out-dir fusecli/cli/e2e -Z unstable-options
+	(cd ./fusecli/cli/e2e && python3 e2e.py)
 .PHONY: setup test run build fmt lint docker clean

--- a/fusecli/README.md
+++ b/fusecli/README.md
@@ -7,6 +7,11 @@ Build:
 $ make cli
 ```
 
+E2E test:
+```bash
+make cli-e2e
+```
+
 Usage:
 ``` 
 $ ./target/release/datafuse-cli 

--- a/fusecli/cli/e2e/e2e.py
+++ b/fusecli/cli/e2e/e2e.py
@@ -1,0 +1,37 @@
+import time
+import warnings
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import asynctest
+import logging
+import asyncio
+
+
+async def execute(argument):
+    proc = await asyncio.create_subprocess_exec(
+        *argument,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE)
+
+    outdata = await proc.stdout.readline()
+    out = outdata.decode('ascii').strip()
+
+    errdata = await proc.stderr.readline()
+    err = errdata.decode('ascii').strip()
+    # Wait for the subprocess exit.
+    await proc.wait()
+    return out, err
+class FuseCliTest(parameterized.TestCase, asynctest.TestCase):
+    @parameterized.parameters(
+        {'command': "10"},
+        {'command': "--balala"},
+        {'command': "foo"},
+    )
+    async def testUnsupportedCommands(self, command):
+        out, err = await execute(("./datafuse-cli", command))
+        self.assertTrue('''error: Found argument '{}' which wasn't expected, or isn't valid in this context'''.format(command) in err)
+
+
+if __name__ == '__main__':
+    absltest.main()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Introduce BDD driven test framework for fusecli, using abseil test and asyncio as implementation

## Changelog

- New Feature


## Related Issues

fixes https://github.com/datafuselabs/datafuse/issues/1298

## Test Plan

Unit Tests

Stateless Tests

