### PR TITLE
[store] refactor: move all key space definitions to `sled_key_space.rs`

### DIFF
--- a/fusestore/store/src/meta_service/mod.rs
+++ b/fusestore/store/src/meta_service/mod.rs
@@ -31,7 +31,6 @@ pub use log_entry::LogEntry;
 pub use meta_service_impl::MetaServiceImpl;
 pub use network::Network;
 pub use placement::Placement;
-pub use raft_state_kv::RaftStateKV;
 pub use raft_state_kv::RaftStateKey;
 pub use raft_state_kv::RaftStateValue;
 pub use raft_txid::RaftTxId;
@@ -49,7 +48,6 @@ pub use snapshot::Snapshot;
 pub use state_machine::Node;
 pub use state_machine::Slot;
 pub use state_machine::StateMachine;
-pub use state_machine_meta::StateMachineMeta;
 pub use state_machine_meta::StateMachineMetaKey;
 pub use state_machine_meta::StateMachineMetaValue;
 

--- a/fusestore/store/src/meta_service/raft_state.rs
+++ b/fusestore/store/src/meta_service/raft_state.rs
@@ -7,9 +7,9 @@ use common_exception::ErrorCode;
 use common_tracing::tracing;
 
 use crate::configs;
+use crate::meta_service::sled_key_space::RaftStateKV;
 use crate::meta_service::AsKeySpace;
 use crate::meta_service::NodeId;
-use crate::meta_service::RaftStateKV;
 use crate::meta_service::RaftStateKey;
 use crate::meta_service::RaftStateValue;
 use crate::meta_service::SledSerde;

--- a/fusestore/store/src/meta_service/raft_state_kv.rs
+++ b/fusestore/store/src/meta_service/raft_state_kv.rs
@@ -10,17 +10,9 @@ use serde::Deserialize;
 use serde::Serialize;
 use sled::IVec;
 
-use crate::meta_service::sled_key_space::SledKeySpace;
 use crate::meta_service::NodeId;
 use crate::meta_service::SledOrderedSerde;
 use crate::meta_service::SledSerde;
-
-/// Key-Value Types for storing meta data of a raft in sled::Tree:
-/// id: NodeId,
-/// hard_state:
-///      current_term,
-///      voted_for,
-pub struct RaftStateKV {}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum RaftStateKey {
@@ -115,11 +107,4 @@ impl From<RaftStateValue> for (u64, u64) {
             _ => panic!("expect StateMachineId"),
         }
     }
-}
-
-impl SledKeySpace for RaftStateKV {
-    const PREFIX: u8 = 4;
-    const NAME: &'static str = "raft-state";
-    type K = RaftStateKey;
-    type V = RaftStateValue;
 }

--- a/fusestore/store/src/meta_service/raft_types.rs
+++ b/fusestore/store/src/meta_service/raft_types.rs
@@ -47,5 +47,16 @@ impl SledOrderedSerde for String {
     }
 }
 
+impl SledSerde for String {
+    fn ser(&self) -> Result<IVec, ErrorCode> {
+        Ok(IVec::from(self.as_str()))
+    }
+
+    fn de<V: AsRef<[u8]>>(v: V) -> Result<Self, ErrorCode>
+    where Self: Sized {
+        Ok(String::from_utf8(v.as_ref().to_vec())?)
+    }
+}
+
 /// For LogId to be able to stored in sled::Tree as a value.
 impl SledSerde for LogId {}

--- a/fusestore/store/src/meta_service/sled_key_space.rs
+++ b/fusestore/store/src/meta_service/sled_key_space.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0.
 
-//! sledkv defines several key-value types to be used in sled::Tree, as an raft storage impl.
+//! sled_key_space defines several key-value types to be used in sled::Tree, as an raft storage impl.
 
 use std::fmt::Debug;
 use std::fmt::Display;
@@ -17,8 +17,12 @@ use crate::meta_service::LogEntry;
 use crate::meta_service::LogIndex;
 use crate::meta_service::Node;
 use crate::meta_service::NodeId;
+use crate::meta_service::RaftStateKey;
+use crate::meta_service::RaftStateValue;
 use crate::meta_service::SledOrderedSerde;
 use crate::meta_service::SledSerde;
+use crate::meta_service::StateMachineMetaKey;
+use crate::meta_service::StateMachineMetaValue;
 
 /// Defines a key space in sled::Tree that has its own key value type.
 /// And a prefix that is used to distinguish keys from different spaces in a SledTree.
