### PR TITLE
[cli] fix: status test should use different temp dir or next time it reads the old data left by previous test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,7 @@ dependencies = [
  "structopt",
  "sysinfo 0.20.0",
  "tar",
+ "tempfile",
  "thiserror",
  "ureq",
 ]

--- a/fusecli/cli/Cargo.toml
+++ b/fusecli/cli/Cargo.toml
@@ -39,6 +39,7 @@ ureq = { version = "2.1.1", features = ["json"] }
 
 [dev-dependencies]
 pretty_assertions = "0.7"
+tempfile = "3.2.0"
 
 [build-dependencies]
 common-building = {path = "../../common/building"}

--- a/fusecli/cli/src/cmds/status.rs
+++ b/fusecli/cli/src/cmds/status.rs
@@ -42,6 +42,7 @@ impl Status {
             .write(true)
             .truncate(true)
             .open(self.path.clone())?;
+        println!("{:?}", self);
         serde_json::to_writer(&file, self)?;
         Ok(())
     }

--- a/fusecli/cli/src/cmds/status_test.rs
+++ b/fusecli/cli/src/cmds/status_test.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
+use tempfile::tempdir;
+
 use crate::cmds::Config;
 use crate::cmds::Status;
 use crate::error::Result;
@@ -9,7 +11,9 @@ use crate::error::Result;
 #[test]
 fn test_status() -> Result<()> {
     let mut conf = Config::default();
-    conf.datafuse_dir = "/tmp/".to_string();
+
+    let t = tempdir()?;
+    conf.datafuse_dir = t.path().to_str().unwrap().to_string();
 
     let mut status = Status::read(conf)?;
     status.version = "xx".to_string();


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [cli] fix: status test should use different temp dir or next time it reads the old data left by previous test

## Changelog


- Bug Fix



