### PR TITLE
[store] refactor: nothing really changed

### DIFF
--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -16,9 +16,9 @@ pub mod raft_state_kv;
 pub mod raft_txid;
 pub mod raft_types;
 pub mod raftmeta;
+pub mod sled_key_space;
 pub mod sled_serde;
-pub mod sled_vartype_tree;
-pub mod sledkv;
+pub mod sled_tree;
 pub mod snapshot;
 pub mod state_machine;
 pub mod state_machine_meta;
@@ -42,9 +42,9 @@ pub use raftmeta::MetaNode;
 pub use raftmeta::MetaStore;
 pub use sled_serde::SledOrderedSerde;
 pub use sled_serde::SledSerde;
-pub use sled_vartype_tree::AsType;
-pub use sled_vartype_tree::SledValueToKey;
-pub use sled_vartype_tree::SledVarTypeTree;
+pub use sled_tree::AsKeySpace;
+pub use sled_tree::SledTree;
+pub use sled_tree::SledValueToKey;
 pub use snapshot::Snapshot;
 pub use state_machine::Node;
 pub use state_machine::Slot;
@@ -77,6 +77,6 @@ mod raftmeta_test;
 #[cfg(test)]
 mod sled_serde_test;
 #[cfg(test)]
-mod sled_vartype_tree_test;
+mod sled_tree_test;
 #[cfg(test)]
 mod state_machine_test;

--- a/fusestore/store/src/meta_service/raft_log.rs
+++ b/fusestore/store/src/meta_service/raft_log.rs
@@ -8,20 +8,20 @@ use async_raft::raft::Entry;
 use common_tracing::tracing;
 
 use crate::configs;
-use crate::meta_service::sledkv;
-use crate::meta_service::AsType;
+use crate::meta_service::sled_key_space;
+use crate::meta_service::AsKeySpace;
 use crate::meta_service::LogEntry;
 use crate::meta_service::LogIndex;
 use crate::meta_service::SledSerde;
+use crate::meta_service::SledTree;
 use crate::meta_service::SledValueToKey;
-use crate::meta_service::SledVarTypeTree;
 
 const TREE_RAFT_LOG: &str = "raft_log";
 
 /// RaftLog stores the logs of a raft node.
 /// It is part of MetaStore.
 pub struct RaftLog {
-    pub(crate) inner: SledVarTypeTree,
+    pub(crate) inner: SledTree,
 }
 
 impl SledSerde for Entry<LogEntry> {}
@@ -40,7 +40,7 @@ impl RaftLog {
         config: &configs::Config,
     ) -> common_exception::Result<RaftLog> {
         let tree_name = config.tree_name(TREE_RAFT_LOG);
-        let inner = SledVarTypeTree::open(db, &tree_name, config.meta_sync()).await?;
+        let inner = SledTree::open(db, &tree_name, config.meta_sync()).await?;
         let rl = RaftLog { inner };
         Ok(rl)
     }
@@ -106,7 +106,7 @@ impl RaftLog {
     }
 
     /// Returns a borrowed key space in sled::Tree for logs
-    fn logs(&self) -> AsType<sledkv::Logs> {
+    fn logs(&self) -> AsKeySpace<sled_key_space::Logs> {
         self.inner.key_space()
     }
 }

--- a/fusestore/store/src/meta_service/raft_state.rs
+++ b/fusestore/store/src/meta_service/raft_state.rs
@@ -7,13 +7,13 @@ use common_exception::ErrorCode;
 use common_tracing::tracing;
 
 use crate::configs;
-use crate::meta_service::AsType;
+use crate::meta_service::AsKeySpace;
 use crate::meta_service::NodeId;
 use crate::meta_service::RaftStateKV;
 use crate::meta_service::RaftStateKey;
 use crate::meta_service::RaftStateValue;
 use crate::meta_service::SledSerde;
-use crate::meta_service::SledVarTypeTree;
+use crate::meta_service::SledTree;
 
 /// Raft state stores everything else other than log and state machine, which includes:
 /// id: NodeId,
@@ -29,7 +29,7 @@ pub struct RaftState {
     is_open: bool,
 
     /// A sled tree with key space support.
-    pub(crate) inner: SledVarTypeTree,
+    pub(crate) inner: SledTree,
 }
 
 const TREE_RAFT_STATE: &str = "raft_state";
