### PR TITLE
[store]: refactor: upgrade raft to 0.6.2-alpha.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,6 +1453,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
+ "tracing-appender",
  "uuid",
  "warp",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.9#8b59966dd0a6bf804eb0ba978b5375010bfbc3f3"
+source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.10#6350514cc414dc9d7e9aa0e21ea7b546ed223235"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/common/tracing/src/lib.rs
+++ b/common/tracing/src/lib.rs
@@ -16,7 +16,23 @@ mod logging;
 mod tracing_to_jaeger;
 
 pub use logging::init_default_tracing;
+pub use logging::init_global_tracing;
+pub use logging::init_tracing;
 pub use logging::init_tracing_with_file;
 pub use tracing;
 pub use tracing_to_jaeger::extract_remote_span_as_parent;
 pub use tracing_to_jaeger::inject_span_to_tonic_request;
+
+#[macro_export]
+macro_rules! func_name {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        let n = &name[..name.len() - 3];
+        let nn = n.replace("::{{closure}}", "");
+        nn
+    }};
+}

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -37,7 +37,7 @@ common-tracing = {path = "../common/tracing"}
 
 # Crates.io dependencies
 anyhow = "1.0.43"
-async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.9" }
+async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.10" }
 async-trait = "0.1"
 byteorder = "1.1.0"
 env_logger = "0.9"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -62,6 +62,7 @@ tempfile = "3.2.0"
 thiserror = "1.0.26"
 threadpool = "1.8.1"
 tokio-stream = "0.1"
+tracing-appender = "0.1.2"
 tonic = { version = "0.4.3", features = ["tls"]}
 
 sha2 = "0.9.5"

