### PR TITLE
parser: Fold table references in FROM clause

### DIFF
--- a/query/src/sql/parser/ast/ast_display_test.rs
+++ b/query/src/sql/parser/ast/ast_display_test.rs
@@ -82,39 +82,24 @@ mod test {
                 ]),
                 SelectTarget::Indirections(vec![Indirection::Star]),
             ],
-            from: vec![
-                TableReference::Table {
+            from: TableReference::Join(Join {
+                op: JoinOperator::Inner,
+                condition: JoinCondition::Natural,
+                left: Box::new(TableReference::Table {
                     name: vec![Identifier {
-                        name: "table".to_owned(),
+                        name: "left_table".to_owned(),
                         quote: None,
                     }],
-                    alias: Some(TableAlias {
-                        name: Identifier {
-                            name: "table1".to_owned(),
-                            quote: None,
-                        },
-                        columns: vec![],
-                    }),
-                },
-                TableReference::Join(Join {
-                    op: JoinOperator::Inner,
-                    condition: JoinCondition::Natural,
-                    left: Box::new(TableReference::Table {
-                        name: vec![Identifier {
-                            name: "left_table".to_owned(),
-                            quote: None,
-                        }],
-                        alias: None,
-                    }),
-                    right: Box::new(TableReference::Table {
-                        name: vec![Identifier {
-                            name: "right_table".to_owned(),
-                            quote: None,
-                        }],
-                        alias: None,
-                    }),
+                    alias: None,
                 }),
-            ],
+                right: Box::new(TableReference::Table {
+                    name: vec![Identifier {
+                        name: "right_table".to_owned(),
+                        quote: None,
+                    }],
+                    alias: None,
+                }),
+            }),
             selection: Some(Expr::BinaryOp {
                 op: BinaryOperator::Eq,
                 left: Box::new(Expr::ColumnRef(vec![Identifier {
@@ -145,8 +130,26 @@ mod test {
 
         assert_eq!(
             format!("{}", stmt),
-            r#"SELECT DISTINCT table.column, * FROM table AS table1, left_table NATURAL INNER JOIN right_table WHERE a = b GROUP BY a HAVING a <> b"#
+            r#"SELECT DISTINCT table.column, * FROM left_table NATURAL INNER JOIN right_table WHERE a = b GROUP BY a HAVING a <> b"#
         );
+    }
+
+    #[test]
+    fn test_display_table_reference() {
+        let table_ref = TableReference::Table {
+            name: vec![Identifier {
+                name: "table".to_owned(),
+                quote: None,
+            }],
+            alias: Some(TableAlias {
+                name: Identifier {
+                    name: "table1".to_owned(),
+                    quote: None,
+                },
+                columns: vec![],
+            }),
+        };
+        assert_eq!(format!("{}", table_ref), "table AS table1");
     }
 
     #[test]

--- a/query/src/sql/parser/ast/query.rs
+++ b/query/src/sql/parser/ast/query.rs
@@ -62,7 +62,7 @@ pub struct SelectStmt {
     // `FROM` clause, a list of table references.
     // The table references split by `,` will be joined with cross join,
     // and the result set is union of the joined tables by default.
-    pub from: Vec<TableReference>,
+    pub from: TableReference,
     // `WHERE` clause
     pub selection: Option<Expr>,
     // `GROUP BY` clause
@@ -307,13 +307,7 @@ impl Display for SelectStmt {
         }
 
         // FROM clause
-        write!(f, " FROM ")?;
-        for i in 0..self.from.len() {
-            write!(f, "{}", self.from[i])?;
-            if i != self.from.len() - 1 {
-                write!(f, ", ")?;
-            }
-        }
+        write!(f, " FROM {}", self.from)?;
 
         // WHERE clause
         if let Some(expr) = &self.selection {

--- a/query/src/sql/parser/transformer/transform_sqlparser.rs
+++ b/query/src/sql/parser/transformer/transform_sqlparser.rs
@@ -200,11 +200,24 @@ impl TransformerSqlparser {
         })
     }
 
-    fn transform_from(&self, orig_ast: &[TableWithJoins]) -> Result<Vec<TableReference>> {
-        orig_ast
+    fn transform_from(&self, orig_ast: &[TableWithJoins]) -> Result<TableReference> {
+        let mut table_refs: Vec<TableReference> = orig_ast
             .iter()
             .map(|v| self.transform_table_with_joins(v))
-            .collect()
+            .collect::<Result<_>>()?;
+        if table_refs.len() == 1 {
+            Ok(table_refs.drain(..).next().unwrap())
+        } else {
+            let left_table = table_refs.drain(0..1).next().unwrap();
+            table_refs.into_iter().fold(Ok(left_table), |acc, r| {
+                Ok(TableReference::Join(Join {
+                    op: JoinOperator::CrossJoin,
+                    condition: JoinCondition::None,
+                    left: Box::new(acc?),
+                    right: Box::new(r),
+                }))
+            })
+        }
     }
 
     fn transform_table_with_joins(

--- a/query/src/sql/parser/transformer/transform_sqlparser_test.rs
+++ b/query/src/sql/parser/transformer/transform_sqlparser_test.rs
@@ -22,6 +22,7 @@ mod test {
         let parser = Parser {};
         let sqls = vec![
             "select distinct a, count(*) from t where a = 1 and b - 1 < a group by a having a = 1;",
+            "select * from a, b, c;",
             "select * from a join b on a.a = b.a;",
             "select * from a left outer join b on a.a = b.a;",
             "select * from a right outer join b on a.a = b.a;",
@@ -44,6 +45,7 @@ mod test {
             .collect();
         let expected = vec![
             r#"SELECT DISTINCT a, count(*) FROM t WHERE a = 1 AND b - 1 < a GROUP BY a HAVING a = 1"#,
+            r#"SELECT * FROM a CROSS JOIN b CROSS JOIN c"#,
             r#"SELECT * FROM a INNER JOIN b ON a.a = b.a"#,
             r#"SELECT * FROM a LEFT OUTER JOIN b ON a.a = b.a"#,
             r#"SELECT * FROM a RIGHT OUTER JOIN b ON a.a = b.a"#,


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary
Part of #1218 

Minor change, refactor `FROM` clause, use `CROSS JOIN` to replace comma seperated `TableReference`.

## Changelog

- Improvement


