### PR TITLE
[store] fix: read latest log index from active leader

### DIFF
--- a/fusestore/store/src/meta_service/raftmeta_test.rs
+++ b/fusestore/store/src/meta_service/raftmeta_test.rs
@@ -284,6 +284,7 @@ async fn test_meta_node_set_file() -> anyhow::Result<()> {
         tracing::info!("start");
 
         let (mut _nlog, tcs) = setup_cluster(hashset![0, 1, 2], hashset![3, 4]).await?;
+
         let all = test_context_nodes(&tcs);
 
         // test writing on every node
@@ -650,7 +651,8 @@ async fn setup_non_voter(
 /// Write one log on leader, check all nodes replicated the log.
 /// Returns the number log committed.
 async fn assert_set_file_synced(meta_nodes: Vec<Arc<MetaNode>>, key: &str) -> anyhow::Result<u64> {
-    let leader = meta_nodes[0].clone();
+    let leader_id = meta_nodes[0].get_leader().await;
+    let leader = meta_nodes[leader_id as usize].clone();
 
     let last_applied = leader.raft.metrics().borrow().last_applied;
     tracing::info!("leader: last_applied={}", last_applied);
@@ -679,7 +681,8 @@ async fn assert_set_file_on_specified_node_synced(
     write_to: Arc<MetaNode>,
     key: &str,
 ) -> anyhow::Result<u64> {
-    let leader = meta_nodes[0].clone();
+    let leader_id = meta_nodes[0].get_leader().await;
+    let leader = meta_nodes[leader_id as usize].clone();
 
     let last_applied = leader.raft.metrics().borrow().last_applied;
     tracing::info!("leader: last_applied={}", last_applied);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] fix: read latest log index from active leader
When testing raft related componennt, sometimes the leadership is taken
by other node, i.e., the original leader may not send a heartbeat
quickly enought.

Thus when reading the latest log index, first we have to reload the
leader id, then read log index from it.
Instead of reading log index directly from the default leader node-0.

## Changelog


- Bug Fix




## Related Issues

- #271

Fix: #1360