### PR TITLE
fix: variadic_arguments of LogicFunction should be Some((1, 2))

### DIFF
--- a/common/functions/src/scalars/logics/logic.rs
+++ b/common/functions/src/scalars/logics/logic.rs
@@ -50,6 +50,10 @@ impl Function for LogicFunction {
         "LogicFunction"
     }
 
+    fn variadic_arguments(&self) -> Option<(usize, usize)> {
+        Some((1, 2))
+    }
+
     fn return_type(&self, _args: &[DataType]) -> Result<DataType> {
         Ok(DataType::Boolean)
     }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

`variadic_arguments` of LogicFunction should be Some((1, 2)).

## Changelog

- Bug Fix:  `variadic_arguments` of LogicFunction should be Some((1, 2))

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

