### PR TITLE
[store] refactor: extract common function flush_async

### DIFF
--- a/fusestore/store/src/meta_service/raft_log.rs
+++ b/fusestore/store/src/meta_service/raft_log.rs
@@ -72,9 +72,9 @@ impl RaftLog {
     ///    In this case, atomic delete is quite enough(to not leave a hole).
     ///    If the system allows logs hole, non-atomic delete is quite enough(depends on the upper layer).
     ///
-    pub async fn range_delete<R>(&self, range: R) -> common_exception::Result<()>
+    pub async fn range_remove<R>(&self, range: R) -> common_exception::Result<()>
     where R: RangeBounds<LogIndex> {
-        self.logs().range_delete(range, true).await
+        self.logs().range_remove(range, true).await
     }
 
     pub fn range_keys<R>(&self, range: R) -> common_exception::Result<Vec<LogIndex>>
@@ -82,9 +82,9 @@ impl RaftLog {
         self.logs().range_keys(range)
     }
 
-    pub fn range_get<R>(&self, range: R) -> common_exception::Result<Vec<Entry<LogEntry>>>
+    pub fn range_values<R>(&self, range: R) -> common_exception::Result<Vec<Entry<LogEntry>>>
     where R: RangeBounds<LogIndex> {
-        self.logs().range_get(range)
+        self.logs().range_values(range)
     }
 
     /// Append logs into RaftLog.

--- a/fusestore/store/src/meta_service/raft_log_test.rs
+++ b/fusestore/store/src/meta_service/raft_log_test.rs
@@ -66,34 +66,34 @@ async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
 
     rl.append(&logs).await?;
 
-    let got = rl.range_get(0..)?;
+    let got = rl.range_values(0..)?;
     assert_eq!(logs, got);
 
-    let got = rl.range_get(0..=2)?;
+    let got = rl.range_values(0..=2)?;
     assert_eq!(logs[0..1], got);
 
-    let got = rl.range_get(0..3)?;
+    let got = rl.range_values(0..3)?;
     assert_eq!(logs[0..1], got);
 
-    let got = rl.range_get(0..5)?;
+    let got = rl.range_values(0..5)?;
     assert_eq!(logs[0..2], got);
 
-    let got = rl.range_get(0..10)?;
+    let got = rl.range_values(0..10)?;
     assert_eq!(logs[0..3], got);
 
-    let got = rl.range_get(0..11)?;
+    let got = rl.range_values(0..11)?;
     assert_eq!(logs[0..4], got);
 
-    let got = rl.range_get(9..11)?;
+    let got = rl.range_values(9..11)?;
     assert_eq!(logs[2..4], got);
 
-    let got = rl.range_get(10..256)?;
+    let got = rl.range_values(10..256)?;
     assert_eq!(logs[3..4], got);
 
-    let got = rl.range_get(10..257)?;
+    let got = rl.range_values(10..257)?;
     assert_eq!(logs[3..5], got);
 
-    let got = rl.range_get(257..)?;
+    let got = rl.range_values(257..)?;
     assert_eq!(logs[5..], got);
     Ok(())
 }
@@ -129,7 +129,7 @@ async fn test_raft_log_insert() -> anyhow::Result<()> {
         rl.insert(log).await?;
     }
 
-    assert_eq!(logs, rl.range_get(..)?);
+    assert_eq!(logs, rl.range_values(..)?);
 
     Ok(())
 }
@@ -206,7 +206,7 @@ async fn test_raft_log_last() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_raft_log_range_delete() -> anyhow::Result<()> {
+async fn test_raft_log_range_remove() -> anyhow::Result<()> {
     init_store_unittest();
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -246,21 +246,21 @@ async fn test_raft_log_range_delete() -> anyhow::Result<()> {
     ];
 
     rl.append(&logs).await?;
-    rl.range_delete(0..).await?;
-    assert_eq!(logs[5..], rl.range_get(0..)?);
+    rl.range_remove(0..).await?;
+    assert_eq!(logs[5..], rl.range_values(0..)?);
 
     rl.append(&logs).await?;
-    rl.range_delete(1..).await?;
-    assert_eq!(logs[5..], rl.range_get(0..)?);
+    rl.range_remove(1..).await?;
+    assert_eq!(logs[5..], rl.range_values(0..)?);
 
     rl.append(&logs).await?;
-    rl.range_delete(3..).await?;
-    assert_eq!(logs[0..1], rl.range_get(0..)?);
+    rl.range_remove(3..).await?;
+    assert_eq!(logs[0..1], rl.range_values(0..)?);
 
     rl.append(&logs).await?;
-    rl.range_delete(3..10).await?;
-    assert_eq!(logs[0..1], rl.range_get(0..5)?);
-    assert_eq!(logs[3..], rl.range_get(5..)?);
+    rl.range_remove(3..10).await?;
+    assert_eq!(logs[0..1], rl.range_values(0..5)?);
+    assert_eq!(logs[3..], rl.range_values(5..)?);
 
     Ok(())
 }

--- a/fusestore/store/src/meta_service/raftmeta.rs
+++ b/fusestore/store/src/meta_service/raftmeta.rs
@@ -271,7 +271,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
             return Ok(vec![]);
         }
 
