### PR TITLE
[store] refactor: add a field `is_open` to MetaStore and RaftState to indicate if it is opened from a previously saved state

### DIFF
--- a/fusestore/store/src/meta_service/meta_store_test.rs
+++ b/fusestore/store/src/meta_service/meta_store_test.rs
@@ -29,9 +29,9 @@ async fn test_meta_store_restart() -> anyhow::Result<()> {
 
     tracing::info!("--- new MetaStore");
     {
-        let (ms, is_open) = MetaStore::open_create(&tc.config, None, Some(())).await?;
+        let ms = MetaStore::open_create(&tc.config, None, Some(())).await?;
         assert_eq!(id, ms.id);
-        assert!(!is_open);
+        assert!(!ms.is_open());
         assert_eq!(None, ms.read_hard_state().await?);
 
         tracing::info!("--- update MetaStore");
@@ -45,9 +45,9 @@ async fn test_meta_store_restart() -> anyhow::Result<()> {
 
     tracing::info!("--- reopen MetaStore");
     {
-        let (ms, is_open) = MetaStore::open_create(&tc.config, Some(()), None).await?;
+        let ms = MetaStore::open_create(&tc.config, Some(()), None).await?;
         assert_eq!(id, ms.id);
-        assert!(is_open);
+        assert!(ms.is_open());
         assert_eq!(
             Some(HardState {
                 current_term: 10,

--- a/fusestore/store/src/meta_service/raft_state_test.rs
+++ b/fusestore/store/src/meta_service/raft_state_test.rs
@@ -19,7 +19,8 @@ async fn test_raft_state_create() -> anyhow::Result<()> {
     let mut tc = new_sled_test_context();
     let db = &tc.db;
     tc.config.id = 3;
-    let (rs, is_open) = RaftState::open_create(db, &tc.config, None, Some(())).await?;
+    let rs = RaftState::open_create(db, &tc.config, None, Some(())).await?;
+    let is_open = rs.is_open();
 
     assert_eq!(3, rs.id);
     assert!(!is_open);
@@ -52,13 +53,15 @@ async fn test_raft_state_open() -> anyhow::Result<()> {
     let mut tc = new_sled_test_context();
     let db = &tc.db;
     tc.config.id = 3;
-    let (rs, is_open) = RaftState::open_create(db, &tc.config, None, Some(())).await?;
+    let rs = RaftState::open_create(db, &tc.config, None, Some(())).await?;
+    let is_open = rs.is_open();
 
     assert_eq!(3, rs.id);
     assert!(!is_open);
 
     tc.config.id = 1000;
-    let (rs, is_open) = RaftState::open_create(db, &tc.config, Some(()), None).await?;
+    let rs = RaftState::open_create(db, &tc.config, Some(()), None).await?;
+    let is_open = rs.is_open();
     assert_eq!(3, rs.id);
     assert!(is_open);
     Ok(())
@@ -71,7 +74,8 @@ async fn test_raft_state_open_or_create() -> anyhow::Result<()> {
     let mut tc = new_sled_test_context();
     let db = &tc.db;
     tc.config.id = 3;
-    let (rs, is_open) = RaftState::open_create(db, &tc.config, Some(()), Some(())).await?;
+    let rs = RaftState::open_create(db, &tc.config, Some(()), Some(())).await?;
+    let is_open = rs.is_open();
 
     assert_eq!(3, rs.id);
     assert!(!is_open);
@@ -88,7 +92,7 @@ async fn test_raft_state_write_read_hard_state() -> anyhow::Result<()> {
     let mut tc = new_sled_test_context();
     let db = &tc.db;
     tc.config.id = 3;
-    let (rs, _) = RaftState::open_create(db, &tc.config, None, Some(())).await?;
+    let rs = RaftState::open_create(db, &tc.config, None, Some(())).await?;
 
     assert_eq!(3, rs.id);
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: add a field `is_open` to MetaStore and RaftState to indicate if it is opened from a previously saved state

## Changelog




- Improvement


## Related Issues

- #271
- #1080 