### PR TITLE
[store]: feature: RaftState: stores the last snapshot meta. To avoid potential repliation bug.

### DIFF
--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -45,6 +45,7 @@ futures = "0.3"
 indexmap = "1.7.0"
 lazy_static = "1.4.0"
 log = "0.4"
+maplit = "1.0.2"
 metrics = "0.17.0"
 metrics-exporter-prometheus = "0.6.0"
 num = "0.4"
@@ -71,7 +72,6 @@ warp = { version = "0.3.1", features = ["tls"] }
 env_logger = "*"
 pretty_assertions = "0.7"
 test-env-log = "0.2.7"
-maplit = "1.0.2"
 flaky_test = "0.1"
 
 [build-dependencies]

--- a/store/src/meta_service/raft_state_kv.rs
+++ b/store/src/meta_service/raft_state_kv.rs
@@ -5,6 +5,7 @@
 use std::fmt;
 
 use async_raft::storage::HardState;
+use async_raft::SnapshotMeta;
 use common_exception::ErrorCode;
 use serde::Deserialize;
 use serde::Serialize;
@@ -28,14 +29,29 @@ pub enum RaftStateKey {
     /// 2. Update this field to point to the new state machine.
     /// 3. Cleanup old state machine.
     StateMachineId,
+
+    /// The last snapshot meta data.
+    /// Because membership log is not applied to state machine,
+    /// Before logs are removed, the membership need to be saved.
+    ///
+    /// The async-raft::MemStore saves it in a removed log slot,
+    /// which may mess up the replication:
+    /// Replication has chance sending this pointer log that was an client data.
+    ///
+    /// The presence of snapshot meta does not mean there is a valid snapshot data.
+    /// Since snapshot data is not saved on disk.
+    /// A snapshot meta guarantees no smaller snapshot will be installed when installing snapshot,
+    /// and no membership config is lost when removing logs that are included in snapshot.
+    SnapshotMeta,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RaftStateValue {
     NodeId(NodeId),
     HardState(HardState),
     /// active state machine, previous state machine
     StateMachineId((u64, u64)),
+    SnapshotMeta(SnapshotMeta),
 }
 
 impl fmt::Display for RaftStateKey {
@@ -50,6 +66,9 @@ impl fmt::Display for RaftStateKey {
             RaftStateKey::StateMachineId => {
                 write!(f, "StateMachineId")
             }
+            RaftStateKey::SnapshotMeta => {
+                write!(f, "SnapshotMeta")
+            }
         }
     }
 }
@@ -60,6 +79,7 @@ impl SledOrderedSerde for RaftStateKey {
             RaftStateKey::Id => 1,
             RaftStateKey::HardState => 2,
             RaftStateKey::StateMachineId => 3,
+            RaftStateKey::SnapshotMeta => 4,
         };
 
         Ok(IVec::from(&[i]))
@@ -74,6 +94,8 @@ impl SledOrderedSerde for RaftStateKey {
             return Ok(RaftStateKey::HardState);
         } else if slice[0] == 3 {
             return Ok(RaftStateKey::StateMachineId);
+        } else if slice[0] == 4 {
+            return Ok(RaftStateKey::SnapshotMeta);
         }
 
         Err(ErrorCode::MetaStoreDamaged("invalid key IVec"))
@@ -105,6 +127,15 @@ impl From<RaftStateValue> for (u64, u64) {
         match v {
             RaftStateValue::StateMachineId(x) => x,
             _ => panic!("expect StateMachineId"),
+        }
+    }
+}
+
+impl From<RaftStateValue> for SnapshotMeta {
+    fn from(v: RaftStateValue) -> Self {
+        match v {
+            RaftStateValue::SnapshotMeta(x) => x,
+            _ => panic!("expect Membership"),
         }
     }
 }

--- a/store/src/meta_service/raft_state_test.rs
+++ b/store/src/meta_service/raft_state_test.rs
@@ -1,9 +1,12 @@
 // Copyright 2020-2021 The Datafuse Authors.
 //
 // SPDX-License-Identifier: Apache-2.0.
-
+use async_raft::raft::MembershipConfig;
 use async_raft::storage::HardState;
+use async_raft::LogId;
+use async_raft::SnapshotMeta;
 use common_runtime::tokio;
+use maplit::hashset;
 
 use crate::meta_service::raft_state::RaftState;
 use crate::tests::service::init_store_unittest;
@@ -143,5 +146,54 @@ async fn test_raft_state_write_read_state_machine_id() -> anyhow::Result<()> {
 
     let got = rs.read_state_machine_id()?;
     assert_eq!((1, 2), got);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_raft_state_write_read_removed_snapshot() -> anyhow::Result<()> {
+    // - create a raft state
+    // - write state membership and the read it.
+    init_store_unittest();
+
+    let mut tc = new_sled_test_context();
+    let db = &tc.db;
+    tc.config.id = 3;
+    let rs = RaftState::open_create(db, &tc.config, None, Some(())).await?;
+
+    // read got a None
+
+    let default = SnapshotMeta {
+        last_log_id: LogId { term: 0, index: 0 },
+        membership: MembershipConfig {
+            members: hashset![tc.config.id],
+            members_after_consensus: None,
+        },
+        snapshot_id: "".to_string(),
+    };
+
+    let got = rs.read_snapshot_meta()?;
+    assert_eq!(default.last_log_id, got.last_log_id);
+    assert_eq!(default.membership, got.membership);
+    assert_eq!(default.snapshot_id, got.snapshot_id);
+
+    // write hard state
+
+    let snap_meta = SnapshotMeta {
+        last_log_id: LogId { term: 1, index: 2 },
+        membership: MembershipConfig {
+            members: hashset![1, 2, 3],
+            members_after_consensus: None,
+        },
+        snapshot_id: "".to_string(),
+    };
+
+    rs.write_snapshot_meta(&snap_meta).await?;
+
+    // read the written
+
+    let got = rs.read_snapshot_meta()?;
+    assert_eq!(snap_meta.last_log_id, got.last_log_id);
+    assert_eq!(snap_meta.membership, got.membership);
+    assert_eq!(snap_meta.snapshot_id, got.snapshot_id);
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store]: feature: RaftState: stores the last snapshot meta. To avoid potential repliation bug.
Because membership log is not applied to state machine,
Before logs are removed, the membership need to be saved.

The async-raft::MemStore saves it in a removed log slot,
which may mess up the replication:
Replication has chance sending this pointer log that was an client data.

Although, the presence of snapshot meta does not mean there is a valid snapshot data.
Since snapshot data is not saved on disk.

A snapshot meta only guarantees no smaller snapshot will be installed
when installing snapshot, and no membership config is lost when removing
logs that are included in snapshot.

## Changelog

- New Feature





## Related Issues

- #271
- #1080