### PR TITLE
[deps] all in comfy-table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,12 +94,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237430fd6ed3740afe94eefcc278ae21e050285be882804e0d6e8695f0c94691"
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
 name = "arrayvec"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,7 +111,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 [[package]]
 name = "arrow-flight"
 version = "0.1.0"
-source = "git+https://github.com/datafuse-extras/arrow2?rev=d545253#d545253e30fa9060e1f74b973df378ef2d82fec2"
+source = "git+https://github.com/datafuse-extras/arrow2?rev=e92f47a#e92f47a1ec70f22f07ca8ed5af371e2112d2df3c"
 dependencies = [
  "arrow2",
  "bytes",
@@ -131,11 +125,12 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.2.0"
-source = "git+https://github.com/datafuse-extras/arrow2?rev=d545253#d545253e30fa9060e1f74b973df378ef2d82fec2"
+source = "git+https://github.com/datafuse-extras/arrow2?rev=e92f47a#e92f47a1ec70f22f07ca8ed5af371e2112d2df3c"
 dependencies = [
  "ahash 0.7.4",
  "base64",
  "chrono",
+ "comfy-table",
  "csv",
  "flatbuffers",
  "futures",
@@ -150,7 +145,6 @@ dependencies = [
  "num",
  "packed_simd_2",
  "parquet2 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prettytable-rs",
  "rand 0.8.4",
  "regex",
  "serde",
@@ -335,17 +329,6 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec 0.5.2",
- "constant_time_eq",
 ]
 
 [[package]]
@@ -983,12 +966,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,13 +1307,13 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "colored",
+ "comfy-table",
  "common-building",
- "dirs 3.0.2",
+ "dirs",
  "dyn-clone",
  "flate2",
  "indicatif",
  "pretty_assertions",
- "prettytable-rs",
  "run_script",
  "rustyline",
  "serde",
@@ -1413,17 +1390,6 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-dependencies = [
- "libc",
- "redox_users 0.3.5",
- "winapi",
-]
-
-[[package]]
-name = "dirs"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
@@ -1448,7 +1414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
- "redox_users 0.4.0",
+ "redox_users",
  "winapi",
 ]
 
@@ -1459,7 +1425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users 0.4.0",
+ "redox_users",
  "winapi",
 ]
 
@@ -1656,7 +1622,7 @@ checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.9",
+ "redox_syscall",
  "winapi",
 ]
 
@@ -3459,7 +3425,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.9",
+ "redox_syscall",
  "smallvec",
  "winapi",
 ]
@@ -3821,20 +3787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettytable-rs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
-dependencies = [
- "atty",
- "csv",
- "encode_unicode",
- "lazy_static",
- "term",
- "unicode-width",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4170,12 +4122,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
@@ -4185,23 +4131,12 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
-]
-
-[[package]]
-name = "redox_users"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.3",
- "redox_syscall 0.2.9",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -4335,18 +4270,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fa4becc694242c537d43695743701f362b43c42cb11a3d44c8a01eb0cd18ded"
 dependencies = [
  "fsio",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -5110,19 +5033,8 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.4",
- "redox_syscall 0.2.9",
+ "redox_syscall",
  "remove_dir_all",
- "winapi",
-]
-
-[[package]]
-name = "term"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
-dependencies = [
- "byteorder",
- "dirs 1.0.5",
  "winapi",
 ]
 

--- a/common/arrow/Cargo.toml
+++ b/common/arrow/Cargo.toml
@@ -15,8 +15,8 @@ simd = ["arrow/simd"]
 # Workspace dependencies
 
 # Github dependencies
-arrow = { package = "arrow2", git="https://github.com/datafuse-extras/arrow2", rev = "d545253" }
-arrow-flight = { git="https://github.com/datafuse-extras/arrow2", rev = "d545253" }
+arrow = { package = "arrow2", git="https://github.com/datafuse-extras/arrow2", rev = "e92f47a" }
+arrow-flight = { git="https://github.com/datafuse-extras/arrow2", rev = "e92f47a" }
 parquet = {package = "parquet2", git = "https://github.com/datafuse-extras/parquet2", rev = "05854c0"}
 # Crates.io dependencies
 