@@ -55,7 +55,7 @@ impl RaftState {
         create: Option<()>,
     ) -> common_exception::Result<RaftState> {
         let tree_name = config.tree_name(TREE_RAFT_STATE);
-        let inner = SledVarTypeTree::open(db, &tree_name, config.meta_sync()).await?;
+        let inner = SledTree::open(db, &tree_name, config.meta_sync()).await?;
 
         let state = inner.key_space::<RaftStateKV>();
         let curr_id = state.get(&RaftStateKey::Id)?.map(NodeId::from);
@@ -145,7 +145,7 @@ impl RaftState {
     }
 
     /// Returns a borrowed sled tree key space to store meta of raft log
-    pub fn state(&self) -> AsType<RaftStateKV> {
+    pub fn state(&self) -> AsKeySpace<RaftStateKV> {
         self.inner.key_space()
     }
 }

--- a/fusestore/store/src/meta_service/raft_state_kv.rs
+++ b/fusestore/store/src/meta_service/raft_state_kv.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use sled::IVec;
 
-use crate::meta_service::sledkv::SledKV;
+use crate::meta_service::sled_key_space::SledKeySpace;
 use crate::meta_service::NodeId;
 use crate::meta_service::SledOrderedSerde;
 use crate::meta_service::SledSerde;
@@ -125,9 +125,9 @@ impl From<RaftStateValue> for (u64, u64) {
     }
 }
 
-impl SledKV for RaftStateKV {
+impl SledKeySpace for RaftStateKV {
     const PREFIX: u8 = 4;
-    const NAME: &'static str = "meta";
+    const NAME: &'static str = "raft-state";
     type K = RaftStateKey;
     type V = RaftStateValue;
 }

--- a/fusestore/store/src/meta_service/raft_state_kv.rs
+++ b/fusestore/store/src/meta_service/raft_state_kv.rs
@@ -86,14 +86,6 @@ impl SledOrderedSerde for RaftStateKey {
 
         Err(ErrorCode::MetaStoreDamaged("invalid key IVec"))
     }
-
-    fn order_preserved_serialize(&self, _buf: &mut [u8]) {
-        unimplemented!("no need")
-    }
-
-    fn order_preserved_deserialize(_buf: &[u8]) -> Self {
-        unimplemented!("no need")
-    }
 }
 
 impl SledSerde for RaftStateValue {}

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -42,8 +42,8 @@ use crate::configs;
 use crate::meta_service::raft_db::get_sled_db;
 use crate::meta_service::raft_log::RaftLog;
 use crate::meta_service::raft_state::RaftState;
+use crate::meta_service::sled_key_space;
 use crate::meta_service::sled_serde::SledOrderedSerde;
-use crate::meta_service::sledkv;
 use crate::meta_service::AppliedState;
 use crate::meta_service::Cmd;
 use crate::meta_service::LogEntry;
