### PR TITLE
Remove `remote_factory` from struct `DatabaseCatalog`

### DIFF
--- a/fusequery/query/src/catalogs/impls/remote_meta_store_client.rs
+++ b/fusequery/query/src/catalogs/impls/remote_meta_store_client.rs
@@ -19,7 +19,9 @@ use common_flights::StoreClient;
 use common_infallible::Mutex;
 use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
+use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
+use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
 use common_planners::TableOptions;
 use common_runtime::Runtime;
@@ -245,6 +247,18 @@ where T: 'static + StoreApis + Clone
     async fn drop_table(&self, plan: DropTablePlan) -> Result<()> {
         let mut cli = self.store_api_provider.try_get_store_apis().await?;
         cli.drop_table(plan.clone()).await?;
+        Ok(())
+    }
+
+    async fn create_database(&self, plan: CreateDatabasePlan) -> Result<()> {
+        let mut cli = self.store_api_provider.try_get_store_apis().await?;
+        cli.create_database(plan).await?;
+        Ok(())
+    }
+
+    async fn drop_database(&self, plan: DropDatabasePlan) -> Result<()> {
+        let mut cli = self.store_api_provider.try_get_store_apis().await?;
+        cli.drop_database(plan).await?;
         Ok(())
     }
 }

--- a/fusequery/query/src/catalogs/meta_store_client.rs
+++ b/fusequery/query/src/catalogs/meta_store_client.rs
@@ -4,9 +4,12 @@
 //
 
 use common_datavalues::prelude::Arc;
+use common_exception::Result;
 use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
+use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
+use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
 
 use crate::catalogs::utils::TableMeta;
@@ -19,22 +22,21 @@ use crate::datasources::Database;
 // It should be unified in coming refactorings.
 #[async_trait::async_trait]
 pub trait DBMetaStoreClient: Send + Sync {
-    fn get_database(&self, db_name: &str) -> common_exception::Result<Arc<dyn Database>>;
-    fn get_databases(&self) -> common_exception::Result<Vec<String>>;
-    fn get_table(
-        &self,
-        db_name: &str,
-        table_name: &str,
-    ) -> common_exception::Result<Arc<TableMeta>>;
-    fn get_all_tables(&self) -> common_exception::Result<Vec<(String, Arc<TableMeta>)>>;
+    fn get_database(&self, db_name: &str) -> Result<Arc<dyn Database>>;
+    fn get_databases(&self) -> Result<Vec<String>>;
+    fn get_table(&self, db_name: &str, table_name: &str) -> Result<Arc<TableMeta>>;
+    fn get_all_tables(&self) -> Result<Vec<(String, Arc<TableMeta>)>>;
     fn get_table_by_id(
         &self,
         db_name: &str,
         table_id: MetaId,
         table_version: Option<MetaVersion>,
-    ) -> common_exception::Result<Arc<TableMeta>>;
+    ) -> Result<Arc<TableMeta>>;
 
-    fn get_db_tables(&self, db_name: &str) -> common_exception::Result<Vec<Arc<TableMeta>>>;
-    async fn create_table(&self, plan: CreateTablePlan) -> common_exception::Result<()>;
-    async fn drop_table(&self, plan: DropTablePlan) -> common_exception::Result<()>;
+    fn get_db_tables(&self, db_name: &str) -> Result<Vec<Arc<TableMeta>>>;
+    async fn create_table(&self, plan: CreateTablePlan) -> Result<()>;
+    async fn drop_table(&self, plan: DropTablePlan) -> Result<()>;
+
+    async fn create_database(&self, plan: CreateDatabasePlan) -> Result<()>;
+    async fn drop_database(&self, plan: DropDatabasePlan) -> Result<()>;
 }

--- a/fusequery/query/src/configs/config.rs
+++ b/fusequery/query/src/configs/config.rs
@@ -204,6 +204,7 @@ pub struct Config {
     )]
     pub rpc_tls_store_service_domain_name: String,
 
+    // this flag will be removed when embedded catalog is ready
     #[structopt(long, env =  DISABLE_REMOTE_CATALOG)]
     pub disable_remote_catalog: bool,
 }

--- a/fusequery/query/src/sessions/sessions.rs
+++ b/fusequery/query/src/sessions/sessions.rs
@@ -53,15 +53,13 @@ impl SessionManager {
 
     pub fn from_conf(conf: Config, cluster: ClusterRef) -> Result<SessionManagerRef> {
         let max_active_sessions = conf.max_active_sessions as usize;
-        let remote_factory = RemoteFactory::new(&conf);
-        let store_client_provider = remote_factory.store_client_provider();
-        let cli = Arc::new(RemoteMetaStoreClient::create(Arc::new(
-            store_client_provider,
+        let meta_store_cli = Arc::new(RemoteMetaStoreClient::create(Arc::new(
+            RemoteFactory::new(&conf).store_client_provider(),
         )));
         Ok(Arc::new(SessionManager {
             datasource: Arc::new(DatabaseCatalog::try_create_with_config(
                 conf.disable_remote_catalog,
-                cli,
+                meta_store_cli,
             )?),
             conf,
             cluster,

--- a/fusequery/query/src/sessions/sessions.rs
+++ b/fusequery/query/src/sessions/sessions.rs
@@ -17,9 +17,11 @@ use common_runtime::tokio::sync::mpsc::Receiver;
 use futures::future::Either;
 use metrics::counter;
 
+use crate::catalogs::impls::remote_meta_store_client::RemoteMetaStoreClient;
 use crate::clusters::Cluster;
 use crate::clusters::ClusterRef;
 use crate::configs::Config;
+use crate::datasources::remote::RemoteFactory;
 use crate::datasources::DatabaseCatalog;
 use crate::sessions::session::Session;
 use crate::sessions::session_ref::SessionRef;
@@ -51,8 +53,16 @@ impl SessionManager {
 
     pub fn from_conf(conf: Config, cluster: ClusterRef) -> Result<SessionManagerRef> {
         let max_active_sessions = conf.max_active_sessions as usize;
+        let remote_factory = RemoteFactory::new(&conf);
+        let store_client_provider = remote_factory.store_client_provider();
+        let cli = Arc::new(RemoteMetaStoreClient::create(Arc::new(
+            store_client_provider,
+        )));
         Ok(Arc::new(SessionManager {
-            datasource: Arc::new(DatabaseCatalog::try_create_with_config(&conf)?),
+            datasource: Arc::new(DatabaseCatalog::try_create_with_config(
+                conf.disable_remote_catalog,
+                cli,
+            )?),
             conf,
             cluster,
             max_sessions: max_active_sessions,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

A minor refactoring:

- Remove `remote_factory` from struct `DatabaseCatalog`

Preparation for introducing "Embedded Catalog" (mainly for unit testing), and decomposing of LocalDatabase

## Changelog


- Improvement


## Related Issues

Fixes #1394 

## Test Plan

Unit Tests

Stateless Tests

