### PR TITLE
[store] feature: applies all logs to raft state machine.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.7#8e0cca5241fa423430920ab5c409494569bacb01"
+source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.8#adc24f55d75d9c7c01fcd0f4f9e35dd5aae679aa"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -37,7 +37,7 @@ common-tracing = {path = "../common/tracing"}
 
 # Crates.io dependencies
 anyhow = "1.0.42"
-async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.7" }
+async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.8" }
 async-trait = "0.1"
 byteorder = "1.1.0"
 env_logger = "0.9"

--- a/store/src/meta_service/applied_state.rs
+++ b/store/src/meta_service/applied_state.rs
@@ -64,6 +64,8 @@ pub enum AppliedState {
         prev: Option<SeqValue<KVValue>>,
         result: Option<SeqValue<KVValue>>,
     },
+
+    None,
 }
 
 impl AppDataResponse for AppliedState {}

--- a/store/src/meta_service/raftmeta.rs
+++ b/store/src/meta_service/raftmeta.rs
@@ -317,22 +317,18 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
     #[tracing::instrument(level = "info", skip(self), fields(id=self.id))]
     async fn apply_entry_to_state_machine(
         &self,
-        index: &LogId,
-        data: &LogEntry,
+        entry: &Entry<LogEntry>,
     ) -> anyhow::Result<AppliedState> {
         let mut sm = self.state_machine.write().await;
-        let resp = sm.apply(index, data).await?;
+        let resp = sm.apply(entry).await?;
         Ok(resp)
     }
 
     #[tracing::instrument(level = "info", skip(self, entries), fields(id=self.id))]
