### PR TITLE
ISSUE-1191: fix mysql client borderline missing for EXPLAIN statement

### DIFF
--- a/fusequery/query/src/interpreters/interpreter_explain.rs
+++ b/fusequery/query/src/interpreters/interpreter_explain.rs
@@ -54,7 +54,11 @@ impl ExplainInterpreter {
     fn explain_graph(&self) -> Result<DataBlock> {
         let schema = self.schema();
         let plan = Optimizers::create(self.ctx.clone()).optimize(&self.explain.input)?;
-        let formatted_plan = Series::new(format!("{}", plan.display_graphviz()).lines().collect::<Vec<_>>());
+        let formatted_plan = Series::new(
+            format!("{}", plan.display_graphviz())
+                .lines()
+                .collect::<Vec<_>>(),
+        );
         Ok(DataBlock::create_by_array(schema, vec![formatted_plan]))
     }
 

--- a/fusequery/query/src/interpreters/interpreter_explain.rs
+++ b/fusequery/query/src/interpreters/interpreter_explain.rs
@@ -54,14 +54,14 @@ impl ExplainInterpreter {
     fn explain_graph(&self) -> Result<DataBlock> {
         let schema = self.schema();
         let plan = Optimizers::create(self.ctx.clone()).optimize(&self.explain.input)?;
-        let formatted_plan = Series::new(vec![format!("{}", plan.display_graphviz()).as_str()]);
+        let formatted_plan = Series::new(format!("{}", plan.display_graphviz()).lines().collect::<Vec<_>>());
         Ok(DataBlock::create_by_array(schema, vec![formatted_plan]))
     }
 
     fn explain_syntax(&self) -> Result<DataBlock> {
         let schema = self.schema();
         let plan = Optimizers::create(self.ctx.clone()).optimize(&self.explain.input)?;
-        let formatted_plan = Series::new(vec![format!("{:?}", plan).as_str()]);
+        let formatted_plan = Series::new(format!("{:?}", plan).lines().collect::<Vec<_>>());
         Ok(DataBlock::create_by_array(schema, vec![formatted_plan]))
     }
 
@@ -70,7 +70,7 @@ impl ExplainInterpreter {
         let plan = Optimizers::without_scatters(self.ctx.clone()).optimize(&self.explain.input)?;
         let pipeline_builder = PipelineBuilder::create(self.ctx.clone());
         let pipeline = pipeline_builder.build(&plan)?;
-        let formatted_pipeline = Series::new(vec![format!("{:?}", pipeline).as_str()]);
+        let formatted_pipeline = Series::new(format!("{:?}", pipeline).lines().collect::<Vec<_>>());
         Ok(DataBlock::create_by_array(schema, vec![formatted_pipeline]))
     }
 }

--- a/fusequery/query/src/interpreters/interpreter_explain_test.rs
+++ b/fusequery/query/src/interpreters/interpreter_explain_test.rs
@@ -25,6 +25,7 @@ async fn test_explain_interpreter() -> Result<()> {
         let result = stream.try_collect::<Vec<_>>().await?;
         let block = &result[0];
         assert_eq!(block.num_columns(), 1);
+        assert_eq!(block.column(0).len(), 4);
 
         let expected = vec![
             "+-----------------------------------------------------------------------------------------------------------------------+",

--- a/tests/suites/0_stateless/02_0004_function_name_display.result
+++ b/tests/suites/0_stateless/02_0004_function_name_display.result
@@ -1,1 +1,4 @@
-Projection: mIn(number):UInt64\n  AggregatorFinal: groupBy=[[]], aggr=[[mIn(number)]]\n    AggregatorPartial: groupBy=[[]], aggr=[[mIn(number)]]\n      ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]
+Projection: mIn(number):UInt64
+  AggregatorFinal: groupBy=[[]], aggr=[[mIn(number)]]
+    AggregatorPartial: groupBy=[[]], aggr=[[mIn(number)]]
+      ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]

--- a/tests/suites/0_stateless/02_0004_function_name_display_cluster.result
+++ b/tests/suites/0_stateless/02_0004_function_name_display_cluster.result
@@ -1,1 +1,5 @@
-Projection: mIn(number):UInt64\n  AggregatorFinal: groupBy=[[]], aggr=[[mIn(number)]]\n    RedistributeStage[expr: 0]\n      AggregatorPartial: groupBy=[[]], aggr=[[mIn(number)]]\n        ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]
+Projection: mIn(number):UInt64
+  AggregatorFinal: groupBy=[[]], aggr=[[mIn(number)]]
+    RedistributeStage[expr: 0]
+      AggregatorPartial: groupBy=[[]], aggr=[[mIn(number)]]
+        ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]

