### PR TITLE
use `#[from]` attribute of `thiserror::Error` proc macro

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -22,28 +22,16 @@ pub enum CliError {
     Unknown(String),
 
     #[error("IO error: {0}")]
-    Io(io::Error),
+    Io(#[from] io::Error),
 
     #[error("Script error: {0}")]
-    Script(run_script::ScriptError),
+    Script(#[from] run_script::ScriptError),
 
     #[error("Http error: {0}")]
     Http(Box<ureq::Error>),
 
     #[error("Serde error: {0}")]
     Serde(Box<serde_json::Error>),
-}
-
-impl From<io::Error> for CliError {
-    fn from(err: io::Error) -> CliError {
-        CliError::Io(err)
-    }
-}
-
-impl From<run_script::ScriptError> for CliError {
-    fn from(err: run_script::ScriptError) -> CliError {
-        CliError::Script(err)
-    }
 }
 
 impl From<ureq::Error> for CliError {


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

use `#[from]` attribute of `thiserror::Error` proc macro, and remove some boilerplate code

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

- None

## Test Plan

Unit Tests

Stateless Tests

