### PR TITLE
[store] feature: generic kv support auto expiring an entry.

### DIFF
--- a/common/flights/src/impls/kv_api_impl.rs
+++ b/common/flights/src/impls/kv_api_impl.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 use common_exception::Result;
+use common_metatypes::KVMeta;
 use common_metatypes::MatchSeq;
 pub use common_store_api::kv_api::MGetKVActionResult;
 pub use common_store_api::kv_api::PrefixListReply;
@@ -24,11 +25,13 @@ impl KVApi for StoreClient {
         key: &str,
         seq: MatchSeq,
         value: Option<Vec<u8>>,
+        value_meta: Option<KVMeta>,
     ) -> Result<UpsertKVActionResult> {
         self.do_action(UpsertKVAction {
             key: key.to_string(),
             seq,
             value,
+            value_meta,
         })
         .await
     }
@@ -108,6 +111,7 @@ pub struct UpsertKVAction {
     pub key: String,
     pub seq: MatchSeq,
     pub value: Option<Vec<u8>>,
+    pub value_meta: Option<KVMeta>,
 }
 
 action_declare!(

--- a/common/management/src/user/user_mgr.rs
+++ b/common/management/src/user/user_mgr.rs
@@ -56,7 +56,10 @@ impl<T: KVApi + Send> UserMgrApi for UserMgr<T> {
         // Only when there are no record, i.e. seq=0
         let match_seq = MatchSeq::Exact(0);
 
-        let res = self.kv_api.upsert_kv(&key, match_seq, Some(value)).await?;
+        let res = self
+            .kv_api
+            .upsert_kv(&key, match_seq, Some(value), None)
+            .await?;
 
         match (res.prev, res.result) {
             (None, Some((s, _))) => Ok(s), // do we need to check the seq returned?
@@ -84,7 +87,7 @@ impl<T: KVApi + Send> UserMgrApi for UserMgr<T> {
             .ok_or_else(|| ErrorCode::UnknownUser(format!("unknown user {}", username.as_ref())))?;
 
         match MatchSeq::from(seq).match_seq(&seq_value) {
-            Ok(_) => Ok((seq_value.0, seq_value.1.try_into()?)),
+            Ok(_) => Ok((seq_value.0, seq_value.1.value.try_into()?)),
             Err(_) => Err(ErrorCode::UnknownUser(format!(
                 "username: {}",
                 username.as_ref()
@@ -97,7 +100,7 @@ impl<T: KVApi + Send> UserMgrApi for UserMgr<T> {
         let mut r = vec![];
         for v in values {
             let (_key, (s, val)) = v;
-            let u = serde_json::from_slice::<UserInfo>(&val)
+            let u = serde_json::from_slice::<UserInfo>(&val.value)
                 .map_err_to_code(ErrorCode::IllegalUserInfoFormat, || "")?;
 
             r.push((s, u));
@@ -118,7 +121,7 @@ impl<T: KVApi + Send> UserMgrApi for UserMgr<T> {
         for v in values.result {
             match v {
                 Some(v) => {
-                    let u = serde_json::from_slice::<UserInfo>(&v.1)
+                    let u = serde_json::from_slice::<UserInfo>(&v.1.value)
                         .map_err_to_code(ErrorCode::IllegalUserInfoFormat, || "")?;
                     r.push(Some((v.0, u)));
                 }
@@ -167,7 +170,10 @@ impl<T: KVApi + Send> UserMgrApi for UserMgr<T> {
             None => MatchSeq::GE(1),
             Some(s) => MatchSeq::Exact(s),
         };
-        let res = self.kv_api.upsert_kv(&key, match_seq, Some(value)).await?;
+        let res = self
+            .kv_api
+            .upsert_kv(&key, match_seq, Some(value), None)
+            .await?;
         match res.result {
             Some((s, _)) => Ok(Some(s)),
             None => Err(ErrorCode::UnknownUser(format!(
@@ -183,7 +189,7 @@ impl<T: KVApi + Send> UserMgrApi for UserMgr<T> {
         seq: Option<u64>,
     ) -> Result<()> {
         let key = utils::prepend(username.as_ref());
-        let r = self.kv_api.upsert_kv(&key, seq.into(), None).await?;
+        let r = self.kv_api.upsert_kv(&key, seq.into(), None, None).await?;
         if r.prev.is_some() && r.result.is_none() {
             Ok(())
         } else {

--- a/common/metatypes/src/lib.rs
+++ b/common/metatypes/src/lib.rs
@@ -4,6 +4,7 @@
 
 //! This crate defines data types used in meta data storage service.
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
@@ -23,6 +24,43 @@ mod match_seq_test;
 
 /// Value with a corresponding sequence number
 pub type SeqValue<T = Vec<u8>> = (u64, T);
+
+/// The meta data of a record in meta-store kv
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+pub struct KVMeta {
+    /// expiration time in second since 1970
+    pub expire_at: Option<u64>,
+}
+
+/// Value of StateMachine generic-kv
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
+pub struct KVValue<T = Vec<u8>> {
+    pub meta: Option<KVMeta>,
+    pub value: T,
+}
+
+/// Compare with a timestamp to check if it is expired.
+impl PartialEq<u64> for KVValue {
+    fn eq(&self, other: &u64) -> bool {
+        match self.meta {
+            None => false,
+            Some(ref m) => match m.expire_at {
+                None => false,
+                Some(ref exp) => exp == other,
+            },
+        }
+    }
+}
+
+/// Compare with a timestamp to check if it is expired.
+impl PartialOrd<u64> for KVValue {
+    fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+        match self.meta {
+            None => None,
+            Some(ref m) => m.expire_at.as_ref().map(|exp| exp.cmp(other)),
+        }
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Database {

--- a/common/store-api/src/kv_api.rs
+++ b/common/store-api/src/kv_api.rs
@@ -4,28 +4,30 @@
 //
 
 use async_trait::async_trait;
+use common_metatypes::KVMeta;
+use common_metatypes::KVValue;
 use common_metatypes::MatchSeq;
 use common_metatypes::SeqValue;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct UpsertKVActionResult {
     /// prev is the value before upsert.
-    pub prev: Option<SeqValue>,
+    pub prev: Option<SeqValue<KVValue>>,
     /// result is the value after upsert.
-    pub result: Option<SeqValue>,
+    pub result: Option<SeqValue<KVValue>>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct GetKVActionResult {
-    pub result: Option<SeqValue>,
+    pub result: Option<SeqValue<KVValue>>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct MGetKVActionResult {
-    pub result: Vec<Option<SeqValue>>,
+    pub result: Vec<Option<SeqValue<KVValue>>>,
 }
 
-pub type PrefixListReply = Vec<(String, SeqValue)>;
+pub type PrefixListReply = Vec<(String, SeqValue<KVValue>)>;
 
 #[async_trait]
 pub trait KVApi {
@@ -34,6 +36,7 @@ pub trait KVApi {
         key: &str,
         seq: MatchSeq,
         value: Option<Vec<u8>>,
+        value_meta: Option<KVMeta>,
     ) -> common_exception::Result<UpsertKVActionResult>;
 
     async fn get_kv(&mut self, key: &str) -> common_exception::Result<GetKVActionResult>;

--- a/store/src/executor/kv_handlers.rs
+++ b/store/src/executor/kv_handlers.rs
@@ -28,6 +28,7 @@ impl RequestHandler<UpsertKVAction> for ActionHandler {
                 key: act.key,
                 seq: act.seq,
                 value: act.value,
+                value_meta: act.value_meta,
             },
         };
         let rst = self

--- a/store/src/meta_service/applied_state.rs
+++ b/store/src/meta_service/applied_state.rs
@@ -5,6 +5,7 @@
 use async_raft::AppDataResponse;
 use common_flights::storage_api_impl::DataPartInfo;
 use common_metatypes::Database;
+use common_metatypes::KVValue;
 use common_metatypes::SeqValue;
 use common_metatypes::Table;
 use serde::Deserialize;
@@ -50,8 +51,8 @@ pub enum AppliedState {
     },
 
     KV {
-        prev: Option<SeqValue>,
-        result: Option<SeqValue>,
+        prev: Option<SeqValue<KVValue>>,
+        result: Option<SeqValue<KVValue>>,
     },
 }
 
@@ -110,8 +111,8 @@ impl From<(Option<Vec<DataPartInfo>>, Option<Vec<DataPartInfo>>)> for AppliedSta
     }
 }
 
-impl From<(Option<SeqValue>, Option<SeqValue>)> for AppliedState {
-    fn from(v: (Option<SeqValue>, Option<SeqValue>)) -> Self {
+impl From<(Option<SeqValue<KVValue>>, Option<SeqValue<KVValue>>)> for AppliedState {
+    fn from(v: (Option<SeqValue<KVValue>>, Option<SeqValue<KVValue>>)) -> Self {
         AppliedState::KV {
             prev: v.0,
             result: v.1,

--- a/store/src/meta_service/cmd.rs
+++ b/store/src/meta_service/cmd.rs
@@ -6,6 +6,7 @@ use std::fmt;
 
 use async_raft::NodeId;
 use common_metatypes::Database;
+use common_metatypes::KVMeta;
 use common_metatypes::MatchSeq;
 use common_metatypes::Table;
 use serde::Deserialize;
@@ -76,6 +77,9 @@ pub enum Cmd {
 
         /// The value to set. A `None` indicates to delete it.
         value: Option<Vec<u8>>,
+
+        /// Meta data of a value.
+        value_meta: Option<KVMeta>,
     },
 }
 
@@ -131,8 +135,17 @@ impl fmt::Display for Cmd {
                     db_name, table_name, if_exists
                 )
             }
-            Cmd::UpsertKV { key, seq, value } => {
-                write!(f, "upsert_kv: {}({:?}) = {:?}", key, seq, value)
+            Cmd::UpsertKV {
+                key,
+                seq,
+                value,
+                value_meta,
+            } => {
+                write!(
+                    f,
+                    "upsert_kv: {}({:?}) = {:?} ({:?})",
+                    key, seq, value, value_meta
+                )
             }
         }
     }

--- a/store/src/meta_service/raft_types.rs
+++ b/store/src/meta_service/raft_types.rs
@@ -9,6 +9,7 @@ pub use async_raft::NodeId;
 use byteorder::BigEndian;
 use byteorder::ByteOrder;
 use common_exception::ErrorCode;
+use common_metatypes::KVValue;
 use common_metatypes::SeqValue;
 use sled::IVec;
 
@@ -59,7 +60,7 @@ impl SledSerde for String {
     }
 }
 
-impl SledSerde for SeqValue<Vec<u8>> {}
+impl SledSerde for SeqValue<KVValue> {}
 
 /// For LogId to be able to stored in sled::Tree as a value.
 impl SledSerde for LogId {}

--- a/store/src/meta_service/raftmeta.rs
+++ b/store/src/meta_service/raftmeta.rs
@@ -28,6 +28,7 @@ use common_exception::prelude::ToErrorCode;
 use common_flights::storage_api_impl::AppendResult;
 use common_flights::storage_api_impl::DataPartInfo;
 use common_metatypes::Database;
+use common_metatypes::KVValue;
 use common_metatypes::SeqValue;
 use common_metatypes::Table;
 use common_runtime::tokio;
@@ -976,7 +977,7 @@ impl MetaNode {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn get_kv(&self, key: &str) -> Option<SeqValue> {
+    pub async fn get_kv(&self, key: &str) -> Option<SeqValue<KVValue>> {
         // inconsistent get: from local state machine
 
         let sm = self.sto.state_machine.read().await;
@@ -987,14 +988,14 @@ impl MetaNode {
     pub async fn mget_kv(
         &self,
         keys: &[impl AsRef<str> + std::fmt::Debug],
-    ) -> Vec<Option<SeqValue>> {
+    ) -> Vec<Option<SeqValue<KVValue>>> {
         // inconsistent get: from local state machine
         let sm = self.sto.state_machine.read().await;
         sm.mget_kv(keys)
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn prefix_list_kv(&self, prefix: &str) -> Vec<(String, SeqValue)> {
+    pub async fn prefix_list_kv(&self, prefix: &str) -> Vec<(String, SeqValue<KVValue>)> {
         // inconsistent get: from local state machine
         let sm = self.sto.state_machine.read().await;
         sm.prefix_list_kv(prefix)

--- a/store/src/meta_service/sled_key_space.rs
+++ b/store/src/meta_service/sled_key_space.rs
@@ -11,6 +11,7 @@ use std::ops::RangeBounds;
 
 use async_raft::raft::Entry;
 use common_exception::ErrorCode;
+use common_metatypes::KVValue;
 use common_metatypes::SeqValue;
 use sled::IVec;
 
@@ -154,5 +155,5 @@ impl SledKeySpace for GenericKV {
     const PREFIX: u8 = 6;
     const NAME: &'static str = "generic-kv";
     type K = String;
-    type V = SeqValue;
+    type V = SeqValue<KVValue<Vec<u8>>>;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: generic kv support auto expiring an entry.
Add: UpsertKV adds another `meta` field to specify value meta.  One of
the meta is `expire_at`, which is a timestamp since 1970.  Reading on an
expired entry always returns None, e.g. when reading directly from
StateMachine or when reanding it for an update(apply a raft log).


## Changelog

- New Feature





## Related Issues

- #271
- #1402 
- fix: #1422 