--- a/store/src/api/rpc/flight_service_test.rs
+++ b/store/src/api/rpc/flight_service_test.rs
@@ -47,7 +47,7 @@ async fn test_flight_restart() -> anyhow::Result<()> {
     // - restart
     // - Test read the db and read the table.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let (mut tc, addr) = crate::tests::start_store_server().await?;
 
@@ -165,7 +165,7 @@ async fn test_flight_restart() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_create_database() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     // 1. Service starts.
     let (_tc, addr) = crate::tests::start_store_server().await?;
@@ -231,7 +231,7 @@ async fn test_flight_create_database() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_create_get_table() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     use std::sync::Arc;
 
     use common_datavalues::DataField;
@@ -358,7 +358,7 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_drop_table() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     use std::sync::Arc;
 
     use common_datavalues::DataField;
@@ -463,7 +463,7 @@ async fn test_flight_drop_table() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_do_append() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     use std::sync::Arc;
 
@@ -537,7 +537,7 @@ async fn test_do_append() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_scan_partition() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     use std::sync::Arc;
 
     use common_datavalues::prelude::*;
@@ -631,7 +631,7 @@ async fn test_scan_partition() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_generic_kv_mget() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
         let _ent = span.enter();
@@ -678,7 +678,7 @@ async fn test_flight_generic_kv_mget() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_generic_kv_list() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
         let _ent = span.enter();
@@ -725,7 +725,7 @@ async fn test_flight_generic_kv_list() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_generic_kv_delete() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
         let _ent = span.enter();
@@ -792,7 +792,7 @@ async fn test_flight_generic_kv_delete() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_generic_kv_update() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
         let _ent = span.enter();
@@ -900,7 +900,7 @@ async fn test_flight_generic_kv_timeout() -> anyhow::Result<()> {
     // - Test list expired and non-expired.
     // - Test update with a new expire value.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_timeout");
         let _ent = span.enter();
@@ -1012,7 +1012,7 @@ async fn test_flight_generic_kv_timeout() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_generic_kv() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv");
@@ -1087,7 +1087,7 @@ async fn test_flight_generic_kv() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_get_database_meta_empty_db() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     let (_tc, addr) = crate::tests::start_store_server().await?;
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -1100,7 +1100,7 @@ async fn test_flight_get_database_meta_empty_db() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_get_database_meta_ddl_db() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     let (_tc, addr) = crate::tests::start_store_server().await?;
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -1161,7 +1161,7 @@ async fn test_flight_get_database_meta_ddl_db() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_get_database_meta_ddl_table() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     let (_tc, addr) = crate::tests::start_store_server().await?;
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 

--- a/store/src/configs/config.rs
+++ b/store/src/configs/config.rs
@@ -41,6 +41,10 @@ lazy_static! {
 
 #[derive(Clone, Debug, serde::Deserialize, PartialEq, StructOpt, StructOptToml)]
 pub struct Config {
+    /// Identify a config. This is only meant to make debugging easier with more than one Config involved.
+    #[structopt(long, default_value = "")]
+    pub config_id: String,
+
     #[structopt(long, env = "STORE_LOG_LEVEL", default_value = "INFO")]
     pub log_level: String,
 

--- a/store/src/executor/action_handler_test.rs
+++ b/store/src/executor/action_handler_test.rs
@@ -63,7 +63,7 @@ async fn test_action_handler_do_pull_file() -> anyhow::Result<()> {
     // - Bring up an ActionHandler backed with a Dfs
     // - Assert pulling file works fine.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let (_tc, hdlr) = bring_up_dfs_action_handler(hashmap! {
         "foo" => "bar",
@@ -95,7 +95,7 @@ async fn test_action_handler_add_database() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert retrieving database.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     struct D {
         plan: CreateDatabasePlan,
@@ -162,7 +162,7 @@ async fn test_action_handler_get_database() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert getting present and absent databases.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     struct T {
         db_name: &'static str,
@@ -232,7 +232,7 @@ async fn test_action_handler_drop_database() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert getting present and absent databases.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     struct T {
         db_name: &'static str,
@@ -311,7 +311,7 @@ async fn test_action_handler_create_table() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert retrieving database.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     struct D {
         plan: CreateDatabasePlan,
@@ -433,7 +433,7 @@ async fn test_action_handler_get_table() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert getting present and absent databases.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     struct T {
         db_name: &'static str,
@@ -543,7 +543,7 @@ async fn test_action_handler_drop_table() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert getting present and absent databases.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     struct T {
         db_name: &'static str,
@@ -653,7 +653,7 @@ async fn test_action_handler_trancate_table() -> anyhow::Result<()> {
     // - Add a table.
     // - Assert getting present and absent databases.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     struct T {
         db_name: &'static str,

--- a/store/src/meta_service/meta_service_impl_test.rs
+++ b/store/src/meta_service/meta_service_impl_test.rs
@@ -31,7 +31,7 @@ use crate::tests::service::new_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_meta_server_add_file() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
@@ -71,7 +71,7 @@ async fn test_meta_server_add_file() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_meta_server_set_file() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
@@ -113,7 +113,7 @@ async fn test_meta_server_set_file() -> anyhow::Result<()> {
 async fn test_meta_server_add_set_get() -> anyhow::Result<()> {
     // Test Cmd::AddFile, Cmd::SetFile, Cma::GetFile
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
@@ -208,7 +208,7 @@ async fn test_meta_server_add_set_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_meta_server_incr_seq() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
@@ -247,7 +247,7 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
     // - Bring up a cluster of one leader and one non-voter
     // - Assert that writing on the non-voter returns ForwardToLeader error
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc0 = new_test_context();
     let tc1 = new_test_context();

--- a/store/src/meta_service/meta_store_test.rs
+++ b/store/src/meta_service/meta_store_test.rs
@@ -43,7 +43,7 @@ async fn test_meta_store_restart() -> anyhow::Result<()> {
     // TODO check log
     // TODO check state machine
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let id = 3;
     let mut tc = new_test_context();
@@ -88,7 +88,7 @@ async fn test_meta_store_get_membership_from_log() -> anyhow::Result<()> {
     // - Append logs
     // - Get membership from log.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let id = 3;
     let mut tc = new_test_context();
@@ -187,7 +187,7 @@ async fn test_meta_store_do_log_compaction_empty() -> anyhow::Result<()> {
     // - Create a MetaStore
     // - Create a snapshot check snapshot state
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let id = 3;
     let mut tc = new_test_context();
@@ -235,7 +235,7 @@ async fn test_meta_store_do_log_compaction_1_snap_ptr_1_log() -> anyhow::Result<
     // - Apply logs
     // - Create a snapshot check snapshot state
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let id = 3;
     let mut tc = new_test_context();
@@ -302,7 +302,7 @@ async fn test_meta_store_do_log_compaction_all_logs_with_memberchange() -> anyho
     // - Apply logs
     // - Create a snapshot check snapshot state
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let id = 3;
     let mut tc = new_test_context();
@@ -355,7 +355,7 @@ async fn test_meta_store_do_log_compaction_current_snapshot() -> anyhow::Result<
     // - Apply logs
     // - Create a snapshot check snapshot state
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let id = 3;
     let mut tc = new_test_context();
@@ -407,7 +407,7 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
     // - Create a snapshot
     // - Create a new MetaStore and restore it by install the snapshot
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let (logs, want) = snapshot_logs();
 

--- a/store/src/meta_service/raft_log_test.rs
+++ b/store/src/meta_service/raft_log_test.rs
@@ -26,7 +26,7 @@ use crate::tests::service::new_sled_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_open() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     let tc = new_sled_test_context();
     let db = &tc.db;
     RaftLog::open(db, &tc.config).await?;
@@ -36,7 +36,7 @@ async fn test_raft_log_open() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     let tc = new_sled_test_context();
     let db = &tc.db;
     let rl = RaftLog::open(db, &tc.config).await?;
@@ -110,7 +110,7 @@ async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_insert() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     let tc = new_sled_test_context();
     let db = &tc.db;
     let rl = RaftLog::open(db, &tc.config).await?;
@@ -146,7 +146,7 @@ async fn test_raft_log_insert() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_get() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     let tc = new_sled_test_context();
     let db = &tc.db;
     let rl = RaftLog::open(db, &tc.config).await?;
@@ -184,7 +184,7 @@ async fn test_raft_log_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_last() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     let tc = new_sled_test_context();
     let db = &tc.db;
     let rl = RaftLog::open(db, &tc.config).await?;
@@ -217,7 +217,7 @@ async fn test_raft_log_last() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_range_remove() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
     let tc = new_sled_test_context();
     let db = &tc.db;
     let rl = RaftLog::open(db, &tc.config).await?;

--- a/store/src/meta_service/raft_state_test.rs
+++ b/store/src/meta_service/raft_state_test.rs
@@ -23,7 +23,7 @@ async fn test_raft_state_create() -> anyhow::Result<()> {
     // - create a raft state
     // - creating another raft state in the same sled db should fail
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let mut tc = new_sled_test_context();
     let db = &tc.db;
@@ -57,7 +57,7 @@ async fn test_raft_state_open() -> anyhow::Result<()> {
     // - create a raft state
     // - open it.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let mut tc = new_sled_test_context();
     let db = &tc.db;
@@ -78,7 +78,7 @@ async fn test_raft_state_open() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_state_open_or_create() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let mut tc = new_sled_test_context();
     let db = &tc.db;
@@ -96,7 +96,7 @@ async fn test_raft_state_open_or_create() -> anyhow::Result<()> {
 async fn test_raft_state_write_read_hard_state() -> anyhow::Result<()> {
     // - create a raft state
     // - write hard_state and the read it.
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let mut tc = new_sled_test_context();
     let db = &tc.db;
@@ -130,7 +130,7 @@ async fn test_raft_state_write_read_hard_state() -> anyhow::Result<()> {
 async fn test_raft_state_write_read_state_machine_id() -> anyhow::Result<()> {
     // - create a raft state
     // - write state machine id and the read it.
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let mut tc = new_sled_test_context();
     let db = &tc.db;

--- a/store/src/meta_service/raftmeta_test.rs
+++ b/store/src/meta_service/raftmeta_test.rs
@@ -166,7 +166,7 @@ async fn test_meta_node_boot() -> anyhow::Result<()> {
     // - Start a single node meta service cluster.
     // - Test the single node is recorded by this cluster.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
@@ -183,7 +183,7 @@ async fn test_meta_node_boot() -> anyhow::Result<()> {
 async fn test_meta_node_graceful_shutdown() -> anyhow::Result<()> {
     // - Start a leader then shutdown.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let (_nid0, tc) = setup_leader().await?;
     let mn0 = tc.meta_nodes[0].clone();
@@ -212,7 +212,7 @@ async fn test_meta_node_leader_and_non_voter() -> anyhow::Result<()> {
     // - Start a leader and a non-voter;
     // - Write to leader, check on non-voter.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     {
         let span = tracing::span!(tracing::Level::DEBUG, "test_meta_node_leader_and_non_voter");
@@ -237,7 +237,7 @@ async fn test_meta_node_write_to_local_leader() -> anyhow::Result<()> {
     // - Write to the raft node on the leader, expect Ok.
     // - Write to the raft node on the non-leader, expect ForwardToLeader error.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     {
         let span = tracing::span!(tracing::Level::DEBUG, "test_meta_node_leader_and_non_voter");
@@ -289,7 +289,7 @@ async fn test_meta_node_set_file() -> anyhow::Result<()> {
 
     // TODO: test MetaNode.write during leader changes.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     {
         let span = tracing::span!(tracing::Level::DEBUG, "test_meta_node_set_file");
@@ -318,7 +318,7 @@ async fn test_meta_node_add_database() -> anyhow::Result<()> {
     // - Start a leader, 2 followers and a non-voter;
     // - Assert that every node handles AddDatabase request correctly.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     {
         let span = tracing::span!(tracing::Level::DEBUG, "test_meta_node_add_database");
@@ -388,7 +388,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
     // - Write logs to trigger another snapshot.
     // - Add
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     // Create a snapshot every 10 logs
     let snap_logs = 10;
@@ -486,7 +486,7 @@ async fn test_meta_node_cluster_1_2_2() -> anyhow::Result<()> {
     // - Bring up a cluster with 1 leader, 2 followers and 2 non-voters.
     // - Write to leader, check data is replicated.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let span = tracing::span!(tracing::Level::INFO, "test_meta_node_cluster_1_2_2");
     let _ent = span.enter();
@@ -507,7 +507,7 @@ async fn test_meta_node_restart() -> anyhow::Result<()> {
     // - Check old data an new written data.
 
     // TODO(xp): this only tests for in-memory storage.
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let (_nid0, tc0) = setup_leader().await?;
     let mn0 = tc0.meta_nodes[0].clone();
@@ -579,7 +579,7 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
     //   - TODO(xp): New log will be successfully written and sync
     //   - TODO(xp): A new snapshot will be created and transferred  on demand.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let mut log_cnt: u64 = 0;
     let (_id, mut tc) = setup_leader().await?;

--- a/store/src/meta_service/raftmeta_test.rs
+++ b/store/src/meta_service/raftmeta_test.rs
@@ -881,7 +881,7 @@ where T: Fn(&RaftMetrics) -> bool + Send {
 
 /// Make a default timeout for wait() for test.
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(2000))
+    Some(Duration::from_millis(4000))
 }
 
 fn test_context_nodes(tcs: &Vec<StoreTestContext>) -> Vec<Arc<MetaNode>> {

--- a/store/src/meta_service/sled_tree_test.rs
+++ b/store/src/meta_service/sled_tree_test.rs
@@ -34,7 +34,7 @@ use crate::tests::service::new_sled_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_open() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -45,7 +45,7 @@ async fn test_sledtree_open() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_append() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -103,7 +103,7 @@ async fn test_sledtree_append() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_append_values_and_range_get() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -178,7 +178,7 @@ async fn test_sledtree_append_values_and_range_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_range_keys() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -230,7 +230,7 @@ async fn test_sledtree_range_keys() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_range_kvs() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -261,7 +261,7 @@ async fn test_sledtree_range_kvs() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_range() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     // This test assumes the following order.
     // to check the range boundary.
@@ -356,7 +356,7 @@ async fn test_sledtree_range() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_scan_prefix() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -380,7 +380,7 @@ async fn test_sledtree_scan_prefix() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_insert() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -444,7 +444,7 @@ async fn test_sledtree_insert() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_contains_key() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -483,7 +483,7 @@ async fn test_sledtree_contains_key() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_update_and_fetch() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -508,7 +508,7 @@ async fn test_sledtree_update_and_fetch() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_get() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -547,7 +547,7 @@ async fn test_sledtree_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_last() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     // This test assumes the following order.
     // To ensure a last() does not returns item from another key space with smaller prefix
@@ -604,7 +604,7 @@ async fn test_sledtree_last() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_remove() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -644,7 +644,7 @@ async fn test_sledtree_remove() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_range_remove() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -724,7 +724,7 @@ async fn test_sledtree_range_remove() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_multi_types() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -792,7 +792,7 @@ async fn test_sledtree_multi_types() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_append() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -851,7 +851,7 @@ async fn test_as_append() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_append_values_and_range_get() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -927,7 +927,7 @@ async fn test_as_append_values_and_range_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_range_keys() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -980,7 +980,7 @@ async fn test_as_range_keys() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_range_kvs() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1012,7 +1012,7 @@ async fn test_as_range_kvs() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_scan_prefix() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1055,7 +1055,7 @@ async fn test_as_scan_prefix() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_insert() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1116,7 +1116,7 @@ async fn test_as_insert() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_contains_key() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1156,7 +1156,7 @@ async fn test_as_contains_key() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_update_and_fetch() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1178,7 +1178,7 @@ async fn test_as_update_and_fetch() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_get() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1218,7 +1218,7 @@ async fn test_as_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_last() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1253,7 +1253,7 @@ async fn test_as_last() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_remove() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1286,7 +1286,7 @@ async fn test_as_remove() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_range_remove() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1348,7 +1348,7 @@ async fn test_as_range_remove() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_multi_types() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_sled_test_context();
     let db = &tc.db;

--- a/store/src/meta_service/state_machine.rs
+++ b/store/src/meta_service/state_machine.rs
@@ -197,7 +197,7 @@ impl StateMachine {
         config.tree_name(format!("{}/{}", TREE_STATE_MACHINE, sm_id))
     }
 
-    #[tracing::instrument(level = "debug")]
+    #[tracing::instrument(level = "debug", skip(config), fields(config_id=config.config_id.as_str()))]
     pub fn clean(config: &configs::Config, sm_id: u64) -> common_exception::Result<()> {
         let tree_name = StateMachine::tree_name(config, sm_id);
 
@@ -210,7 +210,7 @@ impl StateMachine {
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug")]
+    #[tracing::instrument(level = "debug", skip(config), fields(config_id=config.config_id.as_str()))]
     pub async fn open(
         config: &configs::Config,
         sm_id: u64,

--- a/store/src/meta_service/state_machine_test.rs
+++ b/store/src/meta_service/state_machine_test.rs
@@ -48,7 +48,7 @@ async fn test_state_machine_assign_rand_nodes_to_slot() -> anyhow::Result<()> {
     // - Create a state machine with 3 node 1,3,5.
     // - Assert that expected number of nodes are assigned to a slot.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -88,7 +88,7 @@ async fn test_state_machine_init_slots() -> anyhow::Result<()> {
     // - Initialize all slots.
     // - Assert slot states.
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -119,7 +119,7 @@ async fn test_state_machine_builder() -> anyhow::Result<()> {
     // - Assert default state machine builder
     // - Assert customized state machine builder
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     {
         let tc = new_test_context();
@@ -153,7 +153,7 @@ async fn test_state_machine_builder() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_non_dup_incr_seq() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -189,7 +189,7 @@ async fn test_state_machine_apply_non_dup_incr_seq() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -216,7 +216,7 @@ async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_add_database() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let mut m = StateMachine::open(&tc.config, 1).await?;
@@ -297,7 +297,7 @@ async fn test_state_machine_apply_add_database() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -450,7 +450,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_non_dup_generic_kv_delete() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     struct T {
         // input:
@@ -546,7 +546,7 @@ async fn test_state_machine_apply_non_dup_generic_kv_delete() -> anyhow::Result<
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -584,7 +584,7 @@ async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_set_file() -> anyhow::Result<()> {
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -625,7 +625,7 @@ async fn test_state_machine_snapshot() -> anyhow::Result<()> {
     // - Feed logs into state machine.
     // - Take a snapshot and examine the data
 
-    init_store_unittest();
+    let _log_guards = init_store_unittest(&common_tracing::func_name!());
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 0).await?;


### PR DESCRIPTION

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store]: refactor: upgrade raft to 0.6.2-alpha.10
change-membership should be log driven but not channel driven

https://github.com/datafuse-extras/async-raft/compare/v0.6.2-alpha.9...datafuse-extras:v0.6.2-alpha.10

A membership change involves two steps: the joint config phase and the
final config phase.
Each phase has a corresponding log invovled.

Previously the raft setup several channel to organize this workflow,
which makes the logic hard to understand and introduces complexity when
restarting or leadership transfered: it needs to re-establish the channels and tasks.

According to the gist of raft, all workflow should be log driven.
Thus the new approach:
- Write two log(the joint and the final) at once it recevies a
  change-membership request.
- All following job is done according to just what log is committed.

This simplifies the workflow and makes it more reliable and intuitive to
understand.

Related changes:

- When `change_membership` is called, append 2 logs at once.

- Introduce universal response channel type to send back a message when
  some internal task is done: `ResponseTx`, and a universal response
  error type: `ResponseError`.

- Internal response channel is now an `Option<ResponseTx>`, since the
  first step of membership change does not need to respond to the
  caller.

- When a new leaser established, if the **last** log is a joint config
  log, append a final config log to let the partial change-membership be
  able to complete.

  And the test is added.

- Removed membership related channels.


##### [store] refactor: add per-case logging
Introduce common_tracing::init_tracing() to create a logger that will be
released when being dropped.

Every test need to hold a `guard` to ensure the log subscriber
working.

Elaborate some tracing span arguments.

## Changelog




- Improvement


## Related Issues

- #271
- #1080