--- a/tests/suites/0_stateless/03_0004_select_order_by.result
+++ b/tests/suites/0_stateless/03_0004_select_order_by.result
@@ -11,7 +11,10 @@
 0	0
 0	1
 0	1
-Projection: (number % 3) as c1:UInt8, (number % 2) as c2:UInt8\n  Sort: (number % 3):UInt8, number:UInt64\n    Expression: (number % 3):UInt8, (number % 2):UInt8, number:UInt64 (Before OrderBy)\n      ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]
+Projection: (number % 3) as c1:UInt8, (number % 2) as c2:UInt8
+  Sort: (number % 3):UInt8, number:UInt64
+    Expression: (number % 3):UInt8, (number % 2):UInt8, number:UInt64 (Before OrderBy)
+      ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]
 0	1
 0	0
 0	1

--- a/tests/suites/0_stateless/03_0004_select_order_by_cluster.result
+++ b/tests/suites/0_stateless/03_0004_select_order_by_cluster.result
@@ -11,7 +11,11 @@
 0	0
 0	1
 0	1
-Projection: (number % 3) as c1:UInt8, (number % 2) as c2:UInt8\n  Sort: (number % 3):UInt8, number:UInt64\n    RedistributeStage[expr: 0]\n      Expression: (number % 3):UInt8, (number % 2):UInt8, number:UInt64 (Before OrderBy)\n        ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]
+Projection: (number % 3) as c1:UInt8, (number % 2) as c2:UInt8
+  Sort: (number % 3):UInt8, number:UInt64
+    RedistributeStage[expr: 0]
+      Expression: (number % 3):UInt8, (number % 2):UInt8, number:UInt64 (Before OrderBy)
+        ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 10, read_bytes: 80]
 0	1
 0	0
 0	1

--- a/tests/suites/0_stateless/03_0005_select_filter.result
+++ b/tests/suites/0_stateless/03_0005_select_filter.result
@@ -1,5 +1,8 @@
 2
 1	2
 2	3
-Projection: number as c1:UInt64, (number + 1) as c2:UInt64\n  Expression: number:UInt64, (number + 1):UInt64 (Before Projection)\n    Filter: (number > 1)\n      ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 3, read_bytes: 24]
+Projection: number as c1:UInt64, (number + 1) as c2:UInt64
+  Expression: number:UInt64, (number + 1):UInt64 (Before Projection)
+    Filter: (number > 1)
+      ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 3, read_bytes: 24]
 2	3

--- a/tests/suites/0_stateless/03_0005_select_filter_cluster.result
+++ b/tests/suites/0_stateless/03_0005_select_filter_cluster.result
@@ -1,5 +1,9 @@
 2
 1	2
 2	3
-RedistributeStage[expr: 0]\n  Projection: number as c1:UInt64, (number + 1) as c2:UInt64\n    Expression: number:UInt64, (number + 1):UInt64 (Before Projection)\n      Filter: (number > 1)\n        ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 3, read_bytes: 24]
+RedistributeStage[expr: 0]
+  Projection: number as c1:UInt64, (number + 1) as c2:UInt64
+    Expression: number:UInt64, (number + 1):UInt64 (Before Projection)
+      Filter: (number > 1)
+        ReadDataSource: scan partitions: [1], scan schema: [number:UInt64], statistics: [read_rows: 3, read_bytes: 24]
 2	3

--- a/tests/suites/0_stateless/04_0000_explain.result
+++ b/tests/suites/0_stateless/04_0000_explain.result
@@ -1,1 +1,8 @@
-Limit: 1\n  Projection: (sum((number + 1)) + 2) as sumx:UInt64\n    Expression: (sum((number + 1)) + 2):UInt64 (Before Projection)\n      AggregatorFinal: groupBy=[[]], aggr=[[sum((number + 1))]]\n        AggregatorPartial: groupBy=[[]], aggr=[[sum((number + 1))]]\n          Expression: (number + 1):UInt64 (Before GroupBy)\n            Filter: ((number + 1) = 4)\n              ReadDataSource: scan partitions: [16], scan schema: [number:UInt64], statistics: [read_rows: 80000, read_bytes: 640000]
+Limit: 1
+  Projection: (sum((number + 1)) + 2) as sumx:UInt64
+    Expression: (sum((number + 1)) + 2):UInt64 (Before Projection)
+      AggregatorFinal: groupBy=[[]], aggr=[[sum((number + 1))]]
+        AggregatorPartial: groupBy=[[]], aggr=[[sum((number + 1))]]
+          Expression: (number + 1):UInt64 (Before GroupBy)
+            Filter: ((number + 1) = 4)
+              ReadDataSource: scan partitions: [16], scan schema: [number:UInt64], statistics: [read_rows: 80000, read_bytes: 640000]