--- a/common/datablocks/src/data_block_debug.rs
+++ b/common/datablocks/src/data_block_debug.rs
@@ -10,7 +10,7 @@ use crate::DataBlock;
 
 ///! Create a visual representation of record batches
 pub fn pretty_format_blocks(results: &[DataBlock]) -> Result<String> {
-    Ok(create_table(results)?.to_string())
+    Ok(create_table(results)?.trim_fmt())
 }
 
 pub fn assert_blocks_eq(expect: Vec<&str>, blocks: &[DataBlock]) {

--- a/common/datavalues/src/series/series_debug.rs
+++ b/common/datavalues/src/series/series_debug.rs
@@ -10,7 +10,7 @@ use super::Series;
 
 ///! Create a visual representation of record batches
 pub fn pretty_format_series(results: &[Series]) -> Result<String> {
-    Ok(create_table(results)?.to_string())
+    Ok(create_table(results)?.trim_fmt())
 }
 
 pub fn assert_series_eq(expect: Vec<&str>, series: &[Series]) {

--- a/fusecli/cli/Cargo.toml
+++ b/fusecli/cli/Cargo.toml
@@ -21,11 +21,11 @@ path = "src/bin/datafuse-cli.rs"
 # Crates.io dependencies
 clap = "2.33.3"
 colored = "2.0.0"
+comfy-table = "4.0.1"
 dirs = "3.0.2"
 dyn-clone = "1.0.4"
 flate2 = "1.0.20"
 indicatif = "0.16.2"
-prettytable-rs = "0.8.0"
 run_script = "^0.8.0"
 rustyline = "8.2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/fusecli/cli/src/cmds/packages/list.rs
+++ b/fusecli/cli/src/cmds/packages/list.rs
@@ -4,8 +4,9 @@
 
 use std::fs;
 
-use colored::Colorize;
 use comfy_table::Cell;
+use comfy_table::CellAlignment;
+use comfy_table::Color;
 use comfy_table::Table;
 
 use crate::cmds::Config;
@@ -51,16 +52,16 @@ impl ListCommand {
                 .into_owned();
             let mut row = vec![];
             row.push(Cell::new(version.as_str()));
-            row.push(Cell::new(format!("{}", path.path().display(),).as_str()));
+            row.push(Cell::new(format!("{}", path.path().display(),)));
 
-            let mut current_marker = "".to_string();
+            let mut current_marker = Cell::new("");
             if current == version {
-                current_marker = format!("{}", "✅ ".blue());
+                current_marker = Cell::new("☑").fg(Color::Green);
             }
-            row.push(Cell::new(current_marker.as_str()));
+            row.push(current_marker.set_alignment(CellAlignment::Center));
             table.add_row(row);
         }
-        writer.writeln(&table.to_string());
+        writer.writeln(&table.trim_fmt());
 
         Ok(())
     }

--- a/fusecli/cli/src/cmds/packages/list.rs
+++ b/fusecli/cli/src/cmds/packages/list.rs
@@ -5,9 +5,8 @@
 use std::fs;
 
 use colored::Colorize;
-use prettytable::Cell;
-use prettytable::Row;
-use prettytable::Table;
+use comfy_table::Cell;
+use comfy_table::Table;
 
 use crate::cmds::Config;
 use crate::cmds::Status;
@@ -35,12 +34,13 @@ impl ListCommand {
         }
 
         let mut table = Table::new();
+        table.load_preset("||--+-++|    ++++++");
         // Title.
-        table.add_row(Row::new(vec![
+        table.set_header(vec![
             Cell::new("Version"),
             Cell::new("Path"),
             Cell::new("Current"),
-        ]));
+        ]);
         for path in paths {
             let path = path.unwrap();
             let version = path
@@ -58,9 +58,9 @@ impl ListCommand {
                 current_marker = format!("{}", "✅ ".blue());
             }
             row.push(Cell::new(current_marker.as_str()));
-            table.add_row(Row::new(row));
+            table.add_row(row);
         }
-        table.print(writer).unwrap();
+        writer.writeln(&table.to_string());
 
         Ok(())
     }

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -46,8 +46,8 @@ pub fn next_port() -> u32 {
     19000u32 + (*Seq::default() as u32)
 }
 
+#[allow(dead_code)]
 pub struct StoreTestContext {
-    #[allow(dead_code)]
     meta_temp_dir: TempDir,
     local_fs_tmp_dir: TempDir,
     pub config: configs::Config,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

remove prettytable-rs, all in comfy-table

- prettytable-rs to comfy-table
- ✅ -> utf-8 `☑`, this will make the comfy-table align correctly
- the format is adjusted to be more compact and consistent with the output of the fusequery 

## Changelog

- Improvement

## Related Issues

Related #1126 #1095 https://github.com/jorgecarleitao/arrow2/pull/251

## Test Plan

Unit Tests

Stateless Tests