-        Ok(self.log.range_get(start..stop)?)
+        Ok(self.log.range_values(start..stop)?)
     }
 
     #[tracing::instrument(level = "info", skip(self), fields(id=self.id))]
@@ -283,9 +283,9 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
 
         // If a stop point was specified, delete from start until the given stop point.
         if let Some(stop) = stop.as_ref() {
-            self.log.range_delete(start..*stop).await?;
+            self.log.range_remove(start..*stop).await?;
         } else {
-            self.log.range_delete(start..).await?;
+            self.log.range_remove(start..).await?;
         }
         Ok(())
     }
@@ -363,7 +363,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
         let meta;
         {
             let mut current_snapshot = self.current_snapshot.write().await;
-            self.log.range_delete(0..last_applied_log.index).await?;
+            self.log.range_remove(0..last_applied_log.index).await?;
 
             let snapshot_id = format!(
                 "{}-{}-{}",
@@ -433,7 +433,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
 
             // Remove logs that are included in the snapshot,
             // except the last one that is replaced with a snapshot pointer.
-            self.log.range_delete(0..meta.last_log_id.index).await?;
+            self.log.range_remove(0..meta.last_log_id.index).await?;
         }
 
         // Update current snapshot.

--- a/fusestore/store/src/meta_service/raftmeta_test.rs
+++ b/fusestore/store/src/meta_service/raftmeta_test.rs
@@ -505,7 +505,7 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
 
     tracing::info!("--- check logs");
     {
-        let logs = leader.sto.log.range_get(..)?;
+        let logs = leader.sto.log.range_values(..)?;
         tracing::info!("logs: {:?}", logs);
         assert_eq!(log_cnt as usize, logs.len());
     }

--- a/fusestore/store/src/meta_service/sled_tree.rs
+++ b/fusestore/store/src/meta_service/sled_tree.rs
@@ -178,17 +178,7 @@ impl SledTree {
                 format!("batch remove: {}", range_mes,)
             })?;
 
-        if flush && self.sync {
-            let span = tracing::span!(tracing::Level::DEBUG, "flush-range-remove");
-            let _ent = span.enter();
-
-            self.tree
-                .flush_async()
-                .await
-                .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
-                    format!("flush range remove: {}", range_mes,)
-                })?;
-        }
+        self.flush_async(flush).await?;
 
         Ok(())
     }
@@ -283,15 +273,7 @@ impl SledTree {
             .apply_batch(batch)
             .map_err_to_code(ErrorCode::MetaStoreDamaged, || "batch append")?;
 
-        if self.sync {
-            let span = tracing::span!(tracing::Level::DEBUG, "flush-append");
-            let _ent = span.enter();
-
-            self.tree
-                .flush_async()
-                .await
-                .map_err_to_code(ErrorCode::MetaStoreDamaged, || "flush append")?;
-        }
+        self.flush_async(true).await?;
 
         Ok(())
     }
@@ -319,15 +301,7 @@ impl SledTree {
             .apply_batch(batch)
             .map_err_to_code(ErrorCode::MetaStoreDamaged, || "batch append_values")?;
 
-        if self.sync {
-            let span = tracing::span!(tracing::Level::DEBUG, "flush-append-values");
-            let _ent = span.enter();
-
-            self.tree
-                .flush_async()
-                .await
-                .map_err_to_code(ErrorCode::MetaStoreDamaged, || "flush append_values")?;
-        }
+        self.flush_async(true).await?;
 
         Ok(())
     }
@@ -358,17 +332,7 @@ impl SledTree {
             Some(x) => Some(KV::deserialize_value(x)?),
         };
 
-        if self.sync {
-            let span = tracing::span!(tracing::Level::DEBUG, "flush-insert");
-            let _ent = span.enter();
-
-            self.tree
-                .flush_async()
-                .await
-                .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
-                    format!("flush insert_value {}", key)
-                })?;
-        }
+        self.flush_async(true).await?;
 
         Ok(prev)
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Nothing really changed.

##### [store] refactor: extract common function flush_async

##### [store] refactor: delete->remove. follow the sled convention

## Changelog




- Improvement


## Related Issues

- #271
- #1080 