### PR TITLE
CLI-938: add datafuse-cli package switch command

### DIFF
--- a/fusecli/README.md
+++ b/fusecli/README.md
@@ -27,6 +27,7 @@ OS version           thinkpad 20.04 (kernel 5.10.0-1038-oem)
 version              Datafuse CLI version
 comment              # your comments
 package              Package command
+
 [test] > package -h
 package 
 
@@ -37,13 +38,26 @@ FLAGS:
     -h, --help    Prints help information
 
 SUBCOMMANDS:
-    fetch    Fetch the latest version package
+    fetch     Fetch the latest version package
+    list      List all the packages
+    switch    Switch the active datafuse to a specified version
 
 [test] > package fetch
 ✅ [ok] Arch x86_64-unknown-linux-gnu
 ✅ [ok] Tag v0.4.69-nightly
 ✅ [ok] Binary /home/bohu/.datafuse/test/downloads/v0.4.69-nightly/datafuse--x86_64-unknown-linux-gnu.tar.gz
 ✅ [ok] Unpack /home/bohu/.datafuse/test/bin/v0.4.69-nightly
+
+[test] > package list
++-----------------+-----------------------------------------------+---------+
+| Version         | Path                                          | Current |
++-----------------+-----------------------------------------------+---------+
+| v0.4.69-nightly | /home/bohu/.datafuse/test/bin/v0.4.69-nightly | ✅      |
++-----------------+-----------------------------------------------+---------+
+| v0.4.68-nightly | /home/bohu/.datafuse/test/bin/v0.4.68-nightly |         |
++-----------------+-----------------------------------------------+---------+
+[test] > package switch v0.4.68-nightly
+✅ [ok] Package switch to v0.4.68-nightly
 [test] > 
 
 ```

--- a/fusecli/cli/src/cmds/mod.rs
+++ b/fusecli/cli/src/cmds/mod.rs
@@ -23,6 +23,7 @@ pub use helps::help::HelpCommand;
 pub use packages::fetch::FetchCommand;
 pub use packages::list::ListCommand;
 pub use packages::package::PackageCommand;
+pub use packages::switch::SwitchCommand;
 pub use processor::Processor;
 pub use status::Status;
 pub use versions::version::VersionCommand;

--- a/fusecli/cli/src/cmds/packages/list.rs
+++ b/fusecli/cli/src/cmds/packages/list.rs
@@ -4,11 +4,13 @@
 
 use std::fs;
 
+use colored::Colorize;
 use prettytable::Cell;
 use prettytable::Row;
 use prettytable::Table;
 
 use crate::cmds::Config;
+use crate::cmds::Status;
 use crate::cmds::Writer;
 use crate::error::Result;
 
@@ -26,16 +28,36 @@ impl ListCommand {
         let bin_dir = format!("{}/bin", self.conf.datafuse_dir.clone());
         let paths = fs::read_dir(bin_dir)?;
 
+        // Status.
+        let mut current = "".to_string();
+        if let Ok(status) = Status::read(self.conf.clone()) {
+            current = status.version;
+        }
+
         let mut table = Table::new();
         // Title.
-        table.add_row(Row::new(vec![Cell::new("Version"), Cell::new("Path")]));
+        table.add_row(Row::new(vec![
+            Cell::new("Version"),
+            Cell::new("Path"),
+            Cell::new("Current"),
+        ]));
         for path in paths {
             let path = path.unwrap();
+            let version = path
+                .path()
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
             let mut row = vec![];
-            row.push(Cell::new(
-                path.path().file_name().unwrap().to_str().unwrap(),
-            ));
+            row.push(Cell::new(version.as_str()));
             row.push(Cell::new(format!("{}", path.path().display(),).as_str()));
+
+            let mut current_marker = "".to_string();
+            if current == version {
+                current_marker = format!("{}", "✅ ".blue());
+            }
+            row.push(Cell::new(current_marker.as_str()));
             table.add_row(Row::new(row));
         }
         table.print(writer).unwrap();

--- a/fusecli/cli/src/cmds/packages/mod.rs
+++ b/fusecli/cli/src/cmds/packages/mod.rs
@@ -5,3 +5,4 @@
 pub mod fetch;
 pub mod list;
 pub mod package;
+pub mod switch;

--- a/fusecli/cli/src/cmds/packages/package.rs
+++ b/fusecli/cli/src/cmds/packages/package.rs
@@ -11,6 +11,7 @@ use crate::cmds::command::Command;
 use crate::cmds::Config;
 use crate::cmds::FetchCommand;
 use crate::cmds::ListCommand;
+use crate::cmds::SwitchCommand;
 use crate::cmds::Writer;
 use crate::error::Result;
 
@@ -38,6 +39,12 @@ impl PackageCommand {
                         .setting(AppSettings::DisableVersion)
                         .setting(AppSettings::ColoredHelp)
                         .about("List all the packages"),
+                )
+                .subcommand(
+                    App::new("switch")
+                        .setting(AppSettings::DisableVersion)
+                        .setting(AppSettings::ColoredHelp)
+                        .about("Switch the active datafuse to a specified version"),
                 ),
         );
         PackageCommand { conf, clap }
@@ -72,6 +79,10 @@ impl Command for PackageCommand {
                 Some("list") => {
                     let list = ListCommand::create(self.conf.clone());
                     list.exec(writer, args)?;
+                }
+                Some("switch") => {
+                    let switch = SwitchCommand::create(self.conf.clone());
+                    switch.exec(writer, args)?;
                 }
                 _ => writer.write_err("unknown command, usage: package -h"),
             },

--- a/fusecli/cli/src/cmds/packages/package.rs
+++ b/fusecli/cli/src/cmds/packages/package.rs
@@ -6,6 +6,7 @@ use std::cell::RefCell;
 
 use clap::App;
 use clap::AppSettings;
+use clap::Arg;
 
 use crate::cmds::command::Command;
 use crate::cmds::Config;
@@ -44,7 +45,10 @@ impl PackageCommand {
                     App::new("switch")
                         .setting(AppSettings::DisableVersion)
                         .setting(AppSettings::ColoredHelp)
-                        .about("Switch the active datafuse to a specified version"),
+                        .about("Switch the active datafuse to a specified version")
+                        .arg(Arg::with_name("version").required(true).help(
+                            "Version of datafuse package, e.g. v0.4.69-nightly. Check the versions: package list"
+                        ))
                 ),
         );
         PackageCommand { conf, clap }
@@ -81,8 +85,9 @@ impl Command for PackageCommand {
                     list.exec(writer, args)?;
                 }
                 Some("switch") => {
+                    let val = matches.subcommand().1.unwrap().value_of("version").unwrap();
                     let switch = SwitchCommand::create(self.conf.clone());
-                    switch.exec(writer, args)?;
+                    switch.exec(writer, val.to_string())?;
                 }
                 _ => writer.write_err("unknown command, usage: package -h"),
             },

--- a/fusecli/cli/src/cmds/packages/switch.rs
+++ b/fusecli/cli/src/cmds/packages/switch.rs
@@ -1,0 +1,45 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use std::fs;
+
+use prettytable::Cell;
+use prettytable::Row;
+use prettytable::Table;
+
+use crate::cmds::Config;
+use crate::cmds::Writer;
+use crate::error::Result;
+
+#[derive(Clone)]
+pub struct SwitchCommand {
+    conf: Config,
+}
+
+impl SwitchCommand {
+    pub fn create(conf: Config) -> Self {
+        SwitchCommand { conf }
+    }
+
+    pub fn exec(&self, writer: &mut Writer, _args: String) -> Result<()> {
+        let bin_dir = format!("{}/bin", self.conf.datafuse_dir.clone());
+        let paths = fs::read_dir(bin_dir)?;
+
+        let mut table = Table::new();
+        // Title.
+        table.add_row(Row::new(vec![Cell::new("Version"), Cell::new("Path")]));
+        for path in paths {
+            let path = path.unwrap();
+            let mut row = vec![];
+            row.push(Cell::new(
+                path.path().file_name().unwrap().to_str().unwrap(),
+            ));
+            row.push(Cell::new(format!("{}", path.path().display(),).as_str()));
+            table.add_row(Row::new(row));
+        }
+        table.print(writer).unwrap();
+
+        Ok(())
+    }
+}

--- a/fusecli/cli/src/cmds/status.rs
+++ b/fusecli/cli/src/cmds/status.rs
@@ -13,7 +13,7 @@ use crate::error::Result;
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Status {
     path: String,
-    pub latest: String,
+    pub version: String,
 }
 
 impl Status {
@@ -25,7 +25,7 @@ impl Status {
             let file = File::create(status_path.as_str())?;
             let status = Status {
                 path: status_path.clone(),
-                latest: "".to_string(),
+                version: "".to_string(),
             };
             serde_json::to_writer(&file, &status)?;
         }

--- a/fusecli/cli/src/cmds/status_test.rs
+++ b/fusecli/cli/src/cmds/status_test.rs
@@ -12,7 +12,7 @@ fn test_status() -> Result<()> {
     conf.datafuse_dir = "/tmp/".to_string();
 
     let mut status = Status::read(conf)?;
-    status.latest = "xx".to_string();
+    status.version = "xx".to_string();
     status.write()?;
 
     Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

* Add datafuse-cli package switch for switching the active datafuse to a specified version

Example:
```
[test] > package list
+-----------------+-----------------------------------------------+---------+
| Version         | Path                                          | Current |
+-----------------+-----------------------------------------------+---------+
| v0.4.69-nightly | /home/bohu/.datafuse/test/bin/v0.4.69-nightly |         |
+-----------------+-----------------------------------------------+---------+
| v0.4.68-nightly | /home/bohu/.datafuse/test/bin/v0.4.68-nightly | ✅      |
+-----------------+-----------------------------------------------+---------+
[test] > package switch v0.4.69-nightly
✅ [ok] Package switch to v0.4.69-nightly
[test] > package list
+-----------------+-----------------------------------------------+---------+
| Version         | Path                                          | Current |
+-----------------+-----------------------------------------------+---------+
| v0.4.69-nightly | /home/bohu/.datafuse/test/bin/v0.4.69-nightly | ✅      |
+-----------------+-----------------------------------------------+---------+
| v0.4.68-nightly | /home/bohu/.datafuse/test/bin/v0.4.68-nightly |         |
+-----------------+-----------------------------------------------+---------+


```
## Changelog

- New Feature

## Related Issues

#938 

## Test Plan

Unit Tests

Stateless Tests

