### PR TITLE
[store] refactor: remove RaftState::write_snapshot_meta().

### DIFF
--- a/store/src/meta_service/raft_state.rs
+++ b/store/src/meta_service/raft_state.rs
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_raft::raft::MembershipConfig;
 use async_raft::storage::HardState;
-use async_raft::LogId;
-use async_raft::SnapshotMeta;
 use common_exception::ErrorCode;
 use common_tracing::tracing;
-use maplit::hashset;
 
 use crate::configs;
 use crate::meta_service::sled_key_space::RaftStateKV;
@@ -156,37 +152,6 @@ impl RaftState {
             None => (0, 0),
         };
         Ok(smid)
-    }
-
-    pub async fn write_snapshot_meta(
-        &self,
-        snap_meta: &SnapshotMeta,
-    ) -> common_exception::Result<()> {
-        let state = self.state();
-        state
-            .insert(
-                &RaftStateKey::SnapshotMeta,
-                &RaftStateValue::SnapshotMeta(snap_meta.clone()),
-            )
-            .await?;
-        Ok(())
-    }
-
-    pub fn read_snapshot_meta(&self) -> common_exception::Result<SnapshotMeta> {
-        let state = self.state();
-        let snap_meta = state.get(&RaftStateKey::SnapshotMeta)?;
-        let snap_meta: SnapshotMeta = match snap_meta {
-            Some(v) => v.into(),
-            None => SnapshotMeta {
-                last_log_id: LogId { term: 0, index: 0 },
-                membership: MembershipConfig {
-                    members: hashset![self.id],
-                    members_after_consensus: None,
-                },
-                snapshot_id: "".to_string(),
-            },
-        };
-        Ok(snap_meta)
     }
 
     /// Returns a borrowed sled tree key space to store meta of raft log

--- a/store/src/meta_service/raft_state_kv.rs
+++ b/store/src/meta_service/raft_state_kv.rs
@@ -15,7 +15,6 @@
 use std::fmt;
 
 use async_raft::storage::HardState;
-use async_raft::SnapshotMeta;
 use common_exception::ErrorCode;
 use serde::Deserialize;
 use serde::Serialize;
@@ -39,20 +38,6 @@ pub enum RaftStateKey {
     /// 2. Update this field to point to the new state machine.
     /// 3. Cleanup old state machine.
     StateMachineId,
-
-    /// The last snapshot meta data.
-    /// Because membership log is not applied to state machine,
-    /// Before logs are removed, the membership need to be saved.
-    ///
-    /// The async-raft::MemStore saves it in a removed log slot,
-    /// which may mess up the replication:
-    /// Replication has chance sending this pointer log that was an client data.
-    ///
-    /// The presence of snapshot meta does not mean there is a valid snapshot data.
-    /// Since snapshot data is not saved on disk.
-    /// A snapshot meta guarantees no smaller snapshot will be installed when installing snapshot,
-    /// and no membership config is lost when removing logs that are included in snapshot.
-    SnapshotMeta,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,7 +46,6 @@ pub enum RaftStateValue {
     HardState(HardState),
     /// active state machine, previous state machine
     StateMachineId((u64, u64)),
-    SnapshotMeta(SnapshotMeta),
 }
 
 impl fmt::Display for RaftStateKey {
@@ -76,9 +60,6 @@ impl fmt::Display for RaftStateKey {
             RaftStateKey::StateMachineId => {
                 write!(f, "StateMachineId")
             }
-            RaftStateKey::SnapshotMeta => {
-                write!(f, "SnapshotMeta")
-            }
         }
     }
 }
@@ -89,7 +70,6 @@ impl SledOrderedSerde for RaftStateKey {
             RaftStateKey::Id => 1,
             RaftStateKey::HardState => 2,
             RaftStateKey::StateMachineId => 3,
-            RaftStateKey::SnapshotMeta => 4,
         };
 
         Ok(IVec::from(&[i]))
@@ -104,8 +84,6 @@ impl SledOrderedSerde for RaftStateKey {
             return Ok(RaftStateKey::HardState);
         } else if slice[0] == 3 {
             return Ok(RaftStateKey::StateMachineId);
-        } else if slice[0] == 4 {
-            return Ok(RaftStateKey::SnapshotMeta);
         }
 
         Err(ErrorCode::MetaStoreDamaged("invalid key IVec"))
@@ -137,15 +115,6 @@ impl From<RaftStateValue> for (u64, u64) {
         match v {
             RaftStateValue::StateMachineId(x) => x,
             _ => panic!("expect StateMachineId"),
-        }
-    }
-}
-
-impl From<RaftStateValue> for SnapshotMeta {
-    fn from(v: RaftStateValue) -> Self {
-        match v {
-            RaftStateValue::SnapshotMeta(x) => x,
-            _ => panic!("expect Membership"),
         }
     }
 }

--- a/store/src/meta_service/raft_state_test.rs
+++ b/store/src/meta_service/raft_state_test.rs
@@ -11,12 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use async_raft::raft::MembershipConfig;
 use async_raft::storage::HardState;
-use async_raft::LogId;
-use async_raft::SnapshotMeta;
 use common_runtime::tokio;
-use maplit::hashset;
 
 use crate::meta_service::raft_state::RaftState;
 use crate::tests::service::init_store_unittest;
@@ -156,54 +152,5 @@ async fn test_raft_state_write_read_state_machine_id() -> anyhow::Result<()> {
 
     let got = rs.read_state_machine_id()?;
     assert_eq!((1, 2), got);
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_raft_state_write_read_removed_snapshot() -> anyhow::Result<()> {
-    // - create a raft state
-    // - write state membership and the read it.
-    init_store_unittest();
-
-    let mut tc = new_sled_test_context();
-    let db = &tc.db;
-    tc.config.id = 3;
-    let rs = RaftState::open_create(db, &tc.config, None, Some(())).await?;
-
-    // read got a None
-
-    let default = SnapshotMeta {
-        last_log_id: LogId { term: 0, index: 0 },
-        membership: MembershipConfig {
-            members: hashset![tc.config.id],
-            members_after_consensus: None,
-        },
-        snapshot_id: "".to_string(),
-    };
-
-    let got = rs.read_snapshot_meta()?;
-    assert_eq!(default.last_log_id, got.last_log_id);
-    assert_eq!(default.membership, got.membership);
-    assert_eq!(default.snapshot_id, got.snapshot_id);
-
-    // write hard state
-
-    let snap_meta = SnapshotMeta {
-        last_log_id: LogId { term: 1, index: 2 },
-        membership: MembershipConfig {
-            members: hashset![1, 2, 3],
-            members_after_consensus: None,
-        },
-        snapshot_id: "".to_string(),
-    };
-
-    rs.write_snapshot_meta(&snap_meta).await?;
-
-    // read the written
-
-    let got = rs.read_snapshot_meta()?;
-    assert_eq!(snap_meta.last_log_id, got.last_log_id);
-    assert_eq!(snap_meta.membership, got.membership);
-    assert_eq!(snap_meta.snapshot_id, got.snapshot_id);
     Ok(())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: remove RaftState::write_snapshot_meta().
It is a bad idea to work around the problem that state machine does not
save membership config.
Solving the problem where it is introduced saves a lot troubles.
I should not have ever tried.
The better solution is: #1479

## Changelog




- Improvement


## Related Issues

- #271
- #1080