-    async fn replicate_to_state_machine(
-        &self,
-        entries: &[(&LogId, &LogEntry)],
-    ) -> anyhow::Result<()> {
+    async fn replicate_to_state_machine(&self, entries: &[&Entry<LogEntry>]) -> anyhow::Result<()> {
         let mut sm = self.state_machine.write().await;
-        for (index, data) in entries {
-            sm.apply(*index, data).await?;
+        for entry in entries {
+            sm.apply(*entry).await?;
         }
         Ok(())
     }

--- a/store/src/meta_service/state_machine_meta.rs
+++ b/store/src/meta_service/state_machine_meta.rs
@@ -14,6 +14,7 @@
 
 use std::fmt;
 
+use async_raft::raft::MembershipConfig;
 use async_raft::LogId;
 use common_exception::ErrorCode;
 use serde::Deserialize;
@@ -27,13 +28,18 @@ use crate::meta_service::SledSerde;
 pub enum StateMachineMetaKey {
     /// The last applied log id in the state machine.
     LastApplied,
+
     /// Whether the state machine is initialized.
     Initialized,
+
+    /// The last membership config
+    LastMembership,
 }
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum StateMachineMetaValue {
     LogId(LogId),
     Bool(bool),
+    Membership(MembershipConfig),
 }
 
 impl fmt::Display for StateMachineMetaKey {
@@ -45,6 +51,9 @@ impl fmt::Display for StateMachineMetaKey {
             StateMachineMetaKey::Initialized => {
                 write!(f, "initialized")
             }
+            StateMachineMetaKey::LastMembership => {
+                write!(f, "last-membership")
+            }
         }
     }
 }
@@ -54,6 +63,7 @@ impl SledOrderedSerde for StateMachineMetaKey {
         let i = match self {
             StateMachineMetaKey::LastApplied => 1,
             StateMachineMetaKey::Initialized => 2,
+            StateMachineMetaKey::LastMembership => 3,
         };
 
         Ok(IVec::from(&[i]))
@@ -66,6 +76,8 @@ impl SledOrderedSerde for StateMachineMetaKey {
             return Ok(StateMachineMetaKey::LastApplied);
         } else if slice[0] == 2 {
             return Ok(StateMachineMetaKey::Initialized);
+        } else if slice[0] == 3 {
+            return Ok(StateMachineMetaKey::LastMembership);
         }
 
         Err(ErrorCode::MetaStoreDamaged("invalid key IVec"))
@@ -88,6 +100,14 @@ impl From<StateMachineMetaValue> for bool {
         match v {
             StateMachineMetaValue::Bool(x) => x,
             _ => panic!("expect LogId"),
+        }
+    }
+}
+impl From<StateMachineMetaValue> for MembershipConfig {
+    fn from(v: StateMachineMetaValue) -> Self {
+        match v {
+            StateMachineMetaValue::Membership(x) => x,
+            _ => panic!("expect Membership"),
         }
     }
 }

--- a/store/src/meta_service/state_machine_test.rs
+++ b/store/src/meta_service/state_machine_test.rs
@@ -15,6 +15,9 @@
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use async_raft::raft::Entry;
+use async_raft::raft::EntryNormal;
+use async_raft::raft::EntryPayload;
 use async_raft::LogId;
 use common_metatypes::Database;
 use common_metatypes::KVMeta;
@@ -189,9 +192,14 @@ async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
 
     for (name, txid, k, want) in cases.iter() {
         let resp = sm
-            .apply(&LogId { term: 0, index: 5 }, &LogEntry {
-                txid: txid.clone(),
-                cmd: Cmd::IncrSeq { key: k.to_string() },
+            .apply(&Entry {
+                log_id: LogId { term: 0, index: 5 },
+                payload: EntryPayload::Normal(EntryNormal {
+                    data: LogEntry {
+                        txid: txid.clone(),
+                        cmd: Cmd::IncrSeq { key: k.to_string() },
+                    },
+                }),
             })
             .await?;
         assert_eq!(AppliedState::Seq { seq: *want }, resp, "{}", name);
@@ -541,12 +549,17 @@ async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {
 
     for (name, txid, k, v, want_prev, want_result) in cases.iter() {
         let resp = sm
-            .apply(&LogId { term: 0, index: 5 }, &LogEntry {
-                txid: txid.clone(),
-                cmd: Cmd::AddFile {
-                    key: k.to_string(),
-                    value: v.to_string(),
-                },
+            .apply(&Entry {
+                log_id: LogId { term: 0, index: 5 },
+                payload: EntryPayload::Normal(EntryNormal {
+                    data: LogEntry {
+                        txid: txid.clone(),
+                        cmd: Cmd::AddFile {
+                            key: k.to_string(),
+                            value: v.to_string(),
+                        },
+                    },
+                }),
             })
             .await?;
         assert_eq!(
@@ -574,12 +587,17 @@ async fn test_state_machine_apply_set_file() -> anyhow::Result<()> {
 
     for (name, txid, k, v, want_prev, want_result) in cases.iter() {
         let resp = sm
-            .apply(&LogId { term: 0, index: 5 }, &LogEntry {
-                txid: txid.clone(),
-                cmd: Cmd::SetFile {
-                    key: k.to_string(),
-                    value: v.to_string(),
-                },
+            .apply(&Entry {
+                log_id: LogId { term: 0, index: 5 },
+                payload: EntryPayload::Normal(EntryNormal {
+                    data: LogEntry {
+                        txid: txid.clone(),
+                        cmd: Cmd::SetFile {
+                            key: k.to_string(),
+                            value: v.to_string(),
+                        },
+                    },
+                }),
             })
             .await?;
         assert_eq!(


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: applies all logs to raft state machine.
pass all logs to apply_entry_to_state_machine(), not just Normal logs.
Pass `Entry<D>` to `apply_entry_to_state_machine()`, not just the only
`EntryPayload::Normal(normal_log)`.

Thus the state machine is able to save the membership changes if it
prefers to.

Why:

In practice, a snapshot contains info about all applied logs, including
the membership config log.
Before this change, the state machine does not receive any membership
log thus when making a snapshot, one needs to walk through all applied
logs to get the last membership that is included in state machine.

By letting the state machine remember the membership log applied,
the snapshto creation becomes more convinient and intuitive: it does not
need to scan the applied logs any more.

Related raft changes:
https://github.com/datafuse-extras/async-raft/tree/v0.6.2-alpha.8

## Changelog

- New Feature





## Related Issues

- #271
- #1080