### PR TITLE
[store] change: MetaNode::upsertKV return two equal value if no modification is applied

### DIFF
--- a/fusestore/store/src/executor/kv_handlers.rs
+++ b/fusestore/store/src/executor/kv_handlers.rs
@@ -14,7 +14,7 @@ use common_flights::kv_api_impl::PrefixListReply;
 use common_flights::kv_api_impl::PrefixListReq;
 use common_flights::kv_api_impl::UpsertKVAction;
 use common_flights::kv_api_impl::UpsertKVActionResult;
-use Cmd::DeleteKVByKey;
+use Cmd::DeleteKV;
 
 use crate::executor::action_handler::RequestHandler;
 use crate::executor::ActionHandler;
@@ -75,7 +75,7 @@ impl RequestHandler<DeleteKVReq> for ActionHandler {
     async fn handle(&self, act: DeleteKVReq) -> common_exception::Result<DeleteKVReply> {
         let cr = LogEntry {
             txid: None,
-            cmd: DeleteKVByKey {
+            cmd: DeleteKV {
                 key: act.key,
                 seq: act.seq.into(),
             },

--- a/fusestore/store/src/meta_service/cmd.rs
+++ b/fusestore/store/src/meta_service/cmd.rs
@@ -85,7 +85,7 @@ pub enum Cmd {
         seq: MatchSeq,
         value: Vec<u8>,
     },
-    DeleteKVByKey {
+    DeleteKV {
         key: String,
         seq: MatchSeq,
     },
@@ -146,7 +146,7 @@ impl fmt::Display for Cmd {
             Cmd::UpsertKV { key, seq, value } => {
                 write!(f, "upsert_kv: {}({:?}) = {:?}", key, seq, value)
             }
-            Cmd::DeleteKVByKey { key, seq } => {
+            Cmd::DeleteKV { key, seq } => {
                 write!(f, "delete_by_key_kv: {}({:?})", key, seq)
             }
         }

--- a/fusestore/store/src/meta_service/state_machine.rs
+++ b/fusestore/store/src/meta_service/state_machine.rs
@@ -490,7 +490,7 @@ impl StateMachine {
             } => {
                 let prev = self.kv.get(key).cloned();
                 if seq.match_seq(&prev).is_err() {
-                    return Ok((prev, None).into());
+                    return Ok((prev.clone(), prev).into());
                 }
 
                 let new_seq = self.incr_seq(SEQ_GENERIC_KV);
@@ -501,7 +501,7 @@ impl StateMachine {
                 Ok((prev, Some(record_value)).into())
             }
 
-            Cmd::DeleteKVByKey { ref key, ref seq } => {
+            Cmd::DeleteKV { ref key, ref seq } => {
                 let prev = self.kv.get(key).cloned();
 
                 if seq.match_seq(&prev).is_err() {

--- a/fusestore/store/src/meta_service/state_machine_test.rs
+++ b/fusestore/store/src/meta_service/state_machine_test.rs
@@ -132,6 +132,8 @@ async fn test_state_machine_builder() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_non_dup_incr_seq() -> anyhow::Result<()> {
+    init_store_unittest();
+
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config).await?;
 
@@ -188,6 +190,8 @@ async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_add_database() -> anyhow::Result<()> {
+    init_store_unittest();
+
     let tc = new_test_context();
     let mut m = StateMachine::open(&tc.config).await?;
 
@@ -267,6 +271,8 @@ async fn test_state_machine_apply_add_database() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Result<()> {
+    init_store_unittest();
+
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config).await?;
 
@@ -300,9 +306,21 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
         case("foo", MatchSeq::Exact(5), "b", None, None),
         case("foo", MatchSeq::Any, "a", None, Some((1, "a"))),
         case("foo", MatchSeq::Any, "b", Some((1, "a")), Some((2, "b"))),
-        case("foo", MatchSeq::Exact(5), "b", Some((2, "b")), None),
+        case(
+            "foo",
+            MatchSeq::Exact(5),
+            "b",
+            Some((2, "b")),
+            Some((2, "b")),
+        ),
         case("bar", MatchSeq::Exact(0), "x", None, Some((3, "x"))),
-        case("bar", MatchSeq::Exact(0), "y", Some((3, "x")), None),
+        case(
+            "bar",
+            MatchSeq::Exact(0),
+            "y",
+            Some((3, "x")),
+            Some((3, "x")),
+        ),
         case("bar", MatchSeq::GE(1), "y", Some((3, "x")), Some((4, "y"))),
     ];
 
@@ -348,6 +366,8 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_non_dup_generic_kv_delete() -> anyhow::Result<()> {
+    init_store_unittest();
+
     struct T {
         // input:
         key: String,
@@ -402,7 +422,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_delete() -> anyhow::Result<
         let resp = sm
             .apply_non_dup(&LogEntry {
                 txid: None,
-                cmd: Cmd::DeleteKVByKey {
+                cmd: Cmd::DeleteKV {
                     key: c.key.clone(),
                     seq: c.seq.clone(),
                 },

--- a/fusestore/store/src/tests/service.rs
+++ b/fusestore/store/src/tests/service.rs
@@ -51,6 +51,7 @@ pub fn next_port() -> u32 {
 pub struct StoreTestContext {
     #[allow(dead_code)]
     meta_temp_dir: TempDir,
+
     #[allow(dead_code)]
     local_fs_tmp_dir: TempDir,
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] change: MetaNode::upsertKV return two equal value if no modification is applied
Previously, if an `Add` action failed, due to mismatching `seq`, it
returns `(previous value, None)`.
From now on it returns `(previous value, previous value)` to indicate
nothing change.

**Why**:

The previous solution can not distinguish the result from a successful
`delete` and the result from a failed `add`.
Thus the caller has to examine the context to determine if the return
value is a success. E.g., by considering the action(`add` or `delete`).

With the new solution, the caller knows if it succeeded by only a simple comparison on
`res.prev` and `res.result`.

## Changelog







## Related Issues

- #271
- #1080 
- #1139 