@@ -110,4 +114,35 @@ impl SledKeySpace for Nodes {
     const NAME: &'static str = "node";
     type K = NodeId;
     type V = Node;
+}
+
+/// Key-Value Types for storing meta data of a raft state machine in sled::Tree, e.g. the last applied log id.
+pub struct StateMachineMeta {}
+impl SledKeySpace for StateMachineMeta {
+    const PREFIX: u8 = 3;
+    const NAME: &'static str = "sm-meta";
+    type K = StateMachineMetaKey;
+    type V = StateMachineMetaValue;
+}
+
+/// Key-Value Types for storing meta data of a raft in sled::Tree:
+/// id: NodeId,
+/// hard_state:
+///      current_term,
+///      voted_for,
+pub struct RaftStateKV {}
+impl SledKeySpace for RaftStateKV {
+    const PREFIX: u8 = 4;
+    const NAME: &'static str = "raft-state";
+    type K = RaftStateKey;
+    type V = RaftStateValue;
+}
+
+/// Key-Value Types for storing DFS files in sled::Tree:
+pub struct Files {}
+impl SledKeySpace for Files {
+    const PREFIX: u8 = 5;
+    const NAME: &'static str = "files";
+    type K = String;
+    type V = String;
 }

--- a/fusestore/store/src/meta_service/sled_tree.rs
+++ b/fusestore/store/src/meta_service/sled_tree.rs
@@ -108,10 +108,7 @@ impl SledTree {
     /// Retrieve the last key value pair.
     pub fn last<KV>(&self) -> common_exception::Result<Option<(KV::K, KV::V)>>
     where KV: SledKeySpace {
-        let range = (
-            Bound::Unbounded,
-            KV::serialize_bound(Bound::Unbounded, "right")?,
-        );
+        let range = KV::serialize_range(&(Bound::Unbounded::<KV::K>, Bound::Unbounded::<KV::K>))?;
 
         let mut it = self.tree.range(range).rev();
         let last = it.next();

--- a/fusestore/store/src/meta_service/sled_tree_test.rs
+++ b/fusestore/store/src/meta_service/sled_tree_test.rs
@@ -9,11 +9,12 @@ use async_raft::LogId;
 use common_runtime::tokio;
 
 use crate::meta_service::sled_key_space;
+use crate::meta_service::sled_key_space::SledKeySpace;
+use crate::meta_service::sled_key_space::StateMachineMeta;
 use crate::meta_service::Cmd;
 use crate::meta_service::LogEntry;
 use crate::meta_service::LogIndex;
 use crate::meta_service::SledTree;
-use crate::meta_service::StateMachineMeta;
 use crate::meta_service::StateMachineMetaKey::Initialized;
 use crate::meta_service::StateMachineMetaKey::LastApplied;
 use crate::meta_service::StateMachineMetaValue;
@@ -361,6 +362,10 @@ async fn test_sledtree_get() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_last() -> anyhow::Result<()> {
     init_store_unittest();
+
+    /// This test assumes the following order.
+    /// To ensure a last() does not returns item from another key space with smaller prefix
+    assert!(sled_key_space::Logs::PREFIX < StateMachineMeta::PREFIX);
 
     let tc = new_sled_test_context();
     let db = &tc.db;

--- a/fusestore/store/src/meta_service/state_machine_meta.rs
+++ b/fusestore/store/src/meta_service/state_machine_meta.rs
@@ -10,12 +10,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use sled::IVec;
 
-use crate::meta_service::sled_key_space::SledKeySpace;
 use crate::meta_service::SledOrderedSerde;
 use crate::meta_service::SledSerde;
-
-/// Key-Value Types for storing meta data of a raft state machine in sled::Tree, e.g. the last applied log id.
-pub struct StateMachineMeta {}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum StateMachineMetaKey {
@@ -84,11 +80,4 @@ impl From<StateMachineMetaValue> for bool {
             _ => panic!("expect LogId"),
         }
     }
-}
-
-impl SledKeySpace for StateMachineMeta {
-    const PREFIX: u8 = 0;
-    const NAME: &'static str = "meta";
-    type K = StateMachineMetaKey;
-    type V = StateMachineMetaValue;
 }

--- a/fusestore/store/src/meta_service/state_machine_test.rs
+++ b/fusestore/store/src/meta_service/state_machine_test.rs
@@ -9,7 +9,6 @@ use common_metatypes::SeqValue;
 use common_runtime::tokio;
 use pretty_assertions::assert_eq;
 
-use crate::meta_service::sled_key_space;
 use crate::meta_service::state_machine::Replication;
 use crate::meta_service::AppliedState;
 use crate::meta_service::Cmd;
@@ -29,8 +28,7 @@ async fn test_state_machine_assign_rand_nodes_to_slot() -> anyhow::Result<()> {
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config).await?;
-    sm.sm_tree
-        .key_space::<sled_key_space::Nodes>()
+    sm.nodes()
         .append(&[
             (1, Node::default()),
             (3, Node::default()),
@@ -70,8 +68,7 @@ async fn test_state_machine_init_slots() -> anyhow::Result<()> {
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config).await?;
-    sm.sm_tree
-        .key_space::<sled_key_space::Nodes>()
+    sm.nodes()
         .append(&[
             (1, Node::default()),
             (3, Node::default()),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: move all key space definitions to `sled_key_space.rs`
- Fix: SledTree::last() should set both left and right bound for a key
  space.

- Add: StateMachine: add util functions to get a key space.

## Changelog




- Improvement


## Related Issues

- #271
- #1080 
- #1385 