### PR TITLE
[store] feature: support snapshot replication.

### DIFF
--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -206,6 +206,9 @@ build_exceptions! {
     MetaStoreAlreadyExists(2402),
     MetaStoreNotFound(2403),
 
+    ConcurrentSnapshotInstall(2404),
+    IllegalSnapshot(2405),
+
     // DatafuseStore server error
 
     DatafuseStoreError(2501),

--- a/store/src/configs/config.rs
+++ b/store/src/configs/config.rs
@@ -211,7 +211,7 @@ impl Config {
     /// Create a unique sled::Tree name by prepending a unique prefix.
     /// So that multiple instance that depends on a sled::Tree can be used in one process.
     /// sled does not allow to open multiple `sled::Db` in one process.
-    pub fn tree_name(&self, name: &str) -> String {
+    pub fn tree_name(&self, name: impl std::fmt::Display) -> String {
         format!("{}{}", self.sled_tree_prefix, name)
     }
 }

--- a/store/src/meta_service/meta_store_test.rs
+++ b/store/src/meta_service/meta_store_test.rs
@@ -12,12 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use async_raft::raft::Entry;
+use async_raft::raft::EntryConfigChange;
+use async_raft::raft::EntryPayload;
+use async_raft::raft::MembershipConfig;
 use async_raft::storage::HardState;
+use async_raft::LogId;
 use async_raft::RaftStorage;
 use common_runtime::tokio;
 use common_tracing::tracing;
+use maplit::btreeset;
 
+use crate::meta_service::state_machine::SerializableSnapshot;
+use crate::meta_service::state_machine_meta::StateMachineMetaKey::LastMembership;
+use crate::meta_service::testing::pretty_snapshot;
+use crate::meta_service::testing::snapshot_logs;
+use crate::meta_service::LogIndex;
 use crate::meta_service::MetaStore;
+use crate::meta_service::StateMachineMetaValue;
 use crate::tests::service::init_store_unittest;
 use crate::tests::service::new_test_context;
 
@@ -69,3 +81,409 @@ async fn test_meta_store_restart() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_store_get_membership_from_log() -> anyhow::Result<()> {
+    // - Create a MetaStore
+    // - Append logs
+    // - Get membership from log.
+
+    init_store_unittest();
+
+    let id = 3;
+    let mut tc = new_test_context();
+    tc.config.id = id;
+
+    tracing::info!("--- new MetaStore");
+    let ms = MetaStore::open_create(&tc.config, None, Some(())).await?;
+
+    let c0 = MembershipConfig {
+        members: btreeset![4],
+        members_after_consensus: None,
+    };
+
+    let c1 = MembershipConfig {
+        members: btreeset![1, 2, 3],
+        members_after_consensus: None,
+    };
+
+    let c2 = MembershipConfig {
+        members: btreeset![1],
+        members_after_consensus: Some(btreeset![2, 3,]),
+    };
+
+    let logs = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 2 },
+            payload: EntryPayload::ConfigChange(EntryConfigChange {
+                membership: c1.clone(),
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 5 },
+            payload: EntryPayload::ConfigChange(EntryConfigChange {
+                membership: c2.clone(),
+            }),
+        },
+    ];
+
+    for l in logs.iter() {
+        ms.log.insert(l).await?;
+    }
+
+    // no snapshot meta:
+
+    let got = ms.get_membership_from_log(Some(2)).await?;
+    assert_eq!(&c1, &got);
+
+    let got = ms.get_membership_from_log(Some(1)).await?;
+    assert_eq!(
+        MembershipConfig {
+            members: btreeset![3],
+            members_after_consensus: None,
+        },
+        got,
+        "no membership found in log or state machine, returning a default value"
+    );
+
+    // with snapshot meta:
+    ms.state_machine
+        .write()
+        .await
+        .sm_meta()
+        .insert(
+            &LastMembership,
+            &StateMachineMetaValue::Membership(c0.clone()),
+        )
+        .await?;
+
+    let got = ms.get_membership_from_log(None).await?;
+    assert_eq!(&c2, &got);
+
+    let got = ms.get_membership_from_log(Some(5)).await?;
+    assert_eq!(&c2, &got);
+
+    let got = ms.get_membership_from_log(Some(4)).await?;
+    assert_eq!(&c1, &got);
+
+    let got = ms.get_membership_from_log(Some(2)).await?;
+    assert_eq!(&c1, &got);
+
+    let got = ms.get_membership_from_log(Some(1)).await?;
+    assert_eq!(
+        MembershipConfig {
+            members: btreeset![4],
+            members_after_consensus: None,
+        },
+        got,
+        "load from state machine"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_store_do_log_compaction_empty() -> anyhow::Result<()> {
+    // - Create a MetaStore
+    // - Create a snapshot check snapshot state
+
+    init_store_unittest();
+
+    let id = 3;
+    let mut tc = new_test_context();
+    tc.config.id = id;
+
+    let ms = MetaStore::open_create(&tc.config, None, Some(())).await?;
+
+    tracing::info!("--- snapshot without any data");
+
+    let curr_snap = ms.do_log_compaction().await?;
+    assert_eq!(LogId { term: 0, index: 0 }, curr_snap.meta.last_log_id);
+
+    assert_eq!(
+        MembershipConfig {
+            members: btreeset![],
+            members_after_consensus: None,
+        },
+        curr_snap.meta.membership
+    );
+
+    tracing::info!("--- check snapshot");
+    {
+        let data = curr_snap.snapshot.into_inner();
+
+        let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
+        let res = pretty_snapshot(&ser_snap.kvs);
+        tracing::debug!("res: {:?}", res);
+
+        let want = vec![
+            "[3, 2]:{\"Bool\":true}", // sm meta: init
+        ]
+        .iter()
+        .map(|x| x.to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(want, res);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_store_do_log_compaction_1_snap_ptr_1_log() -> anyhow::Result<()> {
+    // - Create a MetaStore
+    // - Apply logs
+    // - Create a snapshot check snapshot state
+
+    init_store_unittest();
+
+    let id = 3;
+    let mut tc = new_test_context();
+    tc.config.id = id;
+
+    let ms = MetaStore::open_create(&tc.config, None, Some(())).await?;
+
+    tracing::info!("--- feed logs and state machine");
+
+    let (logs, _want) = snapshot_logs();
+
+    for (i, l) in logs.iter().enumerate() {
+        ms.log.insert(l).await?;
+
+        if i < 2 {
+            ms.state_machine.write().await.apply(&l).await?;
+        }
+    }
+
+    let curr_snap = ms.do_log_compaction().await?;
+    assert_eq!(LogId { term: 1, index: 4 }, curr_snap.meta.last_log_id);
+    assert_eq!(
+        MembershipConfig {
+            members: btreeset![1, 2, 3],
+            members_after_consensus: None,
+        },
+        curr_snap.meta.membership
+    );
+
+    tracing::info!("--- check snapshot");
+    {
+        let data = curr_snap.snapshot.into_inner();
+
+        let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
+        let res = pretty_snapshot(&ser_snap.kvs);
+        tracing::debug!("res: {:?}", res);
+
+        let want = vec![
+            "[3, 1]:{\"LogId\":{\"term\":1,\"index\":4}}", // sm meta: LastApplied
+            "[3, 2]:{\"Bool\":true}",                      // sm meta: init
+            "[3, 3]:{\"Membership\":{\"members\":[1,2,3],\"members_after_consensus\":null}}", // membership
+            "[6, 97]:[1,{\"meta\":null,\"value\":[65]}]", // generic kv
+            "[7, 103, 101, 110, 101, 114, 105, 99, 95, 107, 118]:1", // sequence: by upsertkv
+        ]
+        .iter()
+        .map(|x| x.to_string())
+        .collect::<Vec<_>>();
+
+        assert_eq!(want, res);
+    }
+
+    tracing::info!("--- check logs");
+    {
+        let log_indexes = ms.log.range_keys(..)?;
+        assert_eq!(vec![5u64, 6, 8, 9], log_indexes);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_store_do_log_compaction_all_logs_with_memberchange() -> anyhow::Result<()> {
+    // - Create a MetaStore
+    // - Apply logs
+    // - Create a snapshot check snapshot state
+
+    init_store_unittest();
+
+    let id = 3;
+    let mut tc = new_test_context();
+    tc.config.id = id;
+
+    let ms = MetaStore::open_create(&tc.config, None, Some(())).await?;
+
+    tracing::info!("--- feed logs and state machine");
+
+    let (logs, want) = snapshot_logs();
+
+    for l in logs.iter() {
+        ms.log.insert(l).await?;
+        ms.state_machine.write().await.apply(&l).await?;
+    }
+
+    let curr_snap = ms.do_log_compaction().await?;
+    assert_eq!(LogId { term: 1, index: 9 }, curr_snap.meta.last_log_id);
+    assert_eq!(
+        MembershipConfig {
+            members: btreeset![4, 5, 6],
+            members_after_consensus: None,
+        },
+        curr_snap.meta.membership
+    );
+
+    tracing::info!("--- check snapshot");
+    {
+        let data = curr_snap.snapshot.into_inner();
+
+        let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
+        let res = pretty_snapshot(&ser_snap.kvs);
+        tracing::debug!("res: {:?}", res);
+
+        assert_eq!(want, res);
+    }
+
+    tracing::info!("--- check logs");
+    {
+        let log_indexes = ms.log.range_keys(..)?;
+        assert_eq!(Vec::<LogIndex>::new(), log_indexes);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_store_do_log_compaction_current_snapshot() -> anyhow::Result<()> {
+    // - Create a MetaStore
+    // - Apply logs
+    // - Create a snapshot check snapshot state
+
+    init_store_unittest();
+
+    let id = 3;
+    let mut tc = new_test_context();
+    tc.config.id = id;
+
+    let ms = MetaStore::open_create(&tc.config, None, Some(())).await?;
+
+    tracing::info!("--- feed logs and state machine");
+
+    let (logs, want) = snapshot_logs();
+
+    for l in logs.iter() {
+        ms.log.insert(l).await?;
+        ms.state_machine.write().await.apply(l).await?;
+    }
+
+    ms.do_log_compaction().await?;
+
+    tracing::info!("--- check get_current_snapshot");
+
+    let curr_snap = ms.get_current_snapshot().await?.unwrap();
+    assert_eq!(LogId { term: 1, index: 9 }, curr_snap.meta.last_log_id);
+    assert_eq!(
+        MembershipConfig {
+            members: btreeset![4, 5, 6],
+            members_after_consensus: None,
+        },
+        curr_snap.meta.membership
+    );
+
+    tracing::info!("--- check snapshot");
+    {
+        let data = curr_snap.snapshot.into_inner();
+
+        let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
+        let res = pretty_snapshot(&ser_snap.kvs);
+        tracing::debug!("res: {:?}", res);
+
+        assert_eq!(want, res);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
+    // - Create a MetaStore
+    // - Feed logs
+    // - Create a snapshot
+    // - Create a new MetaStore and restore it by install the snapshot
+
+    init_store_unittest();
+
+    let (logs, want) = snapshot_logs();
+
+    let id = 3;
+    let snap;
+    {
+        let mut tc = new_test_context();
+        tc.config.id = id;
+
+        let ms = MetaStore::open_create(&tc.config, None, Some(())).await?;
+
+        tracing::info!("--- feed logs and state machine");
+
+        for l in logs.iter() {
+            ms.log.insert(l).await?;
+            ms.state_machine.write().await.apply(l).await?;
+        }
+        snap = ms.do_log_compaction().await?;
+    }
+
+    let data = snap.snapshot.into_inner();
+
+    tracing::info!("--- reopen a new MetaStore to install snapshot");
+    {
+        let mut tc = new_test_context();
+        tc.config.id = id;
+
+        let ms = MetaStore::open_create(&tc.config, None, Some(())).await?;
+
+        tracing::info!("--- rejected because old sm is not cleaned");
+        {
+            ms.raft_state.write_state_machine_id(&(1, 2)).await?;
+            let res = ms.install_snapshot(&data).await;
+            assert!(res.is_err(), "different ids disallow installing snapshot");
+            assert!(res.unwrap_err().to_string().starts_with(
+                "Code: 2404, displayText = another snapshot install is not finished yet: 1 2"
+            ));
+        }
+
+        tracing::info!("--- install snapshot");
+        {
+            ms.raft_state.write_state_machine_id(&(0, 0)).await?;
+            ms.install_snapshot(&data).await?;
+        }
+
+        tracing::info!("--- check installed meta");
+        {
+            assert_eq!((1, 1), ms.raft_state.read_state_machine_id()?);
+
+            let mem = ms.state_machine.write().await.get_membership()?;
+            assert_eq!(
+                Some(MembershipConfig {
+                    members: btreeset![4, 5, 6],
+                    members_after_consensus: None,
+                }),
+                mem
+            );
+
+            let last_applied = ms.state_machine.write().await.get_last_applied()?;
+            assert_eq!(LogId { term: 1, index: 9 }, last_applied);
+        }
+
+        tracing::info!("--- check snapshot");
+        {
+            let curr_snap = ms.do_log_compaction().await?;
+            let data = curr_snap.snapshot.into_inner();
+
+            let ser_snap: SerializableSnapshot = serde_json::from_slice(&data)?;
+            let res = pretty_snapshot(&ser_snap.kvs);
+            tracing::debug!("res: {:?}", res);
+
+            assert_eq!(want, res);
+        }
+    }
+
+    Ok(())
+}
+
+// TODO(xp): test finalize_snapshot_installation

--- a/store/src/meta_service/mod.rs
+++ b/store/src/meta_service/mod.rs
@@ -90,3 +90,5 @@ mod sled_serde_test;
 mod sled_tree_test;
 #[cfg(test)]
 mod state_machine_test;
+#[cfg(test)]
+mod testing;

--- a/store/src/meta_service/raft_log.rs
+++ b/store/src/meta_service/raft_log.rs
@@ -87,6 +87,19 @@ impl RaftLog {
         self.logs().range_remove(range, true).await
     }
 
+    /// Returns an iterator of logs
+    pub fn range<R>(
+        &self,
+        range: R,
+    ) -> common_exception::Result<
+        impl DoubleEndedIterator<Item = common_exception::Result<(LogIndex, Entry<LogEntry>)>>,
+    >
+    where
+        R: RangeBounds<LogIndex>,
+    {
+        self.logs().range(range)
+    }
+
     pub fn range_keys<R>(&self, range: R) -> common_exception::Result<Vec<LogIndex>>
     where R: RangeBounds<LogIndex> {
         self.logs().range_keys(range)

--- a/store/src/meta_service/raft_state.rs
+++ b/store/src/meta_service/raft_state.rs
@@ -134,6 +134,7 @@ impl RaftState {
         Ok(hs)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn write_state_machine_id(&self, id: &(u64, u64)) -> common_exception::Result<()> {
         let state = self.state();
         state
@@ -144,6 +145,8 @@ impl RaftState {
             .await?;
         Ok(())
     }
+
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn read_state_machine_id(&self) -> common_exception::Result<(u64, u64)> {
         let state = self.state();
         let smid = state.get(&RaftStateKey::StateMachineId)?;

--- a/store/src/meta_service/raftmeta.rs
+++ b/store/src/meta_service/raftmeta.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::io::Cursor;
+use std::ops::Bound;
 use std::sync::Arc;
 
 use async_raft::async_trait::async_trait;
@@ -27,7 +28,6 @@ use async_raft::storage::CurrentSnapshotData;
 use async_raft::storage::HardState;
 use async_raft::storage::InitialState;
 use async_raft::ClientWriteError;
-use async_raft::LogId;
 use async_raft::NodeId;
 use async_raft::Raft;
 use async_raft::RaftMetrics;
@@ -54,7 +54,7 @@ use crate::configs;
 use crate::meta_service::raft_db::get_sled_db;
 use crate::meta_service::raft_log::RaftLog;
 use crate::meta_service::raft_state::RaftState;
-use crate::meta_service::sled_serde::SledOrderedSerde;
+use crate::meta_service::state_machine::SerializableSnapshot;
 use crate::meta_service::AppliedState;
 use crate::meta_service::Cmd;
 use crate::meta_service::LogEntry;
@@ -65,10 +65,8 @@ use crate::meta_service::Network;
 use crate::meta_service::Node;
 use crate::meta_service::RetryableError;
 use crate::meta_service::ShutdownError;
-use crate::meta_service::SledSerde;
 use crate::meta_service::Snapshot;
 use crate::meta_service::StateMachine;
-use crate::meta_service::StateMachineMetaKey::LastApplied;
 
 /// An storage system implementing the `async_raft::RaftStorage` trait.
 ///
@@ -84,6 +82,8 @@ pub struct MetaStore {
     /// The ID of the Raft node for which this storage instances is configured.
     /// ID is also stored in raft_state. Since `id` never changes, this is a cache for fast access.
     pub id: NodeId,
+
+    config: configs::Config,
 
     /// If the instance is opened from an existent state(e.g. load from disk) or created.
     is_open: bool,
@@ -110,8 +110,6 @@ pub struct MetaStore {
     /// - Acquire a read lock to WRITE or READ. Transactional RW relies on sled concurrency control.
     /// - Acquire a write lock before installing a snapshot, to prevent any write to the db.
     pub state_machine: RwLock<StateMachine>,
-
-    pub snapshot_index: Arc<Mutex<u64>>,
 
     /// The current snapshot.
     pub current_snapshot: RwLock<Option<Snapshot>>,
@@ -167,17 +165,25 @@ impl MetaStore {
         let log = RaftLog::open(&db, config).await?;
         tracing::info!("RaftLog opened");
 
-        let sm = RwLock::new(StateMachine::open(config).await?);
+        let (sm_id, prev_sm_id) = raft_state.read_state_machine_id()?;
+
+        // There is a garbage state machine need to be cleaned.
+        if sm_id != prev_sm_id {
+            StateMachine::clean(config, prev_sm_id)?;
+            raft_state.write_state_machine_id(&(sm_id, sm_id)).await?;
+        }
+
+        let sm = RwLock::new(StateMachine::open(config, sm_id).await?);
         let current_snapshot = RwLock::new(None);
 
         Ok(Self {
             id: raft_state.id,
+            config: config.clone(),
             is_open,
             _db: db,
             raft_state,
             log,
             state_machine: sm,
-            snapshot_index: Arc::new(Mutex::new(0)),
             current_snapshot,
         })
     }
@@ -190,32 +196,91 @@ impl MetaStore {
     pub async fn read_hard_state(&self) -> common_exception::Result<Option<HardState>> {
         self.raft_state.read_hard_state()
     }
-}
 
-impl MetaStore {
+    /// Install a snapshot to build a state machine from it and replace the old state machine with the new one.
+    #[tracing::instrument(level = "debug", skip(self, data))]
+    pub async fn install_snapshot(&self, data: &[u8]) -> common_exception::Result<()> {
+        let mut sm = self.state_machine.write().await;
+
+        let (sm_id, prev_sm_id) = self.raft_state.read_state_machine_id()?;
+        if sm_id != prev_sm_id {
+            return Err(ErrorCode::ConcurrentSnapshotInstall(format!(
+                "another snapshot install is not finished yet: {} {}",
+                sm_id, prev_sm_id
+            )));
+        }
+
+        let new_sm_id = sm_id + 1;
+
+        let snap: SerializableSnapshot = serde_json::from_slice(data)?;
+
+        // If not finished, clean up the new tree.
+        self.raft_state
+            .write_state_machine_id(&(sm_id, new_sm_id))
+            .await?;
+
+        let new_sm = StateMachine::open(&self.config, new_sm_id).await?;
+        let tree = &new_sm.sm_tree.tree;
+        for x in snap.kvs.into_iter() {
+            let k = &x[0];
+            let v = &x[1];
+            tree.insert(k, v.clone())
+                .map_err_to_code(ErrorCode::MetaStoreDamaged, || "fail to insert snapshot")?;
+        }
+
+        tree.flush_async()
+            .await
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "fail to flush snapshot")?;
+
+        // Start to use the new tree, the old can be cleaned.
+        self.raft_state
+            .write_state_machine_id(&(new_sm_id, sm_id))
+            .await?;
+
+        tracing::info!(
+            "installed state machine from snapshot, last_applied: {}",
+            new_sm.get_last_applied()?,
+        );
+
+        StateMachine::clean(&self.config, sm_id)?;
+
+        self.raft_state
+            .write_state_machine_id(&(new_sm_id, new_sm_id))
+            .await?;
+
+        // TODO(xp): use checksum to check consistency?
+
+        *sm = new_sm;
+        Ok(())
+    }
+
     /// Go backwards through the log to find the most recent membership config <= `upto_index`.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn get_membership_from_log(
         &self,
         upto_index: Option<u64>,
     ) -> anyhow::Result<MembershipConfig> {
-        //TODO(xp): test it
-        let it = match upto_index {
-            Some(upto) => self.log.inner.tree.range(0.ser()?..=upto.ser()?).rev(),
-            None => self.log.inner.tree.range(0.ser()?..).rev(),
+        let right_bound = match upto_index {
+            Some(upto) => Bound::Included(upto),
+            None => Bound::Unbounded,
         };
 
-        for ivec in it {
-            let (_k_ivec, v_ivec) = ivec?;
-            let ent = Entry::<LogEntry>::de(v_ivec)?;
-            match &ent.payload {
-                EntryPayload::ConfigChange(cfg) => return Ok(cfg.membership.clone()),
-                EntryPayload::SnapshotPointer(snap) => return Ok(snap.membership.clone()),
-                _ => {}
-            };
+        let it = self.log.range((Bound::Included(0), right_bound))?.rev();
+
+        for rkv in it {
+            let (_log_index, ent) = rkv?;
+            if let EntryPayload::ConfigChange(cfg) = &ent.payload {
+                return Ok(cfg.membership.clone());
+            }
         }
 
-        Ok(MembershipConfig::new_initial(self.id))
+        // There is no membership config in logs.
+        // Try to read it from state machine.
+        let mem = self.state_machine.read().await.get_membership()?;
+
+        let mem = mem.unwrap_or_else(|| MembershipConfig::new_initial(self.id));
+
+        Ok(mem)
     }
 }
 
@@ -224,7 +289,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
     type Snapshot = Cursor<Vec<u8>>;
     type ShutdownError = ShutdownError;
 
-    #[tracing::instrument(level = "info", skip(self), fields(id=self.id))]
+    #[tracing::instrument(level = "debug", skip(self), fields(id=self.id))]
     async fn get_membership_config(&self) -> anyhow::Result<MembershipConfig> {
         self.get_membership_from_log(None).await
     }
@@ -244,12 +309,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
                     None => (0, 0).into(),
                 };
 
-                let sm_meta = sm.sm_meta();
-
-                let last_applied_log = sm_meta
-                    .get(&LastApplied)?
-                    .map(LogId::from)
-                    .unwrap_or_default();
+                let last_applied_log = sm.get_last_applied()?;
 
                 let st = InitialState {
                     last_log_id,
@@ -339,65 +399,44 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
         // NOTE: do_log_compaction is guaranteed to be serialized called by RaftCore.
 
         // TODO(xp): add test of small chunk snapshot transfer and installation
-        // TODO(xp): Building a snapshot does not need a lock
-        let (data, last_applied_log) = {
-            // Serialize the data of the state machine.
-            let sm = self.state_machine.write().await;
 
-            let sm_meta = sm.sm_meta();
+        // TODO(xp): disallow to install a snapshot with smaller last_applied_log
 
-            let last_applied = sm_meta
-                .get(&LastApplied)?
-                .map(LogId::from)
-                .unwrap_or_default();
+        // 1. Take a serialized snapshot
 
-            let view = sm.snapshot();
-            let data = StateMachine::serialize_snapshot(view)?;
-            (data, last_applied)
-        };
+        let (view, last_applied_log, last_membership, snapshot_id) =
+            self.state_machine.write().await.snapshot()?;
 
+        let data = StateMachine::serialize_snapshot(view)?;
         let snapshot_size = data.len();
 
-        let membership_config = self
-            .get_membership_from_log(Some(last_applied_log.index))
-            .await?;
-
-        let snapshot_idx = {
-            let mut l = self.snapshot_index.lock().await;
-            *l += 1;
-            *l
+        let snap_meta = SnapshotMeta {
+            last_log_id: last_applied_log,
+            snapshot_id,
+            membership: last_membership.clone(),
         };
 
-        let meta;
+        let snapshot = Snapshot {
+            meta: snap_meta.clone(),
+            data: data.clone(),
+        };
+
+        // 2. Remove logs that are included in snapshot.
+
+        self.log.range_remove(0..=last_applied_log.index).await?;
+
+        tracing::debug!("log range_remove complete");
+
+        // Update the snapshot first.
         {
             let mut current_snapshot = self.current_snapshot.write().await;
-            self.log.range_remove(0..last_applied_log.index).await?;
-
-            let snapshot_id = format!(
-                "{}-{}-{}",
-                last_applied_log.term, last_applied_log.index, snapshot_idx
-            );
-
-            meta = SnapshotMeta {
-                last_log_id: last_applied_log,
-                snapshot_id,
-                membership: membership_config.clone(),
-            };
-
-            let snapshot = Snapshot {
-                meta: meta.clone(),
-                data: data.clone(),
-            };
-            self.log
-                .insert(&Entry::new_snapshot_pointer(&snapshot.meta))
-                .await?;
-
             *current_snapshot = Some(snapshot);
-        } // Release log & snapshot write locks.
+        }
 
-        tracing::trace!({ snapshot_size = snapshot_size }, "log compaction complete");
+        tracing::debug!(snapshot_size = snapshot_size, "log compaction complete");
+
         Ok(CurrentSnapshotData {
-            meta,
+            meta: snap_meta,
             snapshot: Box::new(Cursor::new(data)),
         })
     }
@@ -413,6 +452,8 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
         meta: &SnapshotMeta,
         snapshot: Box<Self::Snapshot>,
     ) -> anyhow::Result<()> {
+        // TODO(xp): disallow installing a snapshot with smaller last_applied.
+
         tracing::trace!(
             { snapshot_size = snapshot.get_ref().len() },
             "decoding snapshot for installation"
@@ -425,28 +466,18 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
 
         tracing::debug!("SNAP META:{:?}", meta);
 
-        // Update the state machine.
-        {
-            let mut sm = self.state_machine.write().await;
-            sm.install_snapshot(&new_snapshot.data).await?;
-        }
+        // Replace state machine with the new one
+        self.install_snapshot(&new_snapshot.data).await?;
 
-        // Update log.
-        {
-            // Replace the last log in state machine with a pointer log
-            // TODO(xp): This is not necessary if we stores the committed membership.
-            self.log
-                .append(&[Entry::new_snapshot_pointer(meta)])
-                .await?;
-
-            // Remove logs that are included in the snapshot,
-            // except the last one that is replaced with a snapshot pointer.
-            self.log.range_remove(0..meta.last_log_id.index).await?;
-        }
+        // NOTE: a replication may has been using these logs.
+        //       It requires the replication to detect a missing log and restart a snapshot replication.
+        self.log.range_remove(0..=meta.last_log_id.index).await?;
 
         // Update current snapshot.
-        let mut current_snapshot = self.current_snapshot.write().await;
-        *current_snapshot = Some(new_snapshot);
+        {
+            let mut current_snapshot = self.current_snapshot.write().await;
+            *current_snapshot = Some(new_snapshot);
+        }
         Ok(())
     }
 
@@ -454,7 +485,8 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
     async fn get_current_snapshot(
         &self,
     ) -> anyhow::Result<Option<CurrentSnapshotData<Self::Snapshot>>> {
-        match &*self.current_snapshot.read().await {
+        tracing::info!("got snapshot start");
+        let snap = match &*self.current_snapshot.read().await {
             Some(snapshot) => {
                 let data = snapshot.data.clone();
                 Ok(Some(CurrentSnapshotData {
@@ -463,7 +495,11 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
                 }))
             }
             None => Ok(None),
-        }
+        };
+
+        tracing::info!("got snapshot complete");
+
+        snap
     }
 }
 
@@ -500,16 +536,19 @@ impl MetaStore {
 
     /// A non-voter is a node stored in raft store, but is not configured as a voter in the raft group.
     pub async fn list_non_voters(&self) -> HashSet<NodeId> {
+        // TODO(xp): consistency
         let mut rst = HashSet::new();
-        let sm = self.state_machine.read().await;
         let ms = self
             .get_membership_config()
             .await
             .expect("fail to get membership");
 
-        let sm_nodes = sm.nodes();
-        let x = sm_nodes.range_keys(..).expect("fail to list nodes");
-        for node_id in x {
+        let node_ids = {
+            let sm = self.state_machine.read().await;
+            let sm_nodes = sm.nodes();
+            sm_nodes.range_keys(..).expect("fail to list nodes")
+        };
+        for node_id in node_ids {
             // it has been added into this cluster and is not a voter.
             if !ms.contains(&node_id) {
                 rst.insert(node_id);

--- a/store/src/meta_service/state_machine.rs
+++ b/store/src/meta_service/state_machine.rs
@@ -17,12 +17,13 @@ use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Display;
 use std::fmt::Formatter;
-use std::fs::remove_dir_all;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use async_raft::raft::Entry;
 use async_raft::raft::EntryPayload;
+use async_raft::raft::MembershipConfig;
+use async_raft::LogId;
 use common_exception::prelude::ErrorCode;
 use common_exception::ToErrorCode;
 use common_flights::storage_api_impl::AppendResult;
@@ -37,6 +38,7 @@ use common_planners::Statistics;
 use common_tracing::tracing;
 use serde::Deserialize;
 use serde::Serialize;
+use sled::IVec;
 
 use crate::configs;
 use crate::meta_service::placement::rand_n_from_m;
@@ -52,6 +54,7 @@ use crate::meta_service::NodeId;
 use crate::meta_service::Placement;
 use crate::meta_service::SledSerde;
 use crate::meta_service::SledTree;
+use crate::meta_service::StateMachineMetaKey;
 use crate::meta_service::StateMachineMetaKey::Initialized;
 use crate::meta_service::StateMachineMetaKey::LastApplied;
 use crate::meta_service::StateMachineMetaValue;
@@ -162,13 +165,13 @@ impl StateMachineInitializer {
 }
 
 /// A key-value pair in a snapshot is a vec of two `Vec<u8>`.
-type SnapshotKeyValue = Vec<Vec<u8>>;
+pub type SnapshotKeyValue = Vec<Vec<u8>>;
 
 /// Snapshot data for serialization and for transport.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
-struct SerializableSnapshot {
+pub struct SerializableSnapshot {
     /// A list of kv pairs.
-    kvs: Vec<SnapshotKeyValue>,
+    pub kvs: Vec<SnapshotKeyValue>,
 }
 
 impl SerializableSnapshot {
@@ -189,15 +192,32 @@ impl StateMachine {
         }
     }
 
-    /// Returns the temp dir for sled:Db for rebuilding state machine from snapshot.
-    fn tmp_state_machine_dir(config: &configs::Config) -> String {
-        config.meta_dir.clone() + "/sm-tmp"
+    #[tracing::instrument(level = "debug")]
+    pub fn tree_name(config: &configs::Config, sm_id: u64) -> String {
+        config.tree_name(format!("{}/{}", TREE_STATE_MACHINE, sm_id))
     }
 
-    pub async fn open(config: &configs::Config) -> common_exception::Result<StateMachine> {
+    #[tracing::instrument(level = "debug")]
+    pub fn clean(config: &configs::Config, sm_id: u64) -> common_exception::Result<()> {
+        let tree_name = StateMachine::tree_name(config, sm_id);
+
         let db = get_sled_db();
 
-        let tree_name = config.tree_name(TREE_STATE_MACHINE);
+        // it blocks and slow
+        db.drop_tree(tree_name)
+            .map_err_to_code(ErrorCode::MetaStoreDamaged, || "drop prev state machine")?;
+
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug")]
+    pub async fn open(
+        config: &configs::Config,
+        sm_id: u64,
+    ) -> common_exception::Result<StateMachine> {
+        let db = get_sled_db();
+
+        let tree_name = StateMachine::tree_name(config, sm_id);
 
         let sm_tree = SledTree::open(&db, &tree_name, config.meta_sync()).await?;
 
@@ -236,77 +256,52 @@ impl StateMachine {
     }
 
     /// Create a snapshot.
-    /// TODO(xp): we only need iter one sled::Tree to take a snapshot.
-    pub fn snapshot(&self) -> impl Iterator<Item = Vec<Vec<u8>>> {
-        let its = self._db.export();
-        for (typ, name, it) in its {
-            if typ == b"tree" && name == TREE_STATE_MACHINE.as_bytes() {
-                return it;
-            }
-        }
-        panic!("no tree found: {}", TREE_STATE_MACHINE)
+    /// Returns:
+    /// - an consistent iterator of all kvs;
+    /// - the last applied log id
+    /// - the last applied membership config
+    /// - and a snapshot id
+    pub fn snapshot(
+        &self,
+    ) -> common_exception::Result<(
+        impl Iterator<Item = sled::Result<(IVec, IVec)>>,
+        LogId,
+        MembershipConfig,
+        String,
+    )> {
+        let last_applied = self.get_last_applied()?;
+        let mem = self.get_membership()?;
+
+        // NOTE: An initialize node/cluster always has the first log contains membership config.
+        let mem = mem.unwrap_or_default();
+
+        let snapshot_idx = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        let snapshot_id = format!(
+            "{}-{}-{}",
+            last_applied.term, last_applied.index, snapshot_idx
+        );
+
+        Ok((self.sm_tree.tree.iter(), last_applied, mem, snapshot_id))
     }
 
     /// Serialize a snapshot for transport.
-    /// TODO(xp): This step does not require a lock, since sled::Tree::iter() creates a consistent view on a tree
-    ///           no matter if there are other writes applied to the tree.
+    /// This step does not require a lock, since sled::Tree::iter() creates a consistent view on a tree
+    /// no matter if there are other writes applied to the tree.
     pub fn serialize_snapshot(
-        view: impl Iterator<Item = Vec<Vec<u8>>>,
+        view: impl Iterator<Item = sled::Result<(IVec, IVec)>>,
     ) -> common_exception::Result<Vec<u8>> {
         let mut kvs = Vec::new();
-        for kv in view {
-            kvs.push(kv);
+        for rkv in view {
+            let (k, v) = rkv.map_err_to_code(ErrorCode::MetaStoreDamaged, || "taking snapshot")?;
+            kvs.push(vec![k.to_vec(), v.to_vec()]);
         }
-
         let snap = SerializableSnapshot { kvs };
-
         let snap = serde_json::to_vec(&snap)?;
         Ok(snap)
-    }
-
-    /// Install a snapshot to build a state machine from it and replace the state machine with the new one.
-    pub async fn install_snapshot(&mut self, data: &[u8]) -> common_exception::Result<()> {
-        // TODO(xp): test install snapshot:
-        //           The rename is not atomic: a correct way should be: create a temp tree, swap state machine.
-
-        let snap: SerializableSnapshot = serde_json::from_slice(data)?;
-
-        let tmp_path = StateMachine::tmp_state_machine_dir(&self.config);
-
-        remove_dir_all(&tmp_path).map_err_to_code(ErrorCode::MetaStoreDamaged, || {
-            format!("remove tmp state machine dir: {}", tmp_path)
-        })?;
-
-        let db = get_sled_db();
-        // TODO(xp): with a shared db import is now allowed. It populate the entire db.
-        db.import(snap.sled_importable());
-
-        // sled::Db does not have a "flush" method, need to flush every tree one by one.
-        for name in db.tree_names() {
-            let n = String::from_utf8(name.to_vec())
-                .map_err_to_code(ErrorCode::MetaStoreDamaged, || "invalid tree name")?;
-            let t = db
-                .open_tree(&name)
-                .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
-                    format!("open sled tree: {}", n)
-                })?;
-            t.flush_async()
-                .await
-                .map_err_to_code(ErrorCode::MetaStoreDamaged, || {
-                    format!("flush sled tree: {}", n)
-                })?;
-        }
-
-        // close it, move its data dir, re-open it.
-        drop(db);
-
-        // TODO(xp): use checksum to check consistency?
-        // TODO(xp): use a pointer to state machine dir to atomically switch to the new sm dir.
-        // TODO(xp): reopen and replace
-
-        let new_sm = StateMachine::open(&self.config).await?;
-        *self = new_sm;
-        Ok(())
     }
 
     /// Internal func to get an auto-incr seq number.
@@ -589,6 +584,25 @@ impl StateMachine {
                 }
             }
         }
+    }
+
+    pub fn get_membership(&self) -> common_exception::Result<Option<MembershipConfig>> {
+        let sm_meta = self.sm_meta();
+        let mem = sm_meta
+            .get(&StateMachineMetaKey::LastMembership)?
+            .map(MembershipConfig::from);
+
+        Ok(mem)
+    }
+
+    pub fn get_last_applied(&self) -> common_exception::Result<LogId> {
+        let sm_meta = self.sm_meta();
+        let last_applied = sm_meta
+            .get(&LastApplied)?
+            .map(LogId::from)
+            .unwrap_or_default();
+
+        Ok(last_applied)
     }
 
     /// Initialize slots by assign nodes to everyone of them randomly, according to replicationn config.

--- a/store/src/meta_service/testing.rs
+++ b/store/src/meta_service/testing.rs
@@ -1,0 +1,137 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_raft::raft::Entry;
+use async_raft::raft::EntryConfigChange;
+use async_raft::raft::EntryNormal;
+use async_raft::raft::EntryPayload;
+use async_raft::raft::MembershipConfig;
+use async_raft::LogId;
+use common_metatypes::MatchSeq;
+use maplit::btreeset;
+use sled::IVec;
+
+use crate::meta_service::state_machine::SnapshotKeyValue;
+use crate::meta_service::Cmd;
+use crate::meta_service::LogEntry;
+
+/// Logs and the expected snapshot for testing snapshot.
+pub fn snapshot_logs() -> (Vec<Entry<LogEntry>>, Vec<String>) {
+    let logs = vec![
+        Entry {
+            log_id: LogId { term: 1, index: 1 },
+            payload: EntryPayload::ConfigChange(EntryConfigChange {
+                membership: MembershipConfig {
+                    members: btreeset![1, 2, 3],
+                    members_after_consensus: None,
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 4 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::UpsertKV {
+                        key: "a".to_string(),
+                        seq: MatchSeq::Any,
+                        value: Some(b"A".to_vec()),
+                        value_meta: None,
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 5 },
+            payload: EntryPayload::ConfigChange(EntryConfigChange {
+                membership: MembershipConfig {
+                    members: btreeset![4, 5, 6],
+                    members_after_consensus: None,
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 6 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::SetFile {
+                        key: "b".to_string(),
+                        value: "B".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 8 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::IncrSeq {
+                        key: "c".to_string(),
+                    },
+                },
+            }),
+        },
+        Entry {
+            log_id: LogId { term: 1, index: 9 },
+            payload: EntryPayload::Normal(EntryNormal {
+                data: LogEntry {
+                    txid: None,
+                    cmd: Cmd::AddNode {
+                        node_id: 5,
+                        node: Default::default(),
+                    },
+                },
+            }),
+        },
+    ];
+    let want = vec![
+        "[2, 0, 0, 0, 0, 0, 0, 0, 5]:{\"name\":\"\",\"address\":\"\"}", // Nodes
+        "[3, 1]:{\"LogId\":{\"term\":1,\"index\":9}}",                  // sm meta: LastApplied
+        "[3, 2]:{\"Bool\":true}",                                       // sm meta: init
+        "[3, 3]:{\"Membership\":{\"members\":[4,5,6],\"members_after_consensus\":null}}", // membership
+        "[5, 98]:B",                                                                      // Files
+        "[6, 97]:[1,{\"meta\":null,\"value\":[65]}]", // generic kv
+        "[7, 99]:1",                                  // sequence: c
+        "[7, 103, 101, 110, 101, 114, 105, 99, 95, 107, 118]:1", // sequence: by upsertkv
+    ]
+    .iter()
+    .map(|x| x.to_string())
+    .collect::<Vec<_>>();
+
+    (logs, want)
+}
+
+pub fn pretty_snapshot(snap: &Vec<SnapshotKeyValue>) -> Vec<String> {
+    let mut res = vec![];
+    for kv in snap.iter() {
+        let k = kv[0].clone();
+        let v = kv[1].clone();
+        let line = format!("{:?}:{}", k, String::from_utf8(v.to_vec()).unwrap());
+        res.push(line);
+    }
+    res
+}
+
+pub fn pretty_snapshot_iter(snap: impl Iterator<Item = sled::Result<(IVec, IVec)>>) -> Vec<String> {
+    let mut res = vec![];
+    for kv in snap {
+        let (k, v) = kv.unwrap();
+        let line = format!("{:?}:{}", k, String::from_utf8(v.to_vec()).unwrap());
+        res.push(line);
+    }
+
+    res
+}


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: support snapshot replication.
-   Feature: create snapshot from a consistent view of the state machine.
    Everything that is needed in a snapshot now is in a single
    sled::Tree. `sled::Tree::iter()` returns a consistent snapshot view
    of the tree,  which is used to build a snapshot for transfer.

-   Feature: when installing a snapshot, a new sled::Tree is created.
    When all key-values are fed into it, a pointer sled::Tree record
    `StateMachineId` is udpate to point to the new state machine.
    This way a state machine is replaced atomically.

    These actions are not done in a transaction. The old state machine
    may be left a garbage, which will be cleaned up next time server
    starts.

## Changelog

- New Feature





## Related Issues

- #271
- #1080