### PR TITLE
[store] refactor: use UpsertKV to impl deleteKV.

### DIFF
--- a/fusestore/store/src/executor/kv_handlers.rs
+++ b/fusestore/store/src/executor/kv_handlers.rs
@@ -14,10 +14,10 @@ use common_flights::kv_api_impl::PrefixListReply;
 use common_flights::kv_api_impl::PrefixListReq;
 use common_flights::kv_api_impl::UpsertKVAction;
 use common_flights::kv_api_impl::UpsertKVActionResult;
-use Cmd::DeleteKV;
 
 use crate::executor::action_handler::RequestHandler;
 use crate::executor::ActionHandler;
+use crate::meta_service::cmd::Cmd::UpsertKV;
 use crate::meta_service::AppliedState;
 use crate::meta_service::Cmd;
 use crate::meta_service::LogEntry;
@@ -30,7 +30,7 @@ impl RequestHandler<UpsertKVAction> for ActionHandler {
             cmd: Cmd::UpsertKV {
                 key: act.key,
                 seq: act.seq,
-                value: act.value,
+                value: Some(act.value),
             },
         };
         let rst = self
@@ -75,9 +75,10 @@ impl RequestHandler<DeleteKVReq> for ActionHandler {
     async fn handle(&self, act: DeleteKVReq) -> common_exception::Result<DeleteKVReply> {
         let cr = LogEntry {
             txid: None,
-            cmd: DeleteKV {
+            cmd: UpsertKV {
                 key: act.key,
                 seq: act.seq.into(),
+                value: None,
             },
         };
 

--- a/fusestore/store/src/meta_service/cmd.rs
+++ b/fusestore/store/src/meta_service/cmd.rs
@@ -18,27 +18,16 @@ use crate::meta_service::Node;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum Cmd {
     /// AKA put-if-absent. add a key-value record only when key is absent.
-    AddFile {
-        key: String,
-        value: String,
-    },
+    AddFile { key: String, value: String },
 
     /// Override the record with key.
-    SetFile {
-        key: String,
-        value: String,
-    },
+    SetFile { key: String, value: String },
 
     /// Increment the sequence number generator specified by `key` and returns the new value.
-    IncrSeq {
-        key: String,
-    },
+    IncrSeq { key: String },
 
     /// Add node if absent
-    AddNode {
-        node_id: NodeId,
-        node: Node,
-    },
+    AddNode { node_id: NodeId, node: Node },
 
     /// Add a database if absent
     CreateDatabase {
@@ -78,16 +67,15 @@ pub enum Cmd {
     /// Update or insert a general purpose kv store
     UpsertKV {
         key: String,
+
         /// Since a sequence number is always positive, using Exact(0) to perform an add-if-absent operation.
-        /// GE(1) to perform an update-any operation.
-        /// Exact(n) to perform an update on some specified version.
-        /// Any to perform an update or insert that always takes effect.
+        /// - GE(1) to perform an update-any operation.
+        /// - Exact(n) to perform an update on some specified version.
+        /// - Any to perform an update or insert that always takes effect.
         seq: MatchSeq,
-        value: Vec<u8>,
-    },
-    DeleteKV {
-        key: String,
-        seq: MatchSeq,
+
+        /// The value to set. A `None` indicates to delete it.
+        value: Option<Vec<u8>>,
     },
 }
 
@@ -145,9 +133,6 @@ impl fmt::Display for Cmd {
             }
             Cmd::UpsertKV { key, seq, value } => {
                 write!(f, "upsert_kv: {}({:?}) = {:?}", key, seq, value)
-            }
-            Cmd::DeleteKV { key, seq } => {
-                write!(f, "delete_by_key_kv: {}({:?})", key, seq)
             }
         }
     }

--- a/fusestore/store/src/meta_service/state_machine_test.rs
+++ b/fusestore/store/src/meta_service/state_machine_test.rs
@@ -335,7 +335,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
                 cmd: Cmd::UpsertKV {
                     key: c.key.clone(),
                     seq: c.seq.clone(),
-                    value: c.value.clone(),
+                    value: Some(c.value.clone()),
                 },
             })
             .await?;
@@ -413,7 +413,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_delete() -> anyhow::Result<
             cmd: Cmd::UpsertKV {
                 key: "foo".to_string(),
                 seq: MatchSeq::Any,
-                value: "x".as_bytes().to_vec(),
+                value: Some(b"x".to_vec()),
             },
         })
         .await?;
@@ -422,9 +422,10 @@ async fn test_state_machine_apply_non_dup_generic_kv_delete() -> anyhow::Result<
         let resp = sm
             .apply_non_dup(&LogEntry {
                 txid: None,
-                cmd: Cmd::DeleteKV {
+                cmd: Cmd::UpsertKV {
                     key: c.key.clone(),
                     seq: c.seq.clone(),
+                    value: None,
                 },
             })
             .await?;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: use UpsertKV to impl deleteKV.
- `UpsertKV`: if value is None it is a delete operation.

- Use `UpsertKV` to impl delete. Reduced several lines of code.:DDD

## Changelog




- Improvement


## Related Issues

- #271