### PR TITLE
[clickhouse-handler] print error stacktrace in clickhouse-handler

### DIFF
--- a/query/src/servers/clickhouse/interactive_worker.rs
+++ b/query/src/servers/clickhouse/interactive_worker.rs
@@ -21,6 +21,7 @@ use common_datavalues::prelude::Arc;
 use metrics::histogram;
 
 use crate::servers::clickhouse::interactive_worker_base::InteractiveWorkerBase;
+use crate::servers::clickhouse::writers::to_clickhouse_err;
 use crate::servers::clickhouse::writers::QueryWriter;
 use crate::sessions::SessionRef;
 
@@ -48,7 +49,10 @@ impl ClickHouseSession for InteractiveWorker {
         let mut query_writer = QueryWriter::create(ctx.client_revision, conn, context.clone());
 
         let get_query_result = InteractiveWorkerBase::do_query(ctx, context);
-        query_writer.write(get_query_result.await).await?;
+        if let Err(cause) = query_writer.write(get_query_result.await).await {
+            let new_error = cause.add_message(&ctx.state.query);
+            return Err(to_clickhouse_err(new_error));
+        }
 
         histogram!(
             super::clickhouse_metrics::METRIC_CLICKHOUSE_PROCESSOR_REQUEST_DURATION,

--- a/query/src/servers/clickhouse/writers/mod.rs
+++ b/query/src/servers/clickhouse/writers/mod.rs
@@ -16,4 +16,5 @@ mod query_writer;
 
 pub use query_writer::from_clickhouse_block;
 pub use query_writer::to_clickhouse_block;
+pub use query_writer::to_clickhouse_err;
 pub use query_writer::QueryWriter;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Summary about this PR
1. Log error in `datafuse_query::servers::clickhouse::writers::query_writer::QueryWriter::write_error` so we can see error stacktrace in datafuse-query's log.
2. Add query string into error message when `datafuse_query::servers::clickhouse::writers::query_writer::QueryWriter::write` returns an error. Similar to #1353.


## Changelog

- Improvement

## Related Issues

Fixes #1329

## Test Plan

Manual test

