### PR TITLE
Add optimize histogram metric

### DIFF
--- a/query/src/optimizers/metrics.rs
+++ b/query/src/optimizers/metrics.rs
@@ -1,0 +1,15 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub static METRIC_OPTIMIZE_USEDTIME: &str = "optimizer.optimize_usedtime";

--- a/query/src/optimizers/mod.rs
+++ b/query/src/optimizers/mod.rs
@@ -23,8 +23,8 @@ mod optimizer_statistics_exact_test;
 #[cfg(test)]
 mod optimizer_test;
 
-mod optimizer;
 mod metrics;
+mod optimizer;
 mod optimizer_constant_folding;
 mod optimizer_projection_push_down;
 mod optimizer_scatters;

--- a/query/src/optimizers/mod.rs
+++ b/query/src/optimizers/mod.rs
@@ -24,6 +24,7 @@ mod optimizer_statistics_exact_test;
 mod optimizer_test;
 
 mod optimizer;
+mod metrics;
 mod optimizer_constant_folding;
 mod optimizer_projection_push_down;
 mod optimizer_scatters;

--- a/query/src/optimizers/optimizer.rs
+++ b/query/src/optimizers/optimizer.rs
@@ -60,10 +60,7 @@ impl Optimizers {
             plan = optimizer.optimize(&plan)?;
             tracing::debug!("After {} \n{:?}", optimizer.name(), plan);
         }
-        histogram!(
-            super::metrics::METRIC_OPTIMIZE_USEDTIME,
-            start.elapsed()
-        );
+        histogram!(super::metrics::METRIC_OPTIMIZE_USEDTIME, start.elapsed());
         Ok(plan)
     }
 }


### PR DESCRIPTION
Signed-off-by: Alkaid <alkaid@AlkaiddeMacBook-Pro.local>

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Add a histogram metric for optimizer. We can use this metric to know the P99,P90....e.t.c used time by optimizer.

## Changelog

- Other 

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

