### PR TITLE
[store] refactor:  use common_exception::Result to replace anyhow

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -200,6 +200,10 @@ build_exceptions! {
 
     DatafuseStoreError(2501),
 
+    // FS error
+
+    IllegalFileName(2601),
+
 
     // TODO
     // We may need to separate front-end errors from API errors (and system errors?)

--- a/store/src/dfs/distributed_fs.rs
+++ b/store/src/dfs/distributed_fs.rs
@@ -43,7 +43,7 @@ impl Dfs {}
 #[async_trait]
 impl FileSystem for Dfs {
     #[tracing::instrument(level = "debug", skip(self, data))]
-    async fn add(&self, path: &str, data: &[u8]) -> anyhow::Result<()> {
+    async fn add(&self, path: &str, data: &[u8]) -> common_exception::Result<()> {
         // add the file to local fs
 
         self.local_fs.add(path, data).await?;
@@ -75,8 +75,7 @@ impl FileSystem for Dfs {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn list(&self, prefix: &str) -> anyhow::Result<ListResult> {
-        // TODO(xp): use common_exception to replace anyhow
+    async fn list(&self, prefix: &str) -> common_exception::Result<ListResult> {
         let fns = self.meta_node.list_files(prefix).await?;
 
         Ok(ListResult {

--- a/store/src/executor/kv_handlers.rs
+++ b/store/src/executor/kv_handlers.rs
@@ -47,7 +47,7 @@ impl RequestHandler<UpsertKVAction> for ActionHandler {
 #[async_trait::async_trait]
 impl RequestHandler<GetKVAction> for ActionHandler {
     async fn handle(&self, act: GetKVAction) -> common_exception::Result<GetKVActionResult> {
-        let result = self.meta_node.get_kv(&act.key).await;
+        let result = self.meta_node.get_kv(&act.key).await?;
         Ok(GetKVActionResult { result })
     }
 }
@@ -55,7 +55,7 @@ impl RequestHandler<GetKVAction> for ActionHandler {
 #[async_trait::async_trait]
 impl RequestHandler<MGetKVAction> for ActionHandler {
     async fn handle(&self, act: MGetKVAction) -> common_exception::Result<MGetKVActionResult> {
-        let result = self.meta_node.mget_kv(&act.keys).await;
+        let result = self.meta_node.mget_kv(&act.keys).await?;
         Ok(MGetKVActionResult { result })
     }
 }
@@ -63,7 +63,7 @@ impl RequestHandler<MGetKVAction> for ActionHandler {
 #[async_trait::async_trait]
 impl RequestHandler<PrefixListReq> for ActionHandler {
     async fn handle(&self, act: PrefixListReq) -> common_exception::Result<PrefixListReply> {
-        let result = self.meta_node.prefix_list_kv(&(act.0)).await;
+        let result = self.meta_node.prefix_list_kv(&(act.0)).await?;
         Ok(result)
     }
 }

--- a/store/src/fs/ifs.rs
+++ b/store/src/fs/ifs.rs
@@ -14,18 +14,18 @@ where Self: Sync + Send
 {
     /// Add file atomically.
     /// AKA put_if_absent
-    async fn add(&self, path: &str, data: &[u8]) -> anyhow::Result<()>;
+    async fn add(&self, path: &str, data: &[u8]) -> common_exception::Result<()>;
 
     /// read all bytes from a file
     async fn read_all(&self, path: &str) -> exception::Result<Vec<u8>>;
 
     /// List dir and returns directories and files.
-    async fn list(&self, prefix: &str) -> anyhow::Result<ListResult>;
+    async fn list(&self, prefix: &str) -> common_exception::Result<ListResult>;
 
     // async fn read(
     //     path: &str,
     //     offset: usize,
     //     length: usize,
     //     buf: &mut [u8],
-    // ) -> anyhow::Result<usize>;
+    // ) -> common_exception::Result<usize>;
 }

--- a/store/src/localfs/local_fs_test.rs
+++ b/store/src/localfs/local_fs_test.rs
@@ -32,10 +32,11 @@ async fn test_localfs_read_all() -> anyhow::Result<()> {
     {
         // add foo.txt twice, fail
         let got = f.add("foo.txt", "123".as_bytes()).await;
-        assert_eq!(
-            "LocalFS: fail to open foo.txt",
-            got.err().unwrap().to_string()
-        );
+        assert!(got
+            .err()
+            .unwrap()
+            .to_string()
+            .starts_with("Code: 1002, displayText"));
     }
     {
         // add long/bar.txt and read

--- a/store/src/meta_service/placement.rs
+++ b/store/src/meta_service/placement.rs
@@ -26,12 +26,13 @@ use crate::meta_service::Slot;
 pub trait Placement {
     /// Returns the Node-s that are responsible to store a copy of a file.
     fn nodes_to_store_key(&self, key: &str) -> Vec<Node> {
+        // TODO(xp): handle error instead of using unwrap
         let slot_idx = self.slot_index_for_key(key);
         let slot = self.get_slot(slot_idx);
 
         slot.node_ids
             .iter()
-            .map(|nid| self.get_placement_node(nid).unwrap())
+            .map(|nid| self.get_placement_node(nid).unwrap().unwrap())
             .collect()
     }
 
@@ -51,7 +52,7 @@ pub trait Placement {
     fn get_slots(&self) -> &[Slot];
 
     /// Returns a node.
-    fn get_placement_node(&self, node_id: &NodeId) -> Option<Node>;
+    fn get_placement_node(&self, node_id: &NodeId) -> common_exception::Result<Option<Node>>;
 }
 
 /// Evenly chooses `n` elements from `m` elements

--- a/store/src/meta_service/raftmeta.rs
+++ b/store/src/meta_service/raftmeta.rs
@@ -475,7 +475,7 @@ pub struct MetaNode {
 }
 
 impl MetaStore {
-    pub async fn get_node(&self, node_id: &NodeId) -> Option<Node> {
+    pub async fn get_node(&self, node_id: &NodeId) -> common_exception::Result<Option<Node>> {
         let sm = self.state_machine.read().await;
 
         sm.get_node(node_id)
@@ -484,7 +484,7 @@ impl MetaStore {
     pub async fn get_node_addr(&self, node_id: &NodeId) -> common_exception::Result<String> {
         let addr = self
             .get_node(node_id)
-            .await
+            .await?
             .map(|n| n.address)
             .ok_or_else(|| ErrorCode::UnknownNode(format!("node id: {}", node_id)))?;
 
@@ -876,7 +876,7 @@ impl MetaNode {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn get_node(&self, node_id: &NodeId) -> Option<Node> {
+    pub async fn get_node(&self, node_id: &NodeId) -> common_exception::Result<Option<Node>> {
         // inconsistent get: from local state machine
 
         let sm = self.sto.state_machine.read().await;
@@ -985,7 +985,7 @@ impl MetaNode {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn get_kv(&self, key: &str) -> Option<SeqValue<KVValue>> {
+    pub async fn get_kv(&self, key: &str) -> common_exception::Result<Option<SeqValue<KVValue>>> {
         // inconsistent get: from local state machine
 
         let sm = self.sto.state_machine.read().await;
@@ -996,14 +996,17 @@ impl MetaNode {
     pub async fn mget_kv(
         &self,
         keys: &[impl AsRef<str> + std::fmt::Debug],
-    ) -> Vec<Option<SeqValue<KVValue>>> {
+    ) -> common_exception::Result<Vec<Option<SeqValue<KVValue>>>> {
         // inconsistent get: from local state machine
         let sm = self.sto.state_machine.read().await;
         sm.mget_kv(keys)
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn prefix_list_kv(&self, prefix: &str) -> Vec<(String, SeqValue<KVValue>)> {
+    pub async fn prefix_list_kv(
+        &self,
+        prefix: &str,
+    ) -> common_exception::Result<Vec<(String, SeqValue<KVValue>)>> {
         // inconsistent get: from local state machine
         let sm = self.sto.state_machine.read().await;
         sm.prefix_list_kv(prefix)

--- a/store/src/meta_service/raftmeta_test.rs
+++ b/store/src/meta_service/raftmeta_test.rs
@@ -161,7 +161,7 @@ async fn test_meta_node_boot() -> anyhow::Result<()> {
 
     let mn = MetaNode::boot(0, &tc.config).await?;
 
-    let got = mn.get_node(&0).await;
+    let got = mn.get_node(&0).await?;
     assert_eq!(addr, got.unwrap().address);
     mn.stop().await?;
     Ok(())
@@ -512,7 +512,7 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
 
     tracing::info!("--- check state machine: nodes");
     {
-        let node = leader.sto.get_node(&0).await.expect("must not be none");
+        let node = leader.sto.get_node(&0).await?.unwrap();
         assert_eq!(tc.config.meta_api_addr(), node.address);
     }
 
@@ -605,7 +605,7 @@ async fn setup_leader() -> anyhow::Result<(NodeId, StoreTestContext)> {
         assert_meta_connection(&addr).await?;
 
         // assert that boot() adds the node to meta.
-        let got = mn.get_node(&nid).await;
+        let got = mn.get_node(&nid).await?;
         assert_eq!(addr, got.unwrap().address, "nid0 is added");
 
         wait_for_state(&mn, State::Leader).await?;

--- a/store/src/meta_service/state_machine_test.rs
+++ b/store/src/meta_service/state_machine_test.rs
@@ -417,7 +417,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
             }
         };
 
-        let got = sm.get_kv(&c.key);
+        let got = sm.get_kv(&c.key)?;
         assert_eq!(want, got, "get: {}", mes,);
     }
 
@@ -513,7 +513,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_delete() -> anyhow::Result<
 
         // read it to ensure the modified state.
         let want = &c.result;
-        let got = sm.get_kv(&c.key);
+        let got = sm.get_kv(&c.key)?;
         assert_eq!(want, &got, "get: {}", mes,);
     }
 


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor:  use common_exception::Result to replace anyhow

## Changelog




- Improvement


## Related Issues

- #271