--- a/tests/suites/0_stateless/04_0000_explain_cluster.result
+++ b/tests/suites/0_stateless/04_0000_explain_cluster.result
@@ -1,1 +1,9 @@
-Limit: 1\n  Projection: (sum((number + 1)) + 2) as sumx:UInt64\n    Expression: (sum((number + 1)) + 2):UInt64 (Before Projection)\n      AggregatorFinal: groupBy=[[]], aggr=[[sum((number + 1))]]\n        RedistributeStage[expr: 0]\n          AggregatorPartial: groupBy=[[]], aggr=[[sum((number + 1))]]\n            Expression: (number + 1):UInt64 (Before GroupBy)\n              Filter: ((number + 1) = 4)\n                ReadDataSource: scan partitions: [16], scan schema: [number:UInt64], statistics: [read_rows: 80000, read_bytes: 640000]
+Limit: 1
+  Projection: (sum((number + 1)) + 2) as sumx:UInt64
+    Expression: (sum((number + 1)) + 2):UInt64 (Before Projection)
+      AggregatorFinal: groupBy=[[]], aggr=[[sum((number + 1))]]
+        RedistributeStage[expr: 0]
+          AggregatorPartial: groupBy=[[]], aggr=[[sum((number + 1))]]
+            Expression: (number + 1):UInt64 (Before GroupBy)
+              Filter: ((number + 1) = 4)
+                ReadDataSource: scan partitions: [16], scan schema: [number:UInt64], statistics: [read_rows: 80000, read_bytes: 640000]

--- a/tests/suites/0_stateless/04_0001_explain_pipeline.result
+++ b/tests/suites/0_stateless/04_0001_explain_pipeline.result
@@ -1,2 +1,19 @@
-LimitTransform × 1 processor\n  ProjectionTransform × 1 processor\n    ExpressionTransform × 1 processor\n      AggregatorFinalTransform × 1 processor\n        Merge (AggregatorPartialTransform × 8 processors) to (AggregatorFinalTransform × 1)\n          AggregatorPartialTransform × 8 processors\n            ExpressionTransform × 8 processors\n              FilterTransform × 8 processors\n                SourceTransform × 8 processors
-LimitTransform × 1 processor\n  Merge (ProjectionTransform × 8 processors) to (LimitTransform × 1)\n    ProjectionTransform × 8 processors\n      HavingTransform × 8 processors\n        Mixed (GroupByFinalTransform × 1 processor) to (HavingTransform × 8 processors)\n          GroupByFinalTransform × 1 processor\n            Merge (GroupByPartialTransform × 8 processors) to (GroupByFinalTransform × 1)\n              GroupByPartialTransform × 8 processors\n                ExpressionTransform × 8 processors\n                  SourceTransform × 8 processors
+LimitTransform × 1 processor
+  ProjectionTransform × 1 processor
+    ExpressionTransform × 1 processor
+      AggregatorFinalTransform × 1 processor
+        Merge (AggregatorPartialTransform × 8 processors) to (AggregatorFinalTransform × 1)
+          AggregatorPartialTransform × 8 processors
+            ExpressionTransform × 8 processors
+              FilterTransform × 8 processors
+                SourceTransform × 8 processors
+LimitTransform × 1 processor
+  Merge (ProjectionTransform × 8 processors) to (LimitTransform × 1)
+    ProjectionTransform × 8 processors
+      HavingTransform × 8 processors
+        Mixed (GroupByFinalTransform × 1 processor) to (HavingTransform × 8 processors)
+          GroupByFinalTransform × 1 processor
+            Merge (GroupByPartialTransform × 8 processors) to (GroupByFinalTransform × 1)
+              GroupByPartialTransform × 8 processors
+                ExpressionTransform × 8 processors
+                  SourceTransform × 8 processors

--- a/tests/suites/0_stateless/08_0000_optimizer.result
+++ b/tests/suites/0_stateless/08_0000_optimizer.result
@@ -1,5 +1,11 @@
 limit push down: push (limit 10) to projection
 group by push down: push alias to group by
-Projection: max((number + 1)) as c1:UInt64, ((number % 3) + 1) as c2:UInt16\n  AggregatorFinal: groupBy=[[((number % 3) + 1)]], aggr=[[max((number + 1))]]\n    AggregatorPartial: groupBy=[[((number % 3) + 1)]], aggr=[[max((number + 1))]]\n      Expression: ((number % 3) + 1):UInt16, (number + 1):UInt64 (Before GroupBy)\n        ReadDataSource: scan partitions: [16], scan schema: [number:UInt64], statistics: [read_rows: 10000, read_bytes: 80000]
+Projection: max((number + 1)) as c1:UInt64, ((number % 3) + 1) as c2:UInt16
+  AggregatorFinal: groupBy=[[((number % 3) + 1)]], aggr=[[max((number + 1))]]
+    AggregatorPartial: groupBy=[[((number % 3) + 1)]], aggr=[[max((number + 1))]]
+      Expression: ((number % 3) + 1):UInt16, (number + 1):UInt64 (Before GroupBy)
+        ReadDataSource: scan partitions: [16], scan schema: [number:UInt64], statistics: [read_rows: 10000, read_bytes: 80000]
 projection push down: push (name and value) to read datasource
-Projection: name:Utf8\n  Filter: (value > 10)\n    ReadDataSource: scan partitions: [1], scan schema: [name:Utf8, value:Utf8], statistics: [read_rows: 0, read_bytes: 0]
+Projection: name:Utf8
+  Filter: (value > 10)
+    ReadDataSource: scan partitions: [1], scan schema: [name:Utf8, value:Utf8], statistics: [read_rows: 0, read_bytes: 0]

--- a/tests/suites/0_stateless/08_0000_optimizer_cluster.result
+++ b/tests/suites/0_stateless/08_0000_optimizer_cluster.result
@@ -1,5 +1,13 @@
 limit push down: push (limit 10) to projection
 group by push down: push alias to group by
-RedistributeStage[expr: 0]\n  Projection: max((number + 1)) as c1:UInt64, ((number % 3) + 1) as c2:UInt16\n    AggregatorFinal: groupBy=[[((number % 3) + 1)]], aggr=[[max((number + 1))]]\n      RedistributeStage[expr: sipHash(_group_by_key)]\n        AggregatorPartial: groupBy=[[((number % 3) + 1)]], aggr=[[max((number + 1))]]\n          Expression: ((number % 3) + 1):UInt16, (number + 1):UInt64 (Before GroupBy)\n            ReadDataSource: scan partitions: [16], scan schema: [number:UInt64], statistics: [read_rows: 10000, read_bytes: 80000]
+RedistributeStage[expr: 0]
+  Projection: max((number + 1)) as c1:UInt64, ((number % 3) + 1) as c2:UInt16
+    AggregatorFinal: groupBy=[[((number % 3) + 1)]], aggr=[[max((number + 1))]]
+      RedistributeStage[expr: sipHash(_group_by_key)]
+        AggregatorPartial: groupBy=[[((number % 3) + 1)]], aggr=[[max((number + 1))]]
+          Expression: ((number % 3) + 1):UInt16, (number + 1):UInt64 (Before GroupBy)
+            ReadDataSource: scan partitions: [16], scan schema: [number:UInt64], statistics: [read_rows: 10000, read_bytes: 80000]
 projection push down: push (name and value) to read datasource
-Projection: name:Utf8\n  Filter: (value > 10)\n    ReadDataSource: scan partitions: [1], scan schema: [name:Utf8, value:Utf8], statistics: [read_rows: 0, read_bytes: 0]
+Projection: name:Utf8
+  Filter: (value > 10)
+    ReadDataSource: scan partitions: [1], scan schema: [name:Utf8, value:Utf8], statistics: [read_rows: 0, read_bytes: 0]


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Summary about this PR

Regard the explain result of a plan to multiple rows rather than a single row so that we can have the complete borderline when the mysql client outputs `EXPLAIN` results.

Before the PR:
```
mysql> explain select max(number) from numbers(1000) group by number%3;
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                                                                                                                                                                                                                                                                  |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Projection: max(number):UInt64
  AggregatorFinal: groupBy=[[(number % 3)]], aggr=[[max(number)]]
    AggregatorPartial: groupBy=[[(number % 3)]], aggr=[[max(number)]]
      Expression: (number % 3):UInt8, number:UInt64 (Before GroupBy)
        ReadDataSource: scan partitions: [16], scan schema: [number:UInt64], statistics: [read_rows: 1000, read_bytes: 8000] |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)
```

After the PR:
```
mysql> explain select max(number) from numbers(1000) group by number%3;
+-----------------------------------------------------------------------------------------------------------------------------+
| explain                                                                                                                     |
+-----------------------------------------------------------------------------------------------------------------------------+
| Projection: max(number):UInt64                                                                                              |
|   AggregatorFinal: groupBy=[[(number % 3)]], aggr=[[max(number)]]                                                           |
|     AggregatorPartial: groupBy=[[(number % 3)]], aggr=[[max(number)]]                                                       |
|       Expression: (number % 3):UInt8, number:UInt64 (Before GroupBy)                                                        |
|         ReadDataSource: scan partitions: [8], scan schema: [number:UInt64], statistics: [read_rows: 1000, read_bytes: 8000] |
+-----------------------------------------------------------------------------------------------------------------------------+
5 rows in set (0.01 sec)
```

## Changelog

- Bug Fix
- Improvement

## Related Issues

Fixes #1191

## Test Plan

Unit Tests

