### PR TITLE
[store] feature: raft state machine stores generic-kv in sled

### DIFF
--- a/fusestore/store/src/meta_service/raft_types.rs
+++ b/fusestore/store/src/meta_service/raft_types.rs
@@ -9,6 +9,7 @@ pub use async_raft::NodeId;
 use byteorder::BigEndian;
 use byteorder::ByteOrder;
 use common_exception::ErrorCode;
+use common_metatypes::SeqValue;
 use sled::IVec;
 
 use crate::meta_service::sled_serde::SledOrderedSerde;
@@ -57,6 +58,8 @@ impl SledSerde for String {
         Ok(String::from_utf8(v.as_ref().to_vec())?)
     }
 }
+
+impl SledSerde for SeqValue<Vec<u8>> {}
 
 /// For LogId to be able to stored in sled::Tree as a value.
 impl SledSerde for LogId {}

--- a/fusestore/store/src/meta_service/sled_key_space.rs
+++ b/fusestore/store/src/meta_service/sled_key_space.rs
@@ -11,6 +11,7 @@ use std::ops::RangeBounds;
 
 use async_raft::raft::Entry;
 use common_exception::ErrorCode;
+use common_metatypes::SeqValue;
 use sled::IVec;
 
 use crate::meta_service::LogEntry;
@@ -145,4 +146,13 @@ impl SledKeySpace for Files {
     const NAME: &'static str = "files";
     type K = String;
     type V = String;
+}
+
+/// Key-Value Types for storing general purpose kv in sled::Tree:
+pub struct GenericKV {}
+impl SledKeySpace for GenericKV {
+    const PREFIX: u8 = 6;
+    const NAME: &'static str = "generic-kv";
+    type K = String;
+    type V = SeqValue;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: raft state machine stores generic-kv in sled

## Changelog

- New Feature





## Related Issues

- #271
- #1080 

fix: #1386 