### PR TITLE
parser: refine object names with qualified type

### DIFF
--- a/query/src/sql/parser/ast/ast_display_test.rs
+++ b/query/src/sql/parser/ast/ast_display_test.rs
@@ -20,10 +20,10 @@ mod test {
     fn test_display_create_database() {
         let stmt = Statement::CreateDatabase {
             if_not_exists: true,
-            name: vec![Identifier {
+            name: Identifier {
                 name: String::from("column"),
                 quote: Some('`'),
-            }],
+            },
             engine: "".to_string(),
             options: vec![],
         };
@@ -37,16 +37,14 @@ mod test {
     fn test_display_create_table() {
         let stmt = Statement::CreateTable {
             if_not_exists: true,
-            name: vec![
-                Identifier {
-                    name: "db".to_owned(),
-                    quote: Some('`'),
-                },
-                Identifier {
-                    name: "table".to_owned(),
-                    quote: Some('`'),
-                },
-            ],
+            database: Some(Identifier {
+                name: "db".to_owned(),
+                quote: Some('`'),
+            }),
+            table: Identifier {
+                name: "table".to_owned(),
+                quote: Some('`'),
+            },
             columns: vec![ColumnDefinition {
                 name: Identifier {
                     name: "column".to_owned(),
@@ -86,45 +84,67 @@ mod test {
                 op: JoinOperator::Inner,
                 condition: JoinCondition::Natural,
                 left: Box::new(TableReference::Table {
-                    name: vec![Identifier {
+                    database: None,
+                    table: Identifier {
                         name: "left_table".to_owned(),
                         quote: None,
-                    }],
+                    },
                     alias: None,
                 }),
                 right: Box::new(TableReference::Table {
-                    name: vec![Identifier {
+                    database: None,
+                    table: Identifier {
                         name: "right_table".to_owned(),
                         quote: None,
-                    }],
+                    },
                     alias: None,
                 }),
             }),
             selection: Some(Expr::BinaryOp {
                 op: BinaryOperator::Eq,
-                left: Box::new(Expr::ColumnRef(vec![Identifier {
+                left: Box::new(Expr::ColumnRef {
+                    database: None,
+                    table: None,
+                    column: Identifier {
+                        name: "a".to_owned(),
+                        quote: None,
+                    },
+                }),
+                right: Box::new(Expr::ColumnRef {
+                    database: None,
+                    table: None,
+                    column: Identifier {
+                        name: "b".to_owned(),
+                        quote: None,
+                    },
+                }),
+            }),
+            group_by: vec![Expr::ColumnRef {
+                database: None,
+                table: None,
+                column: Identifier {
                     name: "a".to_owned(),
                     quote: None,
-                }])),
-                right: Box::new(Expr::ColumnRef(vec![Identifier {
-                    name: "b".to_owned(),
-                    quote: None,
-                }])),
-            }),
-            group_by: vec![Expr::ColumnRef(vec![Identifier {
-                name: "a".to_owned(),
-                quote: None,
-            }])],
+                },
+            }],
             having: Some(Expr::BinaryOp {
                 op: BinaryOperator::NotEq,
-                left: Box::new(Expr::ColumnRef(vec![Identifier {
-                    name: "a".to_owned(),
-                    quote: None,
-                }])),
-                right: Box::new(Expr::ColumnRef(vec![Identifier {
-                    name: "b".to_owned(),
-                    quote: None,
-                }])),
+                left: Box::new(Expr::ColumnRef {
+                    database: None,
+                    table: None,
+                    column: Identifier {
+                        name: "a".to_owned(),
+                        quote: None,
+                    },
+                }),
+                right: Box::new(Expr::ColumnRef {
+                    database: None,
+                    table: None,
+                    column: Identifier {
+                        name: "b".to_owned(),
+                        quote: None,
+                    },
+                }),
             }),
         };
 
@@ -137,10 +157,11 @@ mod test {
     #[test]
     fn test_display_table_reference() {
         let table_ref = TableReference::Table {
-            name: vec![Identifier {
+            database: None,
+            table: Identifier {
                 name: "table".to_owned(),
                 quote: None,
-            }],
+            },
             alias: Some(TableAlias {
                 name: Identifier {
                     name: "table1".to_owned(),

--- a/query/src/sql/parser/ast/expression.rs
+++ b/query/src/sql/parser/ast/expression.rs
@@ -17,7 +17,7 @@ use std::fmt::Formatter;
 
 use super::Identifier;
 use super::Query;
-use crate::sql::parser::ast::write_identifier_vec;
+use crate::sql::parser::ast::display_identifier_vec;
 
 #[derive(Debug, Clone, PartialEq)]
 #[allow(dead_code)]
@@ -25,7 +25,11 @@ pub enum Expr {
     // Wildcard star
     Wildcard,
     // Column reference, with indirection like `table.column`
-    ColumnRef(Vec<Identifier>),
+    ColumnRef {
+        database: Option<Identifier>,
+        table: Option<Identifier>,
+        column: Identifier,
+    },
     // `IS NULL` expression
     IsNull(Box<Expr>),
     // `IS NOT NULL` expression
@@ -329,8 +333,23 @@ impl Display for Expr {
             Expr::Wildcard => {
                 write!(f, "*")?;
             }
-            Expr::ColumnRef(name) => {
-                write_identifier_vec(name, f)?;
+            Expr::ColumnRef {
+                database,
+                table,
+                column,
+            } => {
+                display_identifier_vec(
+                    f,
+                    vec![
+                        database.to_owned(),
+                        table.to_owned(),
+                        Some(column.to_owned()),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+                )?;
             }
             Expr::IsNull(expr) => {
                 write!(f, "{} IS NULL", expr)?;

--- a/query/src/sql/parser/ast/mod.rs
+++ b/query/src/sql/parser/ast/mod.rs
@@ -33,7 +33,7 @@ pub struct Identifier {
     pub quote: Option<char>,
 }
 
-fn write_identifier_vec(name: &[Identifier], f: &mut Formatter<'_>) -> std::fmt::Result {
+fn display_identifier_vec(f: &mut Formatter<'_>, name: &[Identifier]) -> std::fmt::Result {
     for i in 0..name.len() {
         write!(f, "{}", name[i])?;
         if i != name.len() - 1 {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary
Part of #1218 .

Use qualified fields instead of `Vec<Identifier>` to make AST more semantic.

## Changelog

- Improvement

## Test Plan

Unit Tests

Stateless Tests

