### PR TITLE
kill query action of  store_api

### DIFF
--- a/common/flights/src/impls/mod.rs
+++ b/common/flights/src/impls/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod kv_api_impl;
 pub mod meta_api_impl;
+pub mod session_api_impl;
 pub mod storage_api_impl;
 pub mod storage_api_impl_utils;
 #[cfg(test)]

--- a/common/flights/src/impls/session_api_impl.rs
+++ b/common/flights/src/impls/session_api_impl.rs
@@ -1,0 +1,37 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+
+use common_exception::Result;
+pub use common_store_api::SessionApi;
+use common_tracing::tracing;
+
+use crate::RequestFor;
+use crate::StoreClient;
+use crate::StoreDoAction;
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct KillSessionReq {
+    pub session_id: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct KillSessionReply;
+
+#[async_trait::async_trait]
+impl SessionApi for StoreClient {
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn kill(&mut self, session_id: String) -> Result<()> {
+        self.do_action(KillSessionReq { session_id }).await
+    }
+}
+
+impl RequestFor for KillSessionReq {
+    type Reply = ();
+}
+
+impl From<KillSessionReq> for StoreDoAction {
+    fn from(act: KillSessionReq) -> Self {
+        StoreDoAction::KillSession(act)
+    }
+}

--- a/common/flights/src/impls/session_api_impl.rs
+++ b/common/flights/src/impls/session_api_impl.rs
@@ -11,27 +11,24 @@ use crate::StoreClient;
 use crate::StoreDoAction;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct KillSessionReq {
-    pub session_id: String,
+pub struct KillQueryReq {
+    pub query_id: String,
 }
-
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
-pub struct KillSessionReply;
 
 #[async_trait::async_trait]
 impl SessionApi for StoreClient {
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn kill(&mut self, session_id: String) -> Result<()> {
-        self.do_action(KillSessionReq { session_id }).await
+    async fn kill_query(&mut self, query_id: String) -> Result<()> {
+        self.do_action(KillQueryReq { query_id }).await
     }
 }
 
-impl RequestFor for KillSessionReq {
+impl RequestFor for KillQueryReq {
     type Reply = ();
 }
 
-impl From<KillSessionReq> for StoreDoAction {
-    fn from(act: KillSessionReq) -> Self {
-        StoreDoAction::KillSession(act)
+impl From<KillQueryReq> for StoreDoAction {
+    fn from(act: KillQueryReq) -> Self {
+        StoreDoAction::KillQuery(act)
     }
 }

--- a/common/flights/src/lib.rs
+++ b/common/flights/src/lib.rs
@@ -13,6 +13,7 @@ pub use flight_token::FlightClaim;
 pub use flight_token::FlightToken;
 pub use impls::kv_api_impl;
 pub use impls::meta_api_impl;
+pub use impls::session_api_impl;
 pub use impls::storage_api_impl;
 pub use store_client::StoreClient;
 pub use store_do_action::RequestFor;

--- a/common/flights/src/store_do_action.rs
+++ b/common/flights/src/store_do_action.rs
@@ -22,6 +22,7 @@ use crate::impls::meta_api_impl::DropTableAction;
 use crate::impls::meta_api_impl::GetDatabaseAction;
 use crate::impls::meta_api_impl::GetDatabaseMetaAction;
 use crate::impls::meta_api_impl::GetTableAction;
+use crate::impls::session_api_impl::KillSessionReq;
 use crate::impls::storage_api_impl::ReadPlanAction;
 use crate::impls::storage_api_impl::TruncateTableAction;
 use crate::meta_api_impl::GetTableExtReq;
@@ -67,6 +68,9 @@ pub enum StoreDoAction {
     MGetKV(MGetKVAction),
     PrefixListKV(PrefixListReq),
     DeleteKV(DeleteKVReq),
+
+    // session
+    KillSession(KillSessionReq),
 }
 
 /// Try convert tonic::Request<Action> to DoActionAction.

--- a/common/flights/src/store_do_action.rs
+++ b/common/flights/src/store_do_action.rs
@@ -22,7 +22,7 @@ use crate::impls::meta_api_impl::DropTableAction;
 use crate::impls::meta_api_impl::GetDatabaseAction;
 use crate::impls::meta_api_impl::GetDatabaseMetaAction;
 use crate::impls::meta_api_impl::GetTableAction;
-use crate::impls::session_api_impl::KillSessionReq;
+use crate::impls::session_api_impl::KillQueryReq;
 use crate::impls::storage_api_impl::ReadPlanAction;
 use crate::impls::storage_api_impl::TruncateTableAction;
 use crate::meta_api_impl::GetTableExtReq;
@@ -70,7 +70,7 @@ pub enum StoreDoAction {
     DeleteKV(DeleteKVReq),
 
     // session
-    KillSession(KillSessionReq),
+    KillQuery(KillQueryReq),
 }
 
 /// Try convert tonic::Request<Action> to DoActionAction.

--- a/common/store-api/src/lib.rs
+++ b/common/store-api/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod kv_api;
 mod meta_api;
+mod session_api;
 mod storage_api;
 
 pub use kv_api::GetKVActionResult;
@@ -20,6 +21,7 @@ pub use meta_api::DropTableActionResult;
 pub use meta_api::GetDatabaseActionResult;
 pub use meta_api::GetTableActionResult;
 pub use meta_api::MetaApi;
+pub use session_api::SessionApi;
 pub use storage_api::AppendResult;
 pub use storage_api::BlockStream;
 pub use storage_api::DataPartInfo;

--- a/common/store-api/src/session_api.rs
+++ b/common/store-api/src/session_api.rs
@@ -5,5 +5,5 @@
 
 #[async_trait::async_trait]
 pub trait SessionApi {
-    async fn kill(&mut self, session_id: String) -> common_exception::Result<()>;
+    async fn kill_query(&mut self, query_id: String) -> common_exception::Result<()>;
 }

--- a/common/store-api/src/session_api.rs
+++ b/common/store-api/src/session_api.rs
@@ -1,0 +1,9 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+//
+
+#[async_trait::async_trait]
+pub trait SessionApi {
+    async fn kill(&mut self, session_id: String) -> common_exception::Result<()>;
+}

--- a/fusestore/store/src/executor/action_handler.rs
+++ b/fusestore/store/src/executor/action_handler.rs
@@ -108,7 +108,7 @@ impl ActionHandler {
             StoreDoAction::DeleteKV(a) => s.serialize(self.handle(a).await?),
 
             // session
-            StoreDoAction::KillSession(a) => s.serialize(self.handle(a).await?),
+            StoreDoAction::KillQuery(a) => s.serialize(self.handle(a).await?),
         }
     }
 

--- a/fusestore/store/src/executor/action_handler.rs
+++ b/fusestore/store/src/executor/action_handler.rs
@@ -106,6 +106,9 @@ impl ActionHandler {
             StoreDoAction::MGetKV(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::PrefixListKV(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::DeleteKV(a) => s.serialize(self.handle(a).await?),
+
+            // session
+            StoreDoAction::KillSession(a) => s.serialize(self.handle(a).await?),
         }
     }
 

--- a/fusestore/store/src/executor/mod.rs
+++ b/fusestore/store/src/executor/mod.rs
@@ -11,4 +11,5 @@ pub use action_handler::ReplySerializer;
 mod action_handler_test;
 mod kv_handlers;
 mod meta_handlers;
+mod session_handlers;
 mod storage_handlers;

--- a/fusestore/store/src/executor/session_handlers.rs
+++ b/fusestore/store/src/executor/session_handlers.rs
@@ -1,0 +1,17 @@
+// Copyright 2020-2021 The Datafuse Authors.
+//
+// SPDX-License-Identifier: Apache-2.0.
+//
+
+use common_flights::session_api_impl::KillSessionReq;
+
+use crate::executor::action_handler::RequestHandler;
+use crate::executor::ActionHandler;
+
+#[async_trait::async_trait]
+impl RequestHandler<KillSessionReq> for ActionHandler {
+    async fn handle(&self, _act: KillSessionReq) -> common_exception::Result<()> {
+        // business logic to be specified
+        Ok(())
+    }
+}

--- a/fusestore/store/src/executor/session_handlers.rs
+++ b/fusestore/store/src/executor/session_handlers.rs
@@ -3,14 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0.
 //
 
-use common_flights::session_api_impl::KillSessionReq;
+use common_flights::session_api_impl::KillQueryReq;
 
 use crate::executor::action_handler::RequestHandler;
 use crate::executor::ActionHandler;
 
 #[async_trait::async_trait]
-impl RequestHandler<KillSessionReq> for ActionHandler {
-    async fn handle(&self, _act: KillSessionReq) -> common_exception::Result<()> {
+impl RequestHandler<KillQueryReq> for ActionHandler {
+    async fn handle(&self, _act: KillQueryReq) -> common_exception::Result<()> {
         // business logic to be specified
         Ok(())
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

[store_api] blank implementation for kill session action 

For the time being, Store will do nothing for this action; this API is mainly for Query to wire up all the business logics relevant to kill a session.

## Changelog

- New Feature


## Related Issues

Fixes #1297

## Test Plan

Unit Tests

Stateless Tests

