### PR TITLE
remove `conf` from RpcService by using session_mgr's conf 

### DIFF
--- a/fusequery/query/src/api/rpc_service_test.rs
+++ b/fusequery/query/src/api/rpc_service_test.rs
@@ -37,7 +37,6 @@ async fn test_tls_rpc_server() -> Result<()> {
         sessions: session_manager.clone(),
         abort_notify: Arc::new(Notify::new()),
         dispatcher: Arc::new(FuseQueryFlightDispatcher::create()),
-        conf,
     };
     let addr_str = addr.to_string();
     let stream = TcpListenerStream::new(listener);
@@ -82,7 +81,6 @@ async fn test_tls_rpc_server_invalid_server_config() -> Result<()> {
         sessions: session_manager.clone(),
         abort_notify: Arc::new(Notify::new()),
         dispatcher: Arc::new(FuseQueryFlightDispatcher::create()),
-        conf,
     };
     let stream = TcpListenerStream::new(listener);
     let r = srv.start_with_incoming(stream).await;

--- a/fusequery/query/src/bin/fuse-query.rs
+++ b/fusequery/query/src/bin/fuse-query.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // RPC API service.
     {
         let addr = conf.flight_api_address.parse::<std::net::SocketAddr>()?;
-        let mut srv = RpcService::create(conf.clone(), session_manager.clone());
+        let mut srv = RpcService::create(session_manager.clone());
         let listening = srv.start(addr).await?;
         shutdown_handle.add_service(srv);
         info!("RPC API server listening on {}", listening);

--- a/fusequery/query/src/sessions/sessions.rs
+++ b/fusequery/query/src/sessions/sessions.rs
@@ -60,6 +60,10 @@ impl SessionManager {
         }))
     }
 
+    pub fn get_conf(&self) -> &Config {
+        &self.conf
+    }
+
     pub fn get_cluster(self: &Arc<Self>) -> ClusterRef {
         self.cluster.clone()
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Summary about this PR

## Changelog

- Bug Fix


## Related Issues

Fixes #1304

## Test Plan

Unit Tests

Stateless Tests