@@ -501,7 +501,7 @@ impl MetaStore {
             .await
             .expect("fail to get membership");
 
-        let sm_nodes = sm.sm_tree.key_space::<sledkv::Nodes>();
+        let sm_nodes = sm.sm_tree.key_space::<sled_key_space::Nodes>();
         let x = sm_nodes.range_keys(..).expect("fail to list nodes");
         for node_id in x {
             // it has been added into this cluster and is not a voter.

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -518,7 +518,6 @@ pub struct MetaNodeBuilder {
     config: Option<Config>,
     sto: Option<Arc<MetaStore>>,
     monitor_metrics: bool,
-    start_grpc_service: bool,
     addr: Option<String>,
 }
 
@@ -559,16 +558,15 @@ impl MetaNodeBuilder {
             MetaNode::subscribe_metrics(mn.clone(), metrics_rx).await;
         }
 
-        if self.start_grpc_service {
-            let addr = if let Some(a) = self.addr.take() {
-                a
-            } else {
-                sto.get_node_addr(&node_id).await?
-            };
-            tracing::info!("about to start grpc on {}", addr);
+        let addr = if let Some(a) = self.addr.take() {
+            a
+        } else {
+            sto.get_node_addr(&node_id).await?
+        };
+        tracing::info!("about to start grpc on {}", addr);
 
-            MetaNode::start_grpc(mn.clone(), &addr).await?;
-        }
+        MetaNode::start_grpc(mn.clone(), &addr).await?;
+
         Ok(mn)
     }
 
@@ -578,10 +576,6 @@ impl MetaNodeBuilder {
     }
     pub fn sto(mut self, sto: Arc<MetaStore>) -> Self {
         self.sto = Some(sto);
-        self
-    }
-    pub fn start_grpc_service(mut self, b: bool) -> Self {
-        self.start_grpc_service = b;
         self
     }
     pub fn addr(mut self, a: String) -> Self {
@@ -603,7 +597,6 @@ impl MetaNode {
             config: Some(raft_config),
             sto: None,
             monitor_metrics: true,
-            start_grpc_service: true,
             addr: None,
         }
     }

--- a/fusestore/store/src/meta_service/sled_key_space.rs
+++ b/fusestore/store/src/meta_service/sled_key_space.rs
@@ -20,8 +20,9 @@ use crate::meta_service::NodeId;
 use crate::meta_service::SledOrderedSerde;
 use crate::meta_service::SledSerde;
 
-/// Defines a key-value type to be stored in SledVarTypeTree.
-pub trait SledKV {
+/// Defines a key space in sled::Tree that has its own key value type.
+/// And a prefix that is used to distinguish keys from different spaces in a SledTree.
+pub trait SledKeySpace {
     /// Prefix is a unique u8 that is prepended before the serialized key, to identify a namespace in sled::Tree.
     const PREFIX: u8;
 
@@ -93,18 +94,18 @@ pub trait SledKV {
     }
 }
 
-/// Types for raft log in SledVarTypeTree
+/// Types for raft log in SledTree
 pub struct Logs {}
-impl SledKV for Logs {
+impl SledKeySpace for Logs {
     const PREFIX: u8 = 1;
     const NAME: &'static str = "log";
     type K = LogIndex;
     type V = Entry<LogEntry>;
 }
 
-/// Types for Node in SledVarTypeTree
+/// Types for Node in SledTree
 pub struct Nodes {}
-impl SledKV for Nodes {
+impl SledKeySpace for Nodes {
     const PREFIX: u8 = 2;
     const NAME: &'static str = "node";
     type K = NodeId;

--- a/fusestore/store/src/meta_service/sled_serde.rs
+++ b/fusestore/store/src/meta_service/sled_serde.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-use std::mem::size_of_val;
 use std::ops::Bound;
 use std::ops::RangeBounds;
 
@@ -36,26 +35,11 @@ pub trait SledSerde: Serialize + DeserializeOwned + Sized {
 /// A type that is used as a sled db key should be serialized with order preserved, such as log index.
 pub trait SledOrderedSerde: Serialize + DeserializeOwned + Sized {
     /// (ser)ialize a value to `sled::IVec`.
-    fn ser(&self) -> Result<IVec, ErrorCode> {
-        let size = size_of_val(self);
-        let mut buf = vec![0; size];
-
-        self.order_preserved_serialize(&mut buf);
-        Ok(buf.into())
-    }
+    fn ser(&self) -> Result<IVec, ErrorCode>;
 
     /// (de)serialize a value from `sled::IVec`.
     fn de<V: AsRef<[u8]>>(v: V) -> Result<Self, ErrorCode>
-    where Self: Sized {
-        let v = Self::order_preserved_deserialize(v.as_ref());
-        Ok(v)
-    }
-
-    /// serialize keep the same ordering as original value
-    fn order_preserved_serialize(&self, buf: &mut [u8]);
-
-    /// deserialize from the order preserved bytes
-    fn order_preserved_deserialize(buf: &[u8]) -> Self;
+    where Self: Sized;
 }
 
 /// Serialize/deserialize(ser/de) to/from range to sled IVec range.

--- a/fusestore/store/src/meta_service/sled_tree.rs
+++ b/fusestore/store/src/meta_service/sled_tree.rs
@@ -11,20 +11,20 @@ use common_exception::ErrorCode;
 use common_exception::ToErrorCode;
 use common_tracing::tracing;
 
-use crate::meta_service::sledkv::SledKV;
+use crate::meta_service::sled_key_space::SledKeySpace;
 
 /// Extract key from a value of sled tree that includes its key.
 pub trait SledValueToKey<K> {
     fn to_key(&self) -> K;
 }
 
-/// SledVarTypeTree is a wrapper of sled::Tree that provides access of more than one key-value
+/// SledTree is a wrapper of sled::Tree that provides access of more than one key-value
 /// types.
 /// A `SledKVType` defines a key-value type to be stored.
 /// The key type `K` must be serializable with order preserved, i.e. impl trait `SledOrderedSerde`.
 /// The value type `V` can be any serialize impl, i.e. for most cases, to impl trait `SledSerde`.
 #[derive(Debug, Clone)]
-pub struct SledVarTypeTree {
+pub struct SledTree {
     pub name: String,
 
     /// Whether to fsync after an write operation.
@@ -37,8 +37,8 @@ pub struct SledVarTypeTree {
     pub(crate) tree: sled::Tree,
 }
 
-impl SledVarTypeTree {
-    /// Open SledVarTypeTree
+impl SledTree {
+    /// Open SledTree
     pub async fn open<N: AsRef<[u8]> + Display>(
         db: &sled::Db,
         tree_name: N,
@@ -56,9 +56,9 @@ impl SledVarTypeTree {
                 format!("open tree: {}", tree_name)
             })?;
 
-        tracing::debug!("SledVarTypeTree opened tree: {}", tree_name);
+        tracing::debug!("SledTree opened tree: {}", tree_name);
 
-        let rl = SledVarTypeTree {
+        let rl = SledTree {
             name: format!("{}", tree_name),
             sync,
             tree: t,
@@ -66,17 +66,17 @@ impl SledVarTypeTree {
         Ok(rl)
     }
 
-    /// Borrows the SledVarTypeTree and creates a wrapper with access limited to a specified key space `KV`.
-    pub fn key_space<KV: SledKV>(&self) -> AsType<KV> {
-        AsType::<KV> {
+    /// Borrows the SledTree and creates a wrapper with access limited to a specified key space `KV`.
+    pub fn key_space<KV: SledKeySpace>(&self) -> AsKeySpace<KV> {
+        AsKeySpace::<KV> {
             inner: self,
             phantom: PhantomData,
         }
     }
 
     /// Return true if the tree contains the key.
-    pub fn contains_key<KV: SledKV>(&self, key: &KV::K) -> common_exception::Result<bool>
-    where KV: SledKV {
+    pub fn contains_key<KV: SledKeySpace>(&self, key: &KV::K) -> common_exception::Result<bool>
+    where KV: SledKeySpace {
         let got = self
             .tree
             .contains_key(KV::serialize_key(key)?)
@@ -88,8 +88,8 @@ impl SledVarTypeTree {
     }
 
     /// Retrieve the value of key.
-    pub fn get<KV: SledKV>(&self, key: &KV::K) -> common_exception::Result<Option<KV::V>>
-    where KV: SledKV {
+    pub fn get<KV: SledKeySpace>(&self, key: &KV::K) -> common_exception::Result<Option<KV::V>>
+    where KV: SledKeySpace {
         let got = self
             .tree
             .get(KV::serialize_key(key)?)
@@ -107,7 +107,7 @@ impl SledVarTypeTree {
 
     /// Retrieve the last key value pair.
     pub fn last<KV>(&self) -> common_exception::Result<Option<(KV::K, KV::V)>>
-    where KV: SledKV {
+    where KV: SledKeySpace {
         let range = (
             Bound::Unbounded,
             KV::serialize_bound(Bound::Unbounded, "right")?,
@@ -134,7 +134,7 @@ impl SledVarTypeTree {
     #[tracing::instrument(level = "debug", skip(self, range))]
     pub async fn range_delete<KV, R>(&self, range: R, flush: bool) -> common_exception::Result<()>
     where
-        KV: SledKV,
+        KV: SledKeySpace,
         R: RangeBounds<KV::K>,
     {
         let mut batch = sled::Batch::default();
@@ -175,7 +175,7 @@ impl SledVarTypeTree {
     /// Get keys in `range`
     pub fn range_keys<KV, R>(&self, range: R) -> common_exception::Result<Vec<KV::K>>
     where
-        KV: SledKV,
+        KV: SledKeySpace,
         R: RangeBounds<KV::K>,
     {
         let mut res = vec![];
@@ -199,7 +199,7 @@ impl SledVarTypeTree {
     /// Get values of key in `range`
     pub fn range_get<KV, R>(&self, range: R) -> common_exception::Result<Vec<KV::V>>
     where
-        KV: SledKV,
+        KV: SledKeySpace,
         R: RangeBounds<KV::K>,
     {
         let mut res = vec![];
@@ -221,9 +221,9 @@ impl SledVarTypeTree {
         Ok(res)
     }
 
-    /// Append many key-values into SledVarTypeTree.
+    /// Append many key-values into SledTree.
     pub async fn append<KV>(&self, kvs: &[(KV::K, KV::V)]) -> common_exception::Result<()>
-    where KV: SledKV {
+    where KV: SledKeySpace {
         let mut batch = sled::Batch::default();
 
         for (key, value) in kvs.iter() {
@@ -250,12 +250,12 @@ impl SledVarTypeTree {
         Ok(())
     }
 
-    /// Append many values into SledVarTypeTree.
+    /// Append many values into SledTree.
     /// This could be used in cases the key is included in value and a value should impl trait `IntoKey` to retrieve the key from a value.
     #[tracing::instrument(level = "debug", skip(self, values))]
     pub async fn append_values<KV>(&self, values: &[KV::V]) -> common_exception::Result<()>
     where
-        KV: SledKV,
+        KV: SledKeySpace,
         KV::V: SledValueToKey<KV::K>,
     {
         let mut batch = sled::Batch::default();
@@ -295,7 +295,7 @@ impl SledVarTypeTree {
         value: &KV::V,
     ) -> common_exception::Result<Option<KV::V>>
     where
-        KV: SledKV,
+        KV: SledKeySpace,
     {
         let k = KV::serialize_key(key)?;
         let v = KV::serialize_value(value)?;
@@ -331,7 +331,7 @@ impl SledVarTypeTree {
     #[tracing::instrument(level = "debug", skip(self, value))]
     pub async fn insert_value<KV>(&self, value: &KV::V) -> common_exception::Result<Option<KV::V>>
     where
-        KV: SledKV,
+        KV: SledKeySpace,
         KV::V: SledValueToKey<KV::K>,
     {
         let key = value.to_key();
@@ -341,7 +341,7 @@ impl SledVarTypeTree {
     /// Build a string describing the range for a range operation.
     fn range_message<KV, R>(&self, range: &R) -> String
     where
-        KV: SledKV,
+        KV: SledKeySpace,
         R: RangeBounds<KV::K>,
     {
         format!(
@@ -354,13 +354,13 @@ impl SledVarTypeTree {
     }
 }
 
-/// AsType borrows the internal SledVarTypeTree with access limited to a specified namespace `KV`.
-pub struct AsType<'a, KV: SledKV> {
-    inner: &'a SledVarTypeTree,
+/// It borrows the internal SledTree with access limited to a specified namespace `KV`.
+pub struct AsKeySpace<'a, KV: SledKeySpace> {
+    inner: &'a SledTree,
     phantom: PhantomData<KV>,
 }
 
-impl<'a, KV: SledKV> AsType<'a, KV> {
+impl<'a, KV: SledKeySpace> AsKeySpace<'a, KV> {
     pub fn contains_key(&self, key: &KV::K) -> common_exception::Result<bool> {
         self.inner.contains_key::<KV>(key)
     }

--- a/fusestore/store/src/meta_service/state_machine.rs
+++ b/fusestore/store/src/meta_service/state_machine.rs
@@ -27,14 +27,14 @@ use serde::Serialize;
 use crate::configs;
 use crate::meta_service::placement::rand_n_from_m;
 use crate::meta_service::raft_db::get_sled_db;
-use crate::meta_service::sledkv;
+use crate::meta_service::sled_key_space;
 use crate::meta_service::AppliedState;
 use crate::meta_service::Cmd;
 use crate::meta_service::LogEntry;
 use crate::meta_service::NodeId;
 use crate::meta_service::Placement;
 use crate::meta_service::SledSerde;
-use crate::meta_service::SledVarTypeTree;
+use crate::meta_service::SledTree;
 use crate::meta_service::StateMachineMeta;
 use crate::meta_service::StateMachineMetaKey::Initialized;
 use crate::meta_service::StateMachineMetaKey::LastApplied;
@@ -84,7 +84,7 @@ pub struct StateMachine {
     /// - Every other state is store in its own keyspace such as `Nodes`.
     ///
     /// TODO(xp): migrate other in-memory fields to `sm_tree`.
-    pub sm_tree: SledVarTypeTree,
+    pub sm_tree: SledTree,
 
     /// raft state: A mapping of client IDs to their state info:
     /// (serial, RaftResponse)
@@ -194,7 +194,7 @@ impl StateMachine {
 
         let tree_name = config.tree_name(TREE_STATE_MACHINE);
 
-        let sm_tree = SledVarTypeTree::open(&db, &tree_name, config.meta_sync()).await?;
+        let sm_tree = SledTree::open(&db, &tree_name, config.meta_sync()).await?;
 
         let sm = StateMachine {
             config: config.clone(),
@@ -386,7 +386,7 @@ impl StateMachine {
                 ref node_id,
                 ref node,
             } => {
-                let sm_nodes = self.sm_tree.key_space::<sledkv::Nodes>();
+                let sm_nodes = self.sm_tree.key_space::<sled_key_space::Nodes>();
 
                 let prev = sm_nodes.get(node_id)?;
 
@@ -548,7 +548,7 @@ impl StateMachine {
     }
 
     fn list_node_ids(&self) -> Vec<NodeId> {
-        let sm_nodes = self.sm_tree.key_space::<sledkv::Nodes>();
+        let sm_nodes = self.sm_tree.key_space::<sled_key_space::Nodes>();
         sm_nodes.range_keys(..).expect("fail to list nodes")
     }
 
@@ -563,7 +563,7 @@ impl StateMachine {
     pub fn get_node(&self, node_id: &NodeId) -> Option<Node> {
         // TODO(xp): handle error
 
-        let sm_nodes = self.sm_tree.key_space::<sledkv::Nodes>();
+        let sm_nodes = self.sm_tree.key_space::<sled_key_space::Nodes>();
         sm_nodes.get(node_id).expect("fail to get node")
     }
 

--- a/fusestore/store/src/meta_service/state_machine_meta.rs
+++ b/fusestore/store/src/meta_service/state_machine_meta.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use sled::IVec;
 
-use crate::meta_service::sledkv::SledKV;
+use crate::meta_service::sled_key_space::SledKeySpace;
 use crate::meta_service::SledOrderedSerde;
 use crate::meta_service::SledSerde;
 
@@ -94,7 +94,7 @@ impl From<StateMachineMetaValue> for bool {
     }
 }
 
-impl SledKV for StateMachineMeta {
+impl SledKeySpace for StateMachineMeta {
     const PREFIX: u8 = 0;
     const NAME: &'static str = "meta";
     type K = StateMachineMetaKey;

--- a/fusestore/store/src/meta_service/state_machine_meta.rs
+++ b/fusestore/store/src/meta_service/state_machine_meta.rs
@@ -64,14 +64,6 @@ impl SledOrderedSerde for StateMachineMetaKey {
 
         Err(ErrorCode::MetaStoreDamaged("invalid key IVec"))
     }
-
-    fn order_preserved_serialize(&self, _buf: &mut [u8]) {
-        unimplemented!("no need")
-    }
-
-    fn order_preserved_deserialize(_buf: &[u8]) -> Self {
-        unimplemented!("no need")
-    }
 }
 
 impl SledSerde for StateMachineMetaValue {}

--- a/fusestore/store/src/meta_service/state_machine_test.rs
+++ b/fusestore/store/src/meta_service/state_machine_test.rs
@@ -9,7 +9,7 @@ use common_metatypes::SeqValue;
 use common_runtime::tokio;
 use pretty_assertions::assert_eq;
 
-use crate::meta_service::sledkv;
+use crate::meta_service::sled_key_space;
 use crate::meta_service::state_machine::Replication;
 use crate::meta_service::AppliedState;
 use crate::meta_service::Cmd;
@@ -30,7 +30,7 @@ async fn test_state_machine_assign_rand_nodes_to_slot() -> anyhow::Result<()> {
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config).await?;
     sm.sm_tree
-        .key_space::<sledkv::Nodes>()
+        .key_space::<sled_key_space::Nodes>()
         .append(&[
             (1, Node::default()),
             (3, Node::default()),
@@ -71,7 +71,7 @@ async fn test_state_machine_init_slots() -> anyhow::Result<()> {
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config).await?;
     sm.sm_tree
-        .key_space::<sledkv::Nodes>()
+        .key_space::<sled_key_space::Nodes>()
         .append(&[
             (1, Node::default()),
             (3, Node::default()),


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: remove unused method in trait SledOrderedSerde

##### [store] refactor: remove unused MetaNodeBuilder::start_grpc_service

##### [store] refactor: nothing changed, just rename
```
SledVarTypeTree -> SledTree
AsType -> AsKeySpace
SledKV -> SledKeySpace
```

## Changelog




- Improvement


## Related Issues

- #271