### PR TITLE
[deps] bump opentelemetry related dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff27b33e30432e7b9854936693ca103d8591b0501f7ae9f633de48cda3bf2a67"
+checksum = "e1cf9b1c4e9a6c4de793c632496fa490bdc0e1eea73f0c91394f7b6990935d22"
 dependencies = [
  "async-trait",
  "crossbeam-channel 0.5.1",
@@ -3378,15 +3378,26 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-jaeger"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a9fc8192722e7daa0c56e59e2336b797122fb8598383dcb11c8852733b435c"
+checksum = "db22f492873ea037bc267b35a0e8e4fb846340058cb7c864efe3d0bf23684593"
 dependencies = [
  "async-trait",
  "lazy_static",
  "opentelemetry",
+ "opentelemetry-semantic-conventions",
  "thiserror",
  "thrift",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffeac823339e8b0f27b961f4385057bf9f97f2863bc745bd015fd6091f2270e9"
+dependencies = [
+ "opentelemetry",
 ]
 
 [[package]]
@@ -5505,9 +5516,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c47440f2979c4cd3138922840eec122e3c0ba2148bc290f756bd7fd60fc97fff"
+checksum = "599f388ecb26b28d9c1b2e4437ae019a7b336018b45ed911458cd9ebf91129f6"
 dependencies = [
  "opentelemetry",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,12 +829,12 @@ dependencies = [
  "async-trait",
  "common-exception",
  "common-metatypes",
+ "common-runtime",
  "common-store-api",
  "mockall",
  "serde",
  "serde_json",
  "sha2",
- "tokio",
 ]
 
 [[package]]

--- a/common/management/Cargo.toml
+++ b/common/management/Cargo.toml
@@ -21,6 +21,6 @@ serde_json = "1.0"
 sha2 = "0.9.5"
 
 [dev-dependencies]
-tokio = { version = "1.10.0", features = ["macros", "rt","rt-multi-thread", "sync"] }
+common-runtime = { path = "../runtime"}
 mockall = "0.10.2"
 common-metatypes = {path = "../metatypes"}

--- a/common/management/src/user/user_mgr_test.rs
+++ b/common/management/src/user/user_mgr_test.rs
@@ -18,6 +18,7 @@ use common_exception::ErrorCode;
 use common_metatypes::KVMeta;
 use common_metatypes::MatchSeq;
 use common_metatypes::SeqValue;
+use common_runtime::tokio;
 use common_store_api::kv_api::MGetKVActionResult;
 use common_store_api::kv_api::PrefixListReply;
 use common_store_api::GetKVActionResult;

--- a/common/tracing/Cargo.toml
+++ b/common/tracing/Cargo.toml
@@ -11,12 +11,12 @@ edition = "2021"
 [dependencies] # In alphabetical order
 common-runtime = {path = "../runtime"}
 
-opentelemetry = { version = "0.15", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-jaeger = "0.14"
+opentelemetry = { version = "0.16", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }
 tonic = "0.4.3"
 tracing = "0.1.26"
 tracing-appender = "0.1.2"
 tracing-bunyan-formatter = "0.2"
 tracing-futures = { version = "0.2.5", default-features = false }
-tracing-opentelemetry = "0.14.0"
+tracing-opentelemetry = "0.15.0"
 tracing-subscriber = "0.2.20"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

- bump opentelemetry related dependencies
- use common_runtime only

## Changelog

- Build/Testing/CI

## Related Issues

Fix #1380 #1383 #1498 

## Test Plan

Unit Tests

Stateless Tests

