### PR TITLE
[store] test: fix the RaftError::Shutdown issue

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,6 +43,8 @@ jobs:
           components: rustfmt
           args: --all-features --no-fail-fast
         env:
+          RUST_LOG: debug
+          RUST_BACKTRACE: full
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
@@ -63,3 +65,13 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ${{ steps.coverage.outputs.report }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          path: |
+            _local_fs/
+            _logs/
+            _meta/
+            store/_logs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ name = "common-tracing"
 version = "0.1.0"
 dependencies = [
  "common-runtime",
+ "lazy_static",
  "opentelemetry",
  "opentelemetry-jaeger",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.10#6350514cc414dc9d7e9aa0e21ea7b546ed223235"
+source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.11#1492335798d9725c5d200277248e934a4c9247b9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -279,9 +279,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
+checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bigdecimal"
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitmaps"
@@ -1238,9 +1238,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32a398eb1ccfbe7e4f452bc749c44d38dd732e9a253f19da224c416f00ee7f4"
+checksum = "09910f0830248af4499907177608b81d640c8c404526f8770b87b765fbd8c9a5"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -1302,7 +1302,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "377c9b002a72a0b2c1a18c62e2f3864bdfea4a015e3683a96e24aa45dd6c02d1"
 dependencies = [
- "nix 0.22.0",
+ "nix 0.22.1",
  "winapi",
 ]
 
@@ -1393,7 +1393,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "msql-srv",
  "mysql",
- "nom 7.0.0-alpha2",
+ "nom 7.0.0-alpha3",
  "num",
  "num_cpus",
  "paste",
@@ -1606,9 +1606,9 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713c32426287891008edb98f8b5c6abb2130aa043c93a818728fcda78606f274"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -2128,9 +2128,9 @@ checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "git2"
-version = "0.13.20"
+version = "0.13.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+checksum = "659cd14835e75b64d9dba5b660463506763cf0aa6cb640aeeb0e98d841093490"
 dependencies = [
  "bitflags",
  "libc",
@@ -2319,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -2526,18 +2526,18 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5ca711fd837261e14ec9e674f092cbb931d3fa1482b017ae59328ddc6f3212b"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
+checksum = "e4bf49d50e2961077d9c99f4b7997d770a1114f087c3c2e0069b36c13fc2979d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2622,9 +2622,9 @@ checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.21+1.1.0"
+version = "0.12.22+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+checksum = "89c53ac117c44f7042ad8d8f5681378dfbc6010e49ec2c0d1f11dfedc7a4a1c3"
 dependencies = [
  "cc",
  "libc",
@@ -2761,9 +2761,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "maybe-uninit"
@@ -2773,9 +2773,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap"
@@ -2886,6 +2886,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6595bb28ed34f43c3fe088e48f6cfb2e033cab45f25a5384d5fdf564fbc8c4b2"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,7 +2958,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "mysql_common",
- "nom 7.0.0-alpha2",
+ "nom 7.0.0-alpha3",
 ]
 
 [[package]]
@@ -3013,7 +3019,7 @@ dependencies = [
  "mysql_common",
  "named_pipe",
  "native-tls",
- "nix 0.21.0",
+ "nix 0.21.1",
  "once_cell",
  "pem",
  "percent-encoding",
@@ -3100,21 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3728fec49d363a50a8828a190b379a446cc5cf085c06259bbbeb34447e4ec7"
+checksum = "df8e5e343312e7fbeb2a52139114e9e702991ef9c2aea6817ff2440b35647d56"
 dependencies = [
  "bitflags",
  "cc",
@@ -3125,9 +3119,22 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.22.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
+checksum = "e27ff0416812c5dec77c5047d26f34ff0fda13ec8d8e87110056c22a213a3de7"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "memoffset 0.6.4",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
 dependencies = [
  "bitflags",
  "cc",
@@ -3154,12 +3161,12 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.0.0-alpha2"
+version = "7.0.0-alpha3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39881f3ef37da4bfa8ce3478d840baaed5fdfc6560c0b91006924ec191a756bf"
+checksum = "afb043391c8ebfbf60c4c92f6929b9cc830ed9e3bbf7d156e24ab731e3257d97"
 dependencies = [
- "lexical-core",
  "memchr",
+ "minimal-lexical",
  "version_check",
 ]
 
@@ -3312,9 +3319,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+checksum = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
 dependencies = [
  "memchr",
 ]
@@ -3339,9 +3346,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -3359,9 +3366,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.65"
+version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -3785,7 +3792,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix 0.20.0",
+ "nix 0.20.1",
  "parking_lot",
  "prost 0.8.0",
  "prost-build 0.8.0",
@@ -4437,7 +4444,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix 0.22.0",
+ "nix 0.22.1",
  "radix_trie",
  "scopeguard",
  "smallvec",
@@ -4580,9 +4587,9 @@ dependencies = [
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
  "serde",
@@ -5499,9 +5506,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -5691,12 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -5909,9 +5913,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
+checksum = "8ce9b1b516211d33767048e5d47fa2a381ed8b76fc48d2ce4aa39877f9f183e0"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -5921,9 +5925,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
+checksum = "cfe8dc78e2326ba5f845f4b5bf548401604fa20b1dd1d365fb73b6c1d6364041"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -5936,9 +5940,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
+checksum = "95fded345a6559c2cfee778d562300c581f7d4ff3edb9b0d230d69800d213972"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -5948,9 +5952,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
+checksum = "44468aa53335841d9d6b6c023eaab07c0cd4bddbcfdee3e2bb1e8d2cb8069fef"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5958,9 +5962,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
+checksum = "0195807922713af1e67dc66132c7328206ed9766af3858164fb583eedc25fbad"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5971,15 +5975,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.75"
+version = "0.2.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+checksum = "acdb075a845574a1fa5f09fd77e43f7747599301ea3417a9fbffdeedfc1f4a29"
 
 [[package]]
 name = "web-sys"
-version = "0.3.52"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
+checksum = "224b2f6b67919060055ef1a67807367c2066ed520c3862cc013d26cf893a783c"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.11#1492335798d9725c5d200277248e934a4c9247b9"
+source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.13#2eccb9e1f82f1bf71f6a2cf9ef6da7bf6232fa84"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "msql-srv"
 version = "0.9.5"
-source = "git+https://github.com/datafuse-extras/msql-srv?rev=ed40333#ed4033359ceb5a4de5c20343a1e8f5a816d7ae06"
+source = "git+https://github.com/datafuse-extras/msql-srv?rev=cc53408#cc534089d214636fa107375e7b94bacc246746d9"
 dependencies = [
  "byteorder",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,5 @@ debug = true
 
 [profile.dev]
 split-debuginfo = "unpacked"
+
+

--- a/common/exception/src/exception.rs
+++ b/common/exception/src/exception.rs
@@ -317,9 +317,9 @@ impl From<anyhow::Error> for ErrorCode {
     fn from(error: anyhow::Error) -> Self {
         ErrorCode {
             code: 1002,
-            display_text: String::from(""),
+            display_text: format!("{}, source: {:?}", error, error.source()),
             cause: Some(Box::new(OtherErrors::AnyHow { error })),
-            backtrace: None,
+            backtrace: Some(ErrorCodeBacktrace::Origin(Arc::new(Backtrace::new()))),
         }
     }
 }

--- a/common/stoppable/src/stoppable_test.rs
+++ b/common/stoppable/src/stoppable_test.rs
@@ -95,7 +95,7 @@ async fn test_stop_handle() -> Result<()> {
     // - Stop but the task would block.
     // - Signal the task to force stop.
 
-    common_tracing::init_default_tracing();
+    common_tracing::init_default_ut_tracing();
 
     let (stop_tx, _) = broadcast::channel::<()>(1024);
 
@@ -150,7 +150,7 @@ async fn test_stop_handle_drop() -> Result<()> {
     // - Create a task and start it.
     // - Then quit and the Drop should forcibly stop it and the test should not block.
 
-    common_tracing::init_default_tracing();
+    common_tracing::init_default_ut_tracing();
 
     let mut t1 = FooTask::default();
 

--- a/common/tracing/Cargo.toml
+++ b/common/tracing/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 [dependencies] # In alphabetical order
 common-runtime = {path = "../runtime"}
 
+lazy_static = "1.4.0"
 opentelemetry = { version = "0.16", default-features = false, features = ["trace", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
 tonic = "0.4.3"

--- a/common/tracing/src/lib.rs
+++ b/common/tracing/src/lib.rs
@@ -16,6 +16,7 @@ mod logging;
 mod tracing_to_jaeger;
 
 pub use logging::init_default_tracing;
+pub use logging::init_default_ut_tracing;
 pub use logging::init_global_tracing;
 pub use logging::init_tracing;
 pub use logging::init_tracing_with_file;

--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -58,7 +58,7 @@ pub fn init_default_tracing() {
 fn init_tracing_stdout() {
     let fmt_layer = Layer::default()
         .with_thread_ids(true)
-        .with_thread_names(true)
+        .with_thread_names(false)
         // .pretty()
         .with_ansi(false)
         .with_span_events(fmt::format::FmtSpan::FULL);
@@ -82,7 +82,8 @@ fn jaeger_layer<
 
         let tracer = opentelemetry_jaeger::new_pipeline()
             .with_service_name("datafuse-store")
-            .install_batch(opentelemetry::runtime::Tokio)
+            .install_simple()
+            // .install_batch(opentelemetry::runtime::Tokio)
             .expect("install");
 
         let ot_layer = tracing_opentelemetry::layer().with_tracer(tracer);
@@ -164,7 +165,7 @@ pub fn init_file_subscriber(app_name: &str, dir: &str) -> (WorkerGuard, impl Sub
     let f_layer = Layer::new()
         .with_writer(writer)
         .with_thread_ids(true)
-        .with_thread_names(true)
+        .with_thread_names(false)
         .with_ansi(false)
         .with_span_events(fmt::format::FmtSpan::FULL);
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -42,7 +42,7 @@ common-io = { path = "../common/io" }
 common-metatypes = { path = "../common/metatypes" }
 
 # Github dependencies
-msql-srv = { git = "https://github.com/datafuse-extras/msql-srv", rev = "ed40333" }
+msql-srv = { git = "https://github.com/datafuse-extras/msql-srv", rev = "cc53408" }
 clickhouse-rs = { git = "https://github.com/datafuse-extras/clickhouse-rs", rev = "c4743a9" }
 sqlparser = { git = "https://github.com/datafuse-extras/sqlparser-rs", rev = "41ba42b" }
 

--- a/query/src/interpreters/interpreter_database_create_test.rs
+++ b/query/src/interpreters/interpreter_database_create_test.rs
@@ -23,7 +23,7 @@ use crate::sql::*;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_create_database_interpreter() -> Result<()> {
-    common_tracing::init_default_tracing();
+    common_tracing::init_default_ut_tracing();
 
     let ctx = crate::tests::try_create_context()?;
 

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -37,7 +37,7 @@ common-tracing = {path = "../common/tracing"}
 
 # Crates.io dependencies
 anyhow = "1.0.43"
-async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.10" }
+async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.11" }
 async-trait = "0.1"
 byteorder = "1.1.0"
 env_logger = "0.9"

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -37,7 +37,7 @@ common-tracing = {path = "../common/tracing"}
 
 # Crates.io dependencies
 anyhow = "1.0.43"
-async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.11" }
+async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.13" }
 async-trait = "0.1"
 byteorder = "1.1.0"
 env_logger = "0.9"

--- a/store/src/api/rpc/flight_service_test.rs
+++ b/store/src/api/rpc/flight_service_test.rs
@@ -920,7 +920,7 @@ async fn test_flight_generic_kv_timeout() -> anyhow::Result<()> {
                 MatchSeq::Any,
                 Some(b"v1".to_vec()),
                 Some(KVMeta {
-                    expire_at: Some(now),
+                    expire_at: Some(now + 1),
                 }),
             )
             .await?;
@@ -933,7 +933,7 @@ async fn test_flight_generic_kv_timeout() -> anyhow::Result<()> {
 
         tracing::info!("---get expired");
         {
-            tokio::time::sleep(tokio::time::Duration::from_millis(1500)).await;
+            tokio::time::sleep(tokio::time::Duration::from_millis(2000)).await;
             let res = client.get_kv(&"k1".to_string()).await?;
             tracing::debug!("got k1:{:?}", res);
             assert!(res.result.is_none(), "got expired");

--- a/store/src/api/rpc/flight_service_test.rs
+++ b/store/src/api/rpc/flight_service_test.rs
@@ -37,8 +37,6 @@ use common_runtime::tokio;
 use common_tracing::tracing;
 use pretty_assertions::assert_eq;
 
-use crate::tests::service::init_store_unittest;
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_restart() -> anyhow::Result<()> {
     // Issue 1134  https://github.com/datafuselabs/datafuse/issues/1134
@@ -47,7 +45,8 @@ async fn test_flight_restart() -> anyhow::Result<()> {
     // - restart
     // - Test read the db and read the table.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let (mut tc, addr) = crate::tests::start_store_server().await?;
 
@@ -165,7 +164,8 @@ async fn test_flight_restart() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_create_database() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     // 1. Service starts.
     let (_tc, addr) = crate::tests::start_store_server().await?;
@@ -231,7 +231,8 @@ async fn test_flight_create_database() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_create_get_table() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     use std::sync::Arc;
 
     use common_datavalues::DataField;
@@ -358,7 +359,8 @@ async fn test_flight_create_get_table() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_drop_table() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     use std::sync::Arc;
 
     use common_datavalues::DataField;
@@ -463,7 +465,8 @@ async fn test_flight_drop_table() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_do_append() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     use std::sync::Arc;
 
@@ -537,7 +540,8 @@ async fn test_do_append() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_scan_partition() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     use std::sync::Arc;
 
     use common_datavalues::prelude::*;
@@ -631,7 +635,8 @@ async fn test_scan_partition() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_generic_kv_mget() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
         let _ent = span.enter();
@@ -678,7 +683,8 @@ async fn test_flight_generic_kv_mget() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_generic_kv_list() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
         let _ent = span.enter();
@@ -725,7 +731,8 @@ async fn test_flight_generic_kv_list() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_generic_kv_delete() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
         let _ent = span.enter();
@@ -792,7 +799,8 @@ async fn test_flight_generic_kv_delete() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_generic_kv_update() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_list");
         let _ent = span.enter();
@@ -900,7 +908,8 @@ async fn test_flight_generic_kv_timeout() -> anyhow::Result<()> {
     // - Test list expired and non-expired.
     // - Test update with a new expire value.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv_timeout");
         let _ent = span.enter();
@@ -1012,7 +1021,8 @@ async fn test_flight_generic_kv_timeout() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_generic_kv() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     {
         let span = tracing::span!(tracing::Level::INFO, "test_flight_generic_kv");
@@ -1087,7 +1097,8 @@ async fn test_flight_generic_kv() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_get_database_meta_empty_db() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     let (_tc, addr) = crate::tests::start_store_server().await?;
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -1100,7 +1111,8 @@ async fn test_flight_get_database_meta_empty_db() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_get_database_meta_ddl_db() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     let (_tc, addr) = crate::tests::start_store_server().await?;
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 
@@ -1161,7 +1173,8 @@ async fn test_flight_get_database_meta_ddl_db() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_get_database_meta_ddl_table() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     let (_tc, addr) = crate::tests::start_store_server().await?;
     let mut client = StoreClient::try_create(addr.as_str(), "root", "xxx").await?;
 

--- a/store/src/api/rpc/tls_flight_service_test.rs
+++ b/store/src/api/rpc/tls_flight_service_test.rs
@@ -29,7 +29,8 @@ const TEST_CN_NAME: &'static str = "localhost";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_tls() -> anyhow::Result<()> {
-    common_tracing::init_default_tracing();
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let mut tc = new_test_context();
 
@@ -60,7 +61,8 @@ async fn test_flight_tls() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_tls_server_config_failure() -> anyhow::Result<()> {
-    common_tracing::init_default_tracing();
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let mut tc = new_test_context();
 
@@ -74,7 +76,8 @@ async fn test_flight_tls_server_config_failure() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_flight_tls_client_config_failure() -> anyhow::Result<()> {
-    common_tracing::init_default_tracing();
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tls_conf = RpcClientTlsConfig {
         rpc_tls_server_root_ca_cert: "../tests/data/certs/not_exist.pem".to_string(),

--- a/store/src/executor/action_handler_test.rs
+++ b/store/src/executor/action_handler_test.rs
@@ -54,7 +54,6 @@ use crate::executor::ActionHandler;
 use crate::fs::FileSystem;
 use crate::localfs::LocalFS;
 use crate::meta_service::MetaNode;
-use crate::tests::service::init_store_unittest;
 use crate::tests::service::new_test_context;
 use crate::tests::service::StoreTestContext;
 
@@ -63,7 +62,8 @@ async fn test_action_handler_do_pull_file() -> anyhow::Result<()> {
     // - Bring up an ActionHandler backed with a Dfs
     // - Assert pulling file works fine.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let (_tc, hdlr) = bring_up_dfs_action_handler(hashmap! {
         "foo" => "bar",
@@ -95,7 +95,8 @@ async fn test_action_handler_add_database() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert retrieving database.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     struct D {
         plan: CreateDatabasePlan,
@@ -162,7 +163,8 @@ async fn test_action_handler_get_database() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert getting present and absent databases.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     struct T {
         db_name: &'static str,
@@ -232,7 +234,8 @@ async fn test_action_handler_drop_database() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert getting present and absent databases.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     struct T {
         db_name: &'static str,
@@ -311,7 +314,8 @@ async fn test_action_handler_create_table() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert retrieving database.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     struct D {
         plan: CreateDatabasePlan,
@@ -433,7 +437,8 @@ async fn test_action_handler_get_table() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert getting present and absent databases.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     struct T {
         db_name: &'static str,
@@ -543,7 +548,8 @@ async fn test_action_handler_drop_table() -> anyhow::Result<()> {
     // - Add a database.
     // - Assert getting present and absent databases.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     struct T {
         db_name: &'static str,
@@ -653,7 +659,8 @@ async fn test_action_handler_trancate_table() -> anyhow::Result<()> {
     // - Add a table.
     // - Assert getting present and absent databases.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     struct T {
         db_name: &'static str,

--- a/store/src/meta_service/meta_service_impl.rs
+++ b/store/src/meta_service/meta_service_impl.rs
@@ -86,7 +86,7 @@ impl MetaService for MetaServiceImpl {
         Ok(tonic::Response::new(rst))
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "info", skip(self, request))]
     async fn append_entries(
         &self,
         request: tonic::Request<RaftMes>,
@@ -113,7 +113,7 @@ impl MetaService for MetaServiceImpl {
         Ok(tonic::Response::new(mes))
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "info", skip(self, request))]
     async fn install_snapshot(
         &self,
         request: tonic::Request<RaftMes>,
@@ -140,7 +140,7 @@ impl MetaService for MetaServiceImpl {
         Ok(tonic::Response::new(mes))
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "info", skip(self, request))]
     async fn vote(
         &self,
         request: tonic::Request<RaftMes>,

--- a/store/src/meta_service/meta_service_impl_test.rs
+++ b/store/src/meta_service/meta_service_impl_test.rs
@@ -26,12 +26,12 @@ use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
 use crate::meta_service::RetryableError;
 use crate::tests::assert_meta_connection;
-use crate::tests::service::init_store_unittest;
 use crate::tests::service::new_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_meta_server_add_file() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
@@ -71,7 +71,8 @@ async fn test_meta_server_add_file() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_meta_server_set_file() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
@@ -113,7 +114,8 @@ async fn test_meta_server_set_file() -> anyhow::Result<()> {
 async fn test_meta_server_add_set_get() -> anyhow::Result<()> {
     // Test Cmd::AddFile, Cmd::SetFile, Cma::GetFile
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
@@ -208,7 +210,8 @@ async fn test_meta_server_add_set_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_meta_server_incr_seq() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
@@ -247,7 +250,8 @@ async fn test_meta_cluster_write_on_non_leader() -> anyhow::Result<()> {
     // - Bring up a cluster of one leader and one non-voter
     // - Assert that writing on the non-voter returns ForwardToLeader error
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc0 = new_test_context();
     let tc1 = new_test_context();

--- a/store/src/meta_service/meta_store_test.rs
+++ b/store/src/meta_service/meta_store_test.rs
@@ -30,7 +30,6 @@ use crate::meta_service::testing::snapshot_logs;
 use crate::meta_service::LogIndex;
 use crate::meta_service::MetaStore;
 use crate::meta_service::StateMachineMetaValue;
-use crate::tests::service::init_store_unittest;
 use crate::tests::service::new_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -43,7 +42,8 @@ async fn test_meta_store_restart() -> anyhow::Result<()> {
     // TODO check log
     // TODO check state machine
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let id = 3;
     let mut tc = new_test_context();
@@ -88,7 +88,8 @@ async fn test_meta_store_get_membership_from_log() -> anyhow::Result<()> {
     // - Append logs
     // - Get membership from log.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let id = 3;
     let mut tc = new_test_context();
@@ -187,7 +188,8 @@ async fn test_meta_store_do_log_compaction_empty() -> anyhow::Result<()> {
     // - Create a MetaStore
     // - Create a snapshot check snapshot state
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let id = 3;
     let mut tc = new_test_context();
@@ -235,7 +237,8 @@ async fn test_meta_store_do_log_compaction_1_snap_ptr_1_log() -> anyhow::Result<
     // - Apply logs
     // - Create a snapshot check snapshot state
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let id = 3;
     let mut tc = new_test_context();
@@ -302,7 +305,8 @@ async fn test_meta_store_do_log_compaction_all_logs_with_memberchange() -> anyho
     // - Apply logs
     // - Create a snapshot check snapshot state
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let id = 3;
     let mut tc = new_test_context();
@@ -355,7 +359,8 @@ async fn test_meta_store_do_log_compaction_current_snapshot() -> anyhow::Result<
     // - Apply logs
     // - Create a snapshot check snapshot state
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let id = 3;
     let mut tc = new_test_context();
@@ -407,7 +412,8 @@ async fn test_meta_store_install_snapshot() -> anyhow::Result<()> {
     // - Create a snapshot
     // - Create a new MetaStore and restore it by install the snapshot
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let (logs, want) = snapshot_logs();
 

--- a/store/src/meta_service/raft_log_test.rs
+++ b/store/src/meta_service/raft_log_test.rs
@@ -21,12 +21,12 @@ use common_runtime::tokio;
 use crate::meta_service::raft_log::RaftLog;
 use crate::meta_service::Cmd;
 use crate::meta_service::LogEntry;
-use crate::tests::service::init_store_unittest;
 use crate::tests::service::new_sled_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_open() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     let tc = new_sled_test_context();
     let db = &tc.db;
     RaftLog::open(db, &tc.config).await?;
@@ -36,7 +36,8 @@ async fn test_raft_log_open() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     let tc = new_sled_test_context();
     let db = &tc.db;
     let rl = RaftLog::open(db, &tc.config).await?;
@@ -110,7 +111,8 @@ async fn test_raft_log_append_and_range_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_insert() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     let tc = new_sled_test_context();
     let db = &tc.db;
     let rl = RaftLog::open(db, &tc.config).await?;
@@ -146,7 +148,8 @@ async fn test_raft_log_insert() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_get() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     let tc = new_sled_test_context();
     let db = &tc.db;
     let rl = RaftLog::open(db, &tc.config).await?;
@@ -184,7 +187,8 @@ async fn test_raft_log_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_last() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     let tc = new_sled_test_context();
     let db = &tc.db;
     let rl = RaftLog::open(db, &tc.config).await?;
@@ -217,7 +221,8 @@ async fn test_raft_log_last() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_log_range_remove() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
     let tc = new_sled_test_context();
     let db = &tc.db;
     let rl = RaftLog::open(db, &tc.config).await?;

--- a/store/src/meta_service/raft_state_test.rs
+++ b/store/src/meta_service/raft_state_test.rs
@@ -15,7 +15,6 @@ use async_raft::storage::HardState;
 use common_runtime::tokio;
 
 use crate::meta_service::raft_state::RaftState;
-use crate::tests::service::init_store_unittest;
 use crate::tests::service::new_sled_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -23,7 +22,8 @@ async fn test_raft_state_create() -> anyhow::Result<()> {
     // - create a raft state
     // - creating another raft state in the same sled db should fail
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let mut tc = new_sled_test_context();
     let db = &tc.db;
@@ -57,7 +57,8 @@ async fn test_raft_state_open() -> anyhow::Result<()> {
     // - create a raft state
     // - open it.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let mut tc = new_sled_test_context();
     let db = &tc.db;
@@ -78,7 +79,8 @@ async fn test_raft_state_open() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_raft_state_open_or_create() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let mut tc = new_sled_test_context();
     let db = &tc.db;
@@ -96,7 +98,8 @@ async fn test_raft_state_open_or_create() -> anyhow::Result<()> {
 async fn test_raft_state_write_read_hard_state() -> anyhow::Result<()> {
     // - create a raft state
     // - write hard_state and the read it.
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let mut tc = new_sled_test_context();
     let db = &tc.db;
@@ -130,7 +133,8 @@ async fn test_raft_state_write_read_hard_state() -> anyhow::Result<()> {
 async fn test_raft_state_write_read_state_machine_id() -> anyhow::Result<()> {
     // - create a raft state
     // - write state machine id and the read it.
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let mut tc = new_sled_test_context();
     let db = &tc.db;

--- a/store/src/meta_service/raftmeta.rs
+++ b/store/src/meta_service/raftmeta.rs
@@ -151,7 +151,7 @@ impl MetaStore {
     /// 1. If `open` is `Some`, try to open an existent one.
     /// 2. If `create` is `Some`, try to create one.
     /// Otherwise it panic
-    #[tracing::instrument(level = "info", skip(config), fields(config_id=config.config_id.as_str()))]
+    #[tracing::instrument(level = "info", skip(config), fields(config_id=%config.config_id))]
     pub async fn open_create(
         config: &configs::Config,
         open: Option<()>,

--- a/store/src/meta_service/raftmeta.rs
+++ b/store/src/meta_service/raftmeta.rs
@@ -655,8 +655,8 @@ impl MetaNode {
         Config::build("foo_cluster".into())
             .heartbeat_interval(hb)
             // Choose a rational value for election timeout.
-            .election_timeout_min(hb * 4)
-            .election_timeout_max(hb * 8)
+            .election_timeout_min(hb * 8)
+            .election_timeout_max(hb * 12)
             .snapshot_policy(SnapshotPolicy::LogsSinceLast(
                 config.snapshot_logs_since_last,
             ))

--- a/store/src/meta_service/raftmeta.rs
+++ b/store/src/meta_service/raftmeta.rs
@@ -213,6 +213,8 @@ impl MetaStore {
 
         let new_sm_id = sm_id + 1;
 
+        tracing::debug!("snapshot data len: {}", data.len());
+
         let snap: SerializableSnapshot = serde_json::from_slice(data)?;
 
         // If not finished, clean up the new tree.
@@ -221,7 +223,14 @@ impl MetaStore {
             .await?;
 
         let new_sm = StateMachine::open(&self.config, new_sm_id).await?;
+
+        tracing::info!(
+            "insert all key-value into new state machine, n={}",
+            snap.kvs.len()
+        );
+
         let tree = &new_sm.sm_tree.tree;
+        let nkvs = snap.kvs.len();
         for x in snap.kvs.into_iter() {
             let k = &x[0];
             let v = &x[1];
@@ -229,9 +238,17 @@ impl MetaStore {
                 .map_err_to_code(ErrorCode::MetaStoreDamaged, || "fail to insert snapshot")?;
         }
 
+        tracing::info!(
+            "installed state machine from snapshot, no_kvs: {} last_applied: {}",
+            nkvs,
+            new_sm.get_last_applied()?,
+        );
+
         tree.flush_async()
             .await
             .map_err_to_code(ErrorCode::MetaStoreDamaged, || "fail to flush snapshot")?;
+
+        tracing::info!("flushed tree, no_kvs: {}", nkvs);
 
         // Start to use the new tree, the old can be cleaned.
         self.raft_state
@@ -340,7 +357,11 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
     async fn get_log_entries(&self, start: u64, stop: u64) -> anyhow::Result<Vec<Entry<LogEntry>>> {
         // Invalid request, return empty vec.
         if start > stop {
-            tracing::error!("invalid request, start > stop");
+            tracing::error!(
+                "get_log_entries: invalid request, start({}) > stop({})",
+                start,
+                stop
+            );
             return Ok(vec![]);
         }
 
@@ -350,7 +371,11 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
     #[tracing::instrument(level = "info", skip(self), fields(id=self.id))]
     async fn delete_logs_from(&self, start: u64, stop: Option<u64>) -> anyhow::Result<()> {
         if stop.as_ref().map(|stop| &start > stop).unwrap_or(false) {
-            tracing::error!("invalid request, start > stop");
+            tracing::error!(
+                "delete_logs_from: invalid request, start({}) > stop({:?})",
+                start,
+                stop
+            );
             return Ok(());
         }
 
@@ -455,7 +480,7 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
     ) -> anyhow::Result<()> {
         // TODO(xp): disallow installing a snapshot with smaller last_applied.
 
-        tracing::trace!(
+        tracing::debug!(
             { snapshot_size = snapshot.get_ref().len() },
             "decoding snapshot for installation"
         );
@@ -468,7 +493,13 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
         tracing::debug!("SNAP META:{:?}", meta);
 
         // Replace state machine with the new one
-        self.install_snapshot(&new_snapshot.data).await?;
+        let res = self.install_snapshot(&new_snapshot.data).await;
+        match res {
+            Ok(_) => {}
+            Err(e) => {
+                tracing::error!("error: {:?} when install_snapshot", e);
+            }
+        };
 
         // NOTE: a replication may has been using these logs.
         //       It requires the replication to detect a missing log and restart a snapshot replication.

--- a/store/src/meta_service/raftmeta_test.rs
+++ b/store/src/meta_service/raftmeta_test.rs
@@ -34,7 +34,6 @@ use crate::meta_service::NodeId;
 use crate::meta_service::RaftTxId;
 use crate::meta_service::RetryableError;
 use crate::tests::assert_meta_connection;
-use crate::tests::service::init_store_unittest;
 use crate::tests::service::new_test_context;
 use crate::tests::service::StoreTestContext;
 
@@ -166,7 +165,8 @@ async fn test_meta_node_boot() -> anyhow::Result<()> {
     // - Start a single node meta service cluster.
     // - Test the single node is recorded by this cluster.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let addr = tc.config.meta_api_addr();
@@ -183,7 +183,8 @@ async fn test_meta_node_boot() -> anyhow::Result<()> {
 async fn test_meta_node_graceful_shutdown() -> anyhow::Result<()> {
     // - Start a leader then shutdown.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let (_nid0, tc) = setup_leader().await?;
     let mn0 = tc.meta_nodes[0].clone();
@@ -212,7 +213,8 @@ async fn test_meta_node_leader_and_non_voter() -> anyhow::Result<()> {
     // - Start a leader and a non-voter;
     // - Write to leader, check on non-voter.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     {
         let span = tracing::span!(tracing::Level::DEBUG, "test_meta_node_leader_and_non_voter");
@@ -237,7 +239,8 @@ async fn test_meta_node_write_to_local_leader() -> anyhow::Result<()> {
     // - Write to the raft node on the leader, expect Ok.
     // - Write to the raft node on the non-leader, expect ForwardToLeader error.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     {
         let span = tracing::span!(tracing::Level::DEBUG, "test_meta_node_leader_and_non_voter");
@@ -289,7 +292,8 @@ async fn test_meta_node_set_file() -> anyhow::Result<()> {
 
     // TODO: test MetaNode.write during leader changes.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     {
         let span = tracing::span!(tracing::Level::DEBUG, "test_meta_node_set_file");
@@ -318,7 +322,8 @@ async fn test_meta_node_add_database() -> anyhow::Result<()> {
     // - Start a leader, 2 followers and a non-voter;
     // - Assert that every node handles AddDatabase request correctly.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     {
         let span = tracing::span!(tracing::Level::DEBUG, "test_meta_node_add_database");
@@ -388,7 +393,8 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
     // - Write logs to trigger another snapshot.
     // - Add
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     // Create a snapshot every 10 logs
     let snap_logs = 10;
@@ -486,7 +492,8 @@ async fn test_meta_node_cluster_1_2_2() -> anyhow::Result<()> {
     // - Bring up a cluster with 1 leader, 2 followers and 2 non-voters.
     // - Write to leader, check data is replicated.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let span = tracing::span!(tracing::Level::INFO, "test_meta_node_cluster_1_2_2");
     let _ent = span.enter();
@@ -507,7 +514,8 @@ async fn test_meta_node_restart() -> anyhow::Result<()> {
     // - Check old data an new written data.
 
     // TODO(xp): this only tests for in-memory storage.
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let (_nid0, tc0) = setup_leader().await?;
     let mn0 = tc0.meta_nodes[0].clone();
@@ -579,7 +587,8 @@ async fn test_meta_node_restart_single_node() -> anyhow::Result<()> {
     //   - TODO(xp): New log will be successfully written and sync
     //   - TODO(xp): A new snapshot will be created and transferred  on demand.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let mut log_cnt: u64 = 0;
     let (_id, mut tc) = setup_leader().await?;

--- a/store/src/meta_service/sled_tree_test.rs
+++ b/store/src/meta_service/sled_tree_test.rs
@@ -29,12 +29,12 @@ use crate::meta_service::SledTree;
 use crate::meta_service::StateMachineMetaKey::Initialized;
 use crate::meta_service::StateMachineMetaKey::LastApplied;
 use crate::meta_service::StateMachineMetaValue;
-use crate::tests::service::init_store_unittest;
 use crate::tests::service::new_sled_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_open() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -45,7 +45,8 @@ async fn test_sledtree_open() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_append() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -103,7 +104,8 @@ async fn test_sledtree_append() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_append_values_and_range_get() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -178,7 +180,8 @@ async fn test_sledtree_append_values_and_range_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_range_keys() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -230,7 +233,8 @@ async fn test_sledtree_range_keys() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_range_kvs() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -261,7 +265,8 @@ async fn test_sledtree_range_kvs() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_range() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     // This test assumes the following order.
     // to check the range boundary.
@@ -356,7 +361,8 @@ async fn test_sledtree_range() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_scan_prefix() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -380,7 +386,8 @@ async fn test_sledtree_scan_prefix() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_insert() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -444,7 +451,8 @@ async fn test_sledtree_insert() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_contains_key() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -483,7 +491,8 @@ async fn test_sledtree_contains_key() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_update_and_fetch() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -508,7 +517,8 @@ async fn test_sledtree_update_and_fetch() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_get() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -547,7 +557,8 @@ async fn test_sledtree_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_last() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     // This test assumes the following order.
     // To ensure a last() does not returns item from another key space with smaller prefix
@@ -604,7 +615,8 @@ async fn test_sledtree_last() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_remove() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -644,7 +656,8 @@ async fn test_sledtree_remove() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_range_remove() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -724,7 +737,8 @@ async fn test_sledtree_range_remove() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_sledtree_multi_types() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -792,7 +806,8 @@ async fn test_sledtree_multi_types() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_append() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -851,7 +866,8 @@ async fn test_as_append() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_append_values_and_range_get() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -927,7 +943,8 @@ async fn test_as_append_values_and_range_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_range_keys() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -980,7 +997,8 @@ async fn test_as_range_keys() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_range_kvs() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1012,7 +1030,8 @@ async fn test_as_range_kvs() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_scan_prefix() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1055,7 +1074,8 @@ async fn test_as_scan_prefix() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_insert() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1116,7 +1136,8 @@ async fn test_as_insert() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_contains_key() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1156,7 +1177,8 @@ async fn test_as_contains_key() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_update_and_fetch() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1178,7 +1200,8 @@ async fn test_as_update_and_fetch() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_get() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1218,7 +1241,8 @@ async fn test_as_get() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_last() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1253,7 +1277,8 @@ async fn test_as_last() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_remove() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1286,7 +1311,8 @@ async fn test_as_remove() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_range_remove() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;
@@ -1348,7 +1374,8 @@ async fn test_as_range_remove() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_as_multi_types() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_sled_test_context();
     let db = &tc.db;

--- a/store/src/meta_service/state_machine.rs
+++ b/store/src/meta_service/state_machine.rs
@@ -192,7 +192,7 @@ impl StateMachine {
         }
     }
 
-    #[tracing::instrument(level = "debug")]
+    #[tracing::instrument(level = "debug", skip(config), fields(config_id=%config.config_id, prefix=%config.sled_tree_prefix))]
     pub fn tree_name(config: &configs::Config, sm_id: u64) -> String {
         config.tree_name(format!("{}/{}", TREE_STATE_MACHINE, sm_id))
     }

--- a/store/src/meta_service/state_machine_test.rs
+++ b/store/src/meta_service/state_machine_test.rs
@@ -40,7 +40,6 @@ use crate::meta_service::LogEntry;
 use crate::meta_service::Node;
 use crate::meta_service::Slot;
 use crate::meta_service::StateMachine;
-use crate::tests::service::init_store_unittest;
 use crate::tests::service::new_test_context;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -48,7 +47,8 @@ async fn test_state_machine_assign_rand_nodes_to_slot() -> anyhow::Result<()> {
     // - Create a state machine with 3 node 1,3,5.
     // - Assert that expected number of nodes are assigned to a slot.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -88,7 +88,8 @@ async fn test_state_machine_init_slots() -> anyhow::Result<()> {
     // - Initialize all slots.
     // - Assert slot states.
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -119,7 +120,8 @@ async fn test_state_machine_builder() -> anyhow::Result<()> {
     // - Assert default state machine builder
     // - Assert customized state machine builder
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     {
         let tc = new_test_context();
@@ -153,7 +155,8 @@ async fn test_state_machine_builder() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_non_dup_incr_seq() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -189,7 +192,8 @@ async fn test_state_machine_apply_non_dup_incr_seq() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -216,7 +220,8 @@ async fn test_state_machine_apply_incr_seq() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_add_database() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let mut m = StateMachine::open(&tc.config, 1).await?;
@@ -297,7 +302,8 @@ async fn test_state_machine_apply_add_database() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -450,7 +456,8 @@ async fn test_state_machine_apply_non_dup_generic_kv_upsert_get() -> anyhow::Res
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_non_dup_generic_kv_delete() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     struct T {
         // input:
@@ -546,7 +553,8 @@ async fn test_state_machine_apply_non_dup_generic_kv_delete() -> anyhow::Result<
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -584,7 +592,8 @@ async fn test_state_machine_apply_add_file() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_state_machine_apply_set_file() -> anyhow::Result<()> {
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 1).await?;
@@ -625,7 +634,8 @@ async fn test_state_machine_snapshot() -> anyhow::Result<()> {
     // - Feed logs into state machine.
     // - Take a snapshot and examine the data
 
-    let _log_guards = init_store_unittest(&common_tracing::func_name!());
+    let (_log_guards, ut_span) = init_store_ut!();
+    let _ent = ut_span.enter();
 
     let tc = new_test_context();
     let mut sm = StateMachine::open(&tc.config, 0).await?;

--- a/store/src/tests/service.rs
+++ b/store/src/tests/service.rs
@@ -18,14 +18,14 @@ use anyhow::Result;
 use common_runtime::tokio;
 use common_runtime::tokio::sync::oneshot;
 use common_tracing::tracing;
-use common_tracing::tracing::Span;
+// use common_tracing::tracing::Span;
 use tempfile::tempdir;
 use tempfile::TempDir;
 
+// use tracing_appender::non_blocking::WorkerGuard;
 use crate::api::StoreServer;
 use crate::configs;
 use crate::meta_service::raft_db::get_sled_db;
-use crate::meta_service::raft_db::init_temp_sled_db;
 use crate::meta_service::GetReq;
 use crate::meta_service::MetaNode;
 use crate::meta_service::MetaServiceClient;
@@ -158,7 +158,9 @@ pub async fn assert_meta_connection(addr: &str) -> anyhow::Result<()> {
     tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
     let mut client = MetaServiceClient::connect(format!("http://{}", addr)).await?;
-    let req = tonic::Request::new(GetReq { key: "foo".into() });
+    let req = tonic::Request::new(GetReq {
+        key: "ensure-connection".into(),
+    });
     let rst = client.get(req).await?.into_inner();
     assert_eq!("", rst.value, "connected");
     Ok(())
@@ -173,7 +175,7 @@ macro_rules! init_store_ut {
         crate::meta_service::raft_db::init_temp_sled_db(t);
 
         // common_tracing::init_tracing(&format!("ut-{}", name), "./_logs")
-        common_tracing::init_default_tracing();
+        common_tracing::init_default_ut_tracing();
 
         let name = common_tracing::func_name!();
         let span =


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] fix: snapshot replication timeout will not cause a RaftError

##### [test]: refactor: CI will save logs at debug level.
- Improve CI: run unittest with RUST_BACKTRACE=full and RUST_LOG=debug

- Upload artifect for debugging when there is a failure

- Refactor: elaborate error log;
  Record source an backtrace when converting anyhow::Error to ErrorCode


##### [query] fix dep revision

##### [store] test: fix the RaftError::Shutdown issue
When running unittest, with heavy cpu load, heartbeat message has chance
to be delayed too much.
When this happens, a follower tries to elect itself and revert the
current leader to a follower state.
This causes the leader to discard every in progress request it has
received. And the client receives an **inappropriate** error
`RaftError::Shuttingdown`.

This is actually not a bug.

In such case in practise, a client should re-fetch the latest leader
and retry.

For a unittest, we just extend the timeout to let tests pass happily,
even on a poor CI VM.


##### [store] refactor: refine tracing
- Every test case creates its own span as a root.
  This way the logging/tracing belonging to a single test is easy to
  grep.

- Upgrade to async-raft 0.6.2-alpha.11, with enhanced tracing:
  a span is send along with a message through channels.
  Thus a complete workflow can be tracked.


##### [store] fix: fix flaky test: generic-kv: get-unexpired

## Changelog




- Improvement
- Build/Testing/CI

## Related Issues

- #271
- #1080
- fix: #1494
- fix: #1563