### PR TITLE
[store] refactor: remove MetaStore::{open,new}, open_create() is enough

### DIFF
--- a/fusestore/store/src/meta_service/meta_store_test.rs
+++ b/fusestore/store/src/meta_service/meta_store_test.rs
@@ -8,6 +8,7 @@ use common_runtime::tokio;
 use common_tracing::tracing;
 
 use crate::meta_service::MetaStore;
+use crate::tests::service::init_store_unittest;
 use crate::tests::service::new_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -20,13 +21,17 @@ async fn test_meta_store_restart() -> anyhow::Result<()> {
     // TODO check log
     // TODO check state machine
 
+    init_store_unittest();
+
     let id = 3;
-    let tc = new_test_context();
+    let mut tc = new_test_context();
+    tc.config.id = id;
 
     tracing::info!("--- new MetaStore");
     {
-        let ms = MetaStore::new(id, &tc.config).await?;
+        let (ms, is_open) = MetaStore::open_create(&tc.config, None, Some(())).await?;
         assert_eq!(id, ms.id);
+        assert!(!is_open);
         assert_eq!(None, ms.read_hard_state().await?);
 
         tracing::info!("--- update MetaStore");
@@ -40,8 +45,9 @@ async fn test_meta_store_restart() -> anyhow::Result<()> {
 
     tracing::info!("--- reopen MetaStore");
     {
-        let ms = MetaStore::open(&tc.config).await?;
+        let (ms, is_open) = MetaStore::open_create(&tc.config, Some(()), None).await?;
         assert_eq!(id, ms.id);
+        assert!(is_open);
         assert_eq!(
             Some(HardState {
                 current_term: 10,

--- a/fusestore/store/src/meta_service/placement.rs
+++ b/fusestore/store/src/meta_service/placement.rs
@@ -31,7 +31,7 @@ pub trait Placement {
 
         slot.node_ids
             .iter()
-            .map(|nid| self.get_node(nid).unwrap())
+            .map(|nid| self.get_placement_node(nid).unwrap())
             .collect()
     }
 
@@ -50,7 +50,8 @@ pub trait Placement {
 
     fn get_slots(&self) -> &[Slot];
 
-    fn get_node(&self, node_id: &NodeId) -> Option<Node>;
+    /// Returns a node.
+    fn get_placement_node(&self, node_id: &NodeId) -> Option<Node>;
 }
 
 /// Evenly chooses `n` elements from `m` elements

--- a/fusestore/store/src/meta_service/raft_log.rs
+++ b/fusestore/store/src/meta_service/raft_log.rs
@@ -106,6 +106,6 @@ impl RaftLog {
     }
 
     fn logs(&self) -> AsType<sledkv::Logs> {
-        self.inner.as_type()
+        self.inner.key_space()
     }
 }

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -241,7 +241,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
                     None => (0, 0).into(),
                 };
 
-                let sm_meta = sm.sm_tree.as_type::<StateMachineMeta>();
+                let sm_meta = sm.sm_tree.key_space::<StateMachineMeta>();
 
                 let last_applied_log = sm_meta
                     .get(&LastApplied)?
@@ -345,7 +345,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
             // Serialize the data of the state machine.
             let sm = self.state_machine.write().await;
 
-            let sm_meta = sm.sm_tree.as_type::<StateMachineMeta>();
+            let sm_meta = sm.sm_tree.key_space::<StateMachineMeta>();
 
             let last_applied = sm_meta
                 .get(&LastApplied)?
@@ -508,7 +508,7 @@ impl MetaStore {
             .await
             .expect("fail to get membership");
 
-        let sm_nodes = sm.sm_tree.as_type::<sledkv::Nodes>();
+        let sm_nodes = sm.sm_tree.key_space::<sledkv::Nodes>();
         let x = sm_nodes.range_keys(..).expect("fail to list nodes");
         for node_id in x {
             // it has been added into this cluster and is not a voter.
@@ -840,7 +840,6 @@ impl MetaNode {
         node_id: NodeId,
         config: &configs::Config,
     ) -> common_exception::Result<Arc<MetaNode>> {
-        // TODO test MetaNode::new() on a booted store.
         // TODO(xp): what if fill in the node info into an empty state-machine, then MetaNode can be started without delaying grpc.
 
         let mut config = config.clone();

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -127,27 +127,13 @@ pub struct MetaStore {
 // }
 
 impl MetaStore {
-    /// Create a new `MetaStore` instance.
-    #[tracing::instrument(level = "info")]
-    pub async fn new(id: NodeId, config: &configs::Config) -> common_exception::Result<MetaStore> {
-        // TODO: move id into config.
-        let mut config = config.clone();
-        config.id = id;
-
-        let (ms, _is_open) = Self::open_create(&config, None, Some(())).await?;
-        Ok(ms)
-    }
-
-    /// Open an existent `MetaStore` instance.
-    pub async fn open(config: &configs::Config) -> common_exception::Result<MetaStore> {
-        let (ms, _is_open) = Self::open_create(config, Some(()), None).await?;
-        Ok(ms)
-    }
-
     /// Open an existent `MetaStore` instance or create an new one:
     /// 1. If `open` is `Some`, try to open an existent one.
     /// 2. If `create` is `Some`, try to create one.
     /// Otherwise it panic
+    /// Returns MetaStore instance and a bool indicating if it is opened from a previous state.
+    ///
+    /// TODO(xp): make the is_open flag a field of MetaStore, maybe introduce a trait to define this behavior
     #[tracing::instrument(level = "info")]
     pub async fn open_create(
         config: &configs::Config,

--- a/fusestore/store/src/meta_service/sled_vartype_tree.rs
+++ b/fusestore/store/src/meta_service/sled_vartype_tree.rs
@@ -64,8 +64,8 @@ impl SledVarTypeTree {
         Ok(rl)
     }
 
-    /// Borrows the SledVarTypeTree and creates a wrapper with access limited to a specified namespace `KV`.
-    pub fn as_type<KV: SledKV>(&self) -> AsType<KV> {
+    /// Borrows the SledVarTypeTree and creates a wrapper with access limited to a specified key space `KV`.
+    pub fn key_space<KV: SledKV>(&self) -> AsType<KV> {
         AsType::<KV> {
             inner: self,
             phantom: PhantomData,
@@ -106,8 +106,6 @@ impl SledVarTypeTree {
     /// Retrieve the last key value pair.
     pub fn last<KV>(&self) -> common_exception::Result<Option<(KV::K, KV::V)>>
     where KV: SledKV {
-        // TODO(xp): last should be limited to the value range
-
         let range = (
             Bound::Unbounded,
             KV::serialize_bound(Bound::Unbounded, "right")?,

--- a/fusestore/store/src/meta_service/sled_vartype_tree_test.rs
+++ b/fusestore/store/src/meta_service/sled_vartype_tree_test.rs
@@ -540,7 +540,7 @@ async fn test_as_append() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledVarTypeTree::open(db, tc.config.tree_name("foo"), true).await?;
-    let aslog = tree.as_type::<sledkv::Logs>();
+    let log_tree = tree.key_space::<sledkv::Logs>();
 
     let logs: Vec<(LogIndex, Entry<LogEntry>)> = vec![
         (8, Entry {
@@ -560,7 +560,7 @@ async fn test_as_append() -> anyhow::Result<()> {
         }),
     ];
 
-    aslog.append(&logs).await?;
+    log_tree.append(&logs).await?;
 
     let want: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -580,13 +580,13 @@ async fn test_as_append() -> anyhow::Result<()> {
         },
     ];
 
-    let got = aslog.range_get(0..)?;
+    let got = log_tree.range_get(0..)?;
     assert_eq!(want, got);
 
-    let got = aslog.range_get(0..=5)?;
+    let got = log_tree.range_get(0..=5)?;
     assert_eq!(want[0..1], got);
 
-    let got = aslog.range_get(6..9)?;
+    let got = log_tree.range_get(6..9)?;
     assert_eq!(want[1..], got);
 
     Ok(())
@@ -599,7 +599,7 @@ async fn test_as_append_values_and_range_get() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledVarTypeTree::open(db, tc.config.tree_name("foo"), true).await?;
-    let aslog = tree.as_type::<sledkv::Logs>();
+    let log_tree = tree.key_space::<sledkv::Logs>();
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -634,36 +634,36 @@ async fn test_as_append_values_and_range_get() -> anyhow::Result<()> {
         },
     ];
 
-    aslog.append_values(&logs).await?;
+    log_tree.append_values(&logs).await?;
 
-    let got = aslog.range_get(0..)?;
+    let got = log_tree.range_get(0..)?;
     assert_eq!(logs, got);
 
-    let got = aslog.range_get(0..=2)?;
+    let got = log_tree.range_get(0..=2)?;
     assert_eq!(logs[0..1], got);
 
-    let got = aslog.range_get(0..3)?;
+    let got = log_tree.range_get(0..3)?;
     assert_eq!(logs[0..1], got);
 
-    let got = aslog.range_get(0..5)?;
+    let got = log_tree.range_get(0..5)?;
     assert_eq!(logs[0..2], got);
 
-    let got = aslog.range_get(0..10)?;
+    let got = log_tree.range_get(0..10)?;
     assert_eq!(logs[0..3], got);
 
-    let got = aslog.range_get(0..11)?;
+    let got = log_tree.range_get(0..11)?;
     assert_eq!(logs[0..4], got);
 
-    let got = aslog.range_get(9..11)?;
+    let got = log_tree.range_get(9..11)?;
     assert_eq!(logs[2..4], got);
 
-    let got = aslog.range_get(10..256)?;
+    let got = log_tree.range_get(10..256)?;
     assert_eq!(logs[3..4], got);
 
-    let got = aslog.range_get(10..257)?;
+    let got = log_tree.range_get(10..257)?;
     assert_eq!(logs[3..5], got);
 
-    let got = aslog.range_get(257..)?;
+    let got = log_tree.range_get(257..)?;
     assert_eq!(logs[5..], got);
     Ok(())
 }
@@ -675,7 +675,7 @@ async fn test_as_range_keys() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledVarTypeTree::open(db, tc.config.tree_name("foo"), true).await?;
-    let aslog = tree.as_type::<sledkv::Logs>();
+    let log_tree = tree.key_space::<sledkv::Logs>();
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -692,30 +692,30 @@ async fn test_as_range_keys() -> anyhow::Result<()> {
         },
     ];
 
-    aslog.append_values(&logs).await?;
+    log_tree.append_values(&logs).await?;
 
-    let got = aslog.range_keys(0..)?;
+    let got = log_tree.range_keys(0..)?;
     assert_eq!(vec![2, 9, 10], got);
 
-    let got = aslog.range_keys(0..=2)?;
+    let got = log_tree.range_keys(0..=2)?;
     assert_eq!(vec![2], got);
 
-    let got = aslog.range_keys(0..3)?;
+    let got = log_tree.range_keys(0..3)?;
     assert_eq!(vec![2], got);
 
-    let got = aslog.range_keys(0..10)?;
+    let got = log_tree.range_keys(0..10)?;
     assert_eq!(vec![2, 9], got);
 
-    let got = aslog.range_keys(0..11)?;
+    let got = log_tree.range_keys(0..11)?;
     assert_eq!(vec![2, 9, 10], got);
 
-    let got = aslog.range_keys(9..11)?;
+    let got = log_tree.range_keys(9..11)?;
     assert_eq!(vec![9, 10], got);
 
-    let got = aslog.range_keys(10..256)?;
+    let got = log_tree.range_keys(10..256)?;
     assert_eq!(vec![10], got);
 
-    let got = aslog.range_keys(11..)?;
+    let got = log_tree.range_keys(11..)?;
     assert_eq!(Vec::<LogIndex>::new(), got);
 
     Ok(())
@@ -728,9 +728,9 @@ async fn test_as_insert() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledVarTypeTree::open(db, tc.config.tree_name("foo"), true).await?;
-    let aslog = tree.as_type::<sledkv::Logs>();
+    let log_tree = tree.key_space::<sledkv::Logs>();
 
-    assert_eq!(None, aslog.get(&5)?);
+    assert_eq!(None, log_tree.get(&5)?);
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -751,10 +751,10 @@ async fn test_as_insert() -> anyhow::Result<()> {
     ];
 
     for log in logs.iter() {
-        aslog.insert_value(log).await?;
+        log_tree.insert_value(log).await?;
     }
 
-    assert_eq!(logs, aslog.range_get(..)?);
+    assert_eq!(logs, log_tree.range_get(..)?);
 
     // insert and override
 
@@ -763,7 +763,7 @@ async fn test_as_insert() -> anyhow::Result<()> {
         payload: EntryPayload::Blank,
     };
 
-    let prev = aslog.insert_value(&override_2).await?;
+    let prev = log_tree.insert_value(&override_2).await?;
     assert_eq!(Some(logs[0].clone()), prev);
 
     // insert and override nothing
@@ -776,7 +776,7 @@ async fn test_as_insert() -> anyhow::Result<()> {
         payload: EntryPayload::Blank,
     };
 
-    let prev = aslog.insert_value(&override_nothing).await?;
+    let prev = log_tree.insert_value(&override_nothing).await?;
     assert_eq!(None, prev);
 
     Ok(())
@@ -789,9 +789,9 @@ async fn test_as_contains_key() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledVarTypeTree::open(db, tc.config.tree_name("foo"), true).await?;
-    let aslog = tree.as_type::<sledkv::Logs>();
+    let log_tree = tree.key_space::<sledkv::Logs>();
 
-    assert_eq!(None, aslog.get(&5)?);
+    assert_eq!(None, log_tree.get(&5)?);
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -811,13 +811,13 @@ async fn test_as_contains_key() -> anyhow::Result<()> {
         },
     ];
 
-    aslog.append_values(&logs).await?;
+    log_tree.append_values(&logs).await?;
 
-    assert!(!aslog.contains_key(&1)?);
-    assert!(aslog.contains_key(&2)?);
-    assert!(!aslog.contains_key(&3)?);
-    assert!(aslog.contains_key(&4)?);
-    assert!(!aslog.contains_key(&5)?);
+    assert!(!log_tree.contains_key(&1)?);
+    assert!(log_tree.contains_key(&2)?);
+    assert!(!log_tree.contains_key(&3)?);
+    assert!(log_tree.contains_key(&4)?);
+    assert!(!log_tree.contains_key(&5)?);
 
     Ok(())
 }
@@ -829,9 +829,9 @@ async fn test_as_get() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledVarTypeTree::open(db, tc.config.tree_name("foo"), true).await?;
-    let aslog = tree.as_type::<sledkv::Logs>();
+    let log_tree = tree.key_space::<sledkv::Logs>();
 
-    assert_eq!(None, aslog.get(&5)?);
+    assert_eq!(None, log_tree.get(&5)?);
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -851,13 +851,13 @@ async fn test_as_get() -> anyhow::Result<()> {
         },
     ];
 
-    aslog.append_values(&logs).await?;
+    log_tree.append_values(&logs).await?;
 
-    assert_eq!(None, aslog.get(&1)?);
-    assert_eq!(Some(logs[0].clone()), aslog.get(&2)?);
-    assert_eq!(None, aslog.get(&3)?);
-    assert_eq!(Some(logs[1].clone()), aslog.get(&4)?);
-    assert_eq!(None, aslog.get(&5)?);
+    assert_eq!(None, log_tree.get(&1)?);
+    assert_eq!(Some(logs[0].clone()), log_tree.get(&2)?);
+    assert_eq!(None, log_tree.get(&3)?);
+    assert_eq!(Some(logs[1].clone()), log_tree.get(&4)?);
+    assert_eq!(None, log_tree.get(&5)?);
 
     Ok(())
 }
@@ -869,9 +869,9 @@ async fn test_as_last() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledVarTypeTree::open(db, tc.config.tree_name("foo"), true).await?;
-    let aslog = tree.as_type::<sledkv::Logs>();
+    let log_tree = tree.key_space::<sledkv::Logs>();
 
-    assert_eq!(None, aslog.last()?);
+    assert_eq!(None, log_tree.last()?);
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -891,8 +891,8 @@ async fn test_as_last() -> anyhow::Result<()> {
         },
     ];
 
-    aslog.append_values(&logs).await?;
-    assert_eq!(Some((4, logs[1].clone())), aslog.last()?);
+    log_tree.append_values(&logs).await?;
+    assert_eq!(Some((4, logs[1].clone())), log_tree.last()?);
 
     Ok(())
 }
@@ -904,7 +904,7 @@ async fn test_as_range_delete() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledVarTypeTree::open(db, tc.config.tree_name("foo"), true).await?;
-    let aslog = tree.as_type::<sledkv::Logs>();
+    let log_tree = tree.key_space::<sledkv::Logs>();
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -939,22 +939,22 @@ async fn test_as_range_delete() -> anyhow::Result<()> {
         },
     ];
 
-    aslog.append_values(&logs).await?;
-    aslog.range_delete(0.., false).await?;
-    assert_eq!(logs[5..], aslog.range_get(0..)?);
+    log_tree.append_values(&logs).await?;
+    log_tree.range_delete(0.., false).await?;
+    assert_eq!(logs[5..], log_tree.range_get(0..)?);
 
-    aslog.append_values(&logs).await?;
-    aslog.range_delete(1.., false).await?;
-    assert_eq!(logs[5..], aslog.range_get(0..)?);
+    log_tree.append_values(&logs).await?;
+    log_tree.range_delete(1.., false).await?;
+    assert_eq!(logs[5..], log_tree.range_get(0..)?);
 
-    aslog.append_values(&logs).await?;
-    aslog.range_delete(3.., true).await?;
-    assert_eq!(logs[0..1], aslog.range_get(0..)?);
+    log_tree.append_values(&logs).await?;
+    log_tree.range_delete(3.., true).await?;
+    assert_eq!(logs[0..1], log_tree.range_get(0..)?);
 
-    aslog.append_values(&logs).await?;
-    aslog.range_delete(3..10, true).await?;
-    assert_eq!(logs[0..1], aslog.range_get(0..5)?);
-    assert_eq!(logs[3..], aslog.range_get(5..)?);
+    log_tree.append_values(&logs).await?;
+    log_tree.range_delete(3..10, true).await?;
+    assert_eq!(logs[0..1], log_tree.range_get(0..5)?);
+    assert_eq!(logs[3..], log_tree.range_get(5..)?);
 
     Ok(())
 }
@@ -966,8 +966,8 @@ async fn test_as_multi_types() -> anyhow::Result<()> {
     let tc = new_sled_test_context();
     let db = &tc.db;
     let tree = SledVarTypeTree::open(db, tc.config.tree_name("foo"), true).await?;
-    let aslog = tree.as_type::<sledkv::Logs>();
-    let asmeta = tree.as_type::<StateMachineMeta>();
+    let log_tree = tree.key_space::<sledkv::Logs>();
+    let sm_meta = tree.key_space::<StateMachineMeta>();
 
     let logs: Vec<Entry<LogEntry>> = vec![
         Entry {
@@ -987,7 +987,7 @@ async fn test_as_multi_types() -> anyhow::Result<()> {
         },
     ];
 
-    aslog.append_values(&logs).await?;
+    log_tree.append_values(&logs).await?;
 
     let metas = vec![
         (
@@ -996,31 +996,31 @@ async fn test_as_multi_types() -> anyhow::Result<()> {
         ),
         (Initialized, StateMachineMetaValue::Bool(true)),
     ];
-    asmeta.append(&metas).await?;
+    sm_meta.append(&metas).await?;
 
     // range get/keys are limited to its own namespace.
     {
-        let got = aslog.range_get(..)?;
+        let got = log_tree.range_get(..)?;
         assert_eq!(logs, got);
 
-        let got = asmeta.range_get(..=LastApplied)?;
+        let got = sm_meta.range_get(..=LastApplied)?;
         assert_eq!(
             vec![StateMachineMetaValue::LogId(LogId { term: 1, index: 2 })],
             got
         );
 
-        let got = asmeta.range_get(Initialized..)?;
+        let got = sm_meta.range_get(Initialized..)?;
         assert_eq!(vec![StateMachineMetaValue::Bool(true)], got);
 
-        let got = asmeta.range_keys(Initialized..)?;
+        let got = sm_meta.range_keys(Initialized..)?;
         assert_eq!(vec![Initialized], got);
     }
 
     // range delete are limited to its own namespace.
     {
-        asmeta.range_delete(.., false).await?;
+        sm_meta.range_delete(.., false).await?;
 
-        let got = aslog.range_get(..)?;
+        let got = log_tree.range_get(..)?;
         assert_eq!(logs, got);
     }
 

--- a/fusestore/store/src/meta_service/state_machine.rs
+++ b/fusestore/store/src/meta_service/state_machine.rs
@@ -214,7 +214,7 @@ impl StateMachine {
         };
 
         let inited = {
-            let sm_meta = sm.sm_tree.as_type::<StateMachineMeta>();
+            let sm_meta = sm.sm_tree.key_space::<StateMachineMeta>();
             sm_meta.get(&Initialized)?
         };
 
@@ -224,7 +224,7 @@ impl StateMachine {
             // Run the default init on a new state machine.
             // TODO(xp): initialization should be customizable.
             let sm = StateMachine::initializer().init(sm);
-            let sm_meta = sm.sm_tree.as_type::<StateMachineMeta>();
+            let sm_meta = sm.sm_tree.key_space::<StateMachineMeta>();
             sm_meta
                 .insert(&Initialized, &StateMachineMetaValue::Bool(true))
                 .await?;
@@ -330,7 +330,7 @@ impl StateMachine {
     pub async fn apply(&mut self, log_id: &LogId, data: &LogEntry) -> anyhow::Result<AppliedState> {
         // TODO(xp): all update need to be done in a tx.
 
-        let sm_meta = self.sm_tree.as_type::<StateMachineMeta>();
+        let sm_meta = self.sm_tree.key_space::<StateMachineMeta>();
         sm_meta
             .insert(&LastApplied, &StateMachineMetaValue::LogId(*log_id))
             .await?;
@@ -385,7 +385,7 @@ impl StateMachine {
                 ref node_id,
                 ref node,
             } => {
-                let sm_nodes = self.sm_tree.as_type::<sledkv::Nodes>();
+                let sm_nodes = self.sm_tree.key_space::<sledkv::Nodes>();
 
                 let prev = sm_nodes.get(node_id)?;
 
@@ -547,7 +547,7 @@ impl StateMachine {
     }
 
     fn list_node_ids(&self) -> Vec<NodeId> {
-        let sm_nodes = self.sm_tree.as_type::<sledkv::Nodes>();
+        let sm_nodes = self.sm_tree.key_space::<sledkv::Nodes>();
         sm_nodes.range_keys(..).expect("fail to list nodes")
     }
 
@@ -562,8 +562,8 @@ impl StateMachine {
     pub fn get_node(&self, node_id: &NodeId) -> Option<Node> {
         // TODO(xp): handle error
 
-        let as_node = self.sm_tree.as_type::<sledkv::Nodes>();
-        as_node.get(node_id).expect("fail to get node")
+        let sm_nodes = self.sm_tree.key_space::<sledkv::Nodes>();
+        sm_nodes.get(node_id).expect("fail to get node")
     }
 
     pub fn get_database(&self, name: &str) -> Option<Database> {

--- a/fusestore/store/src/meta_service/state_machine.rs
+++ b/fusestore/store/src/meta_service/state_machine.rs
@@ -724,10 +724,7 @@ impl Placement for StateMachine {
         &self.slots
     }
 
-    fn get_node(&self, node_id: &NodeId) -> Option<Node> {
-        // TODO(xp): dup code: remove get_node in StateMachine impl
-        // TODO(xp): handle error
-        let as_node = self.sm_tree.as_type::<sledkv::Nodes>();
-        as_node.get(node_id).expect("fail to get node")
+    fn get_placement_node(&self, node_id: &NodeId) -> Option<Node> {
+        self.get_node(node_id)
     }
 }

--- a/fusestore/store/src/meta_service/state_machine_test.rs
+++ b/fusestore/store/src/meta_service/state_machine_test.rs
@@ -30,7 +30,7 @@ async fn test_state_machine_assign_rand_nodes_to_slot() -> anyhow::Result<()> {
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config).await?;
     sm.sm_tree
-        .as_type::<sledkv::Nodes>()
+        .key_space::<sledkv::Nodes>()
         .append(&[
             (1, Node::default()),
             (3, Node::default()),
@@ -71,7 +71,7 @@ async fn test_state_machine_init_slots() -> anyhow::Result<()> {
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config).await?;
     sm.sm_tree
-        .as_type::<sledkv::Nodes>()
+        .key_space::<sledkv::Nodes>()
         .append(&[
             (1, Node::default()),
             (3, Node::default()),


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: remove MetaStore::{open,new}, open_create() is enough

##### [store] refactor: rename SledVarTypeTree::as_type to key_space

##### [store] refactor: remove dup impl: StateMachine::get_node() is provided by impl Placement

## Changelog




- Improvement


## Related Issues

- #271