### PR TITLE
[tracing] enable file jaegertracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,8 @@ perf.*
 *.out
 *.swp
 _local_fs/*
-_logs/*
 _meta/*
+**/_logs/*
 
 # for tests in mac
 *.stderr-e

--- a/common/tracing/src/logging.rs
+++ b/common/tracing/src/logging.rs
@@ -100,8 +100,7 @@ fn jaeger_layer<
 
         let tracer = opentelemetry_jaeger::new_pipeline()
             .with_service_name("datafuse-store")
-            .install_simple()
-            // .install_batch(opentelemetry::runtime::Tokio)
+            .install_batch(opentelemetry::runtime::Tokio)
             .expect("install");
 
         let ot_layer = tracing_opentelemetry::layer().with_tracer(tracer);
@@ -128,7 +127,8 @@ pub fn init_tracing_with_file(app_name: &str, dir: &str, level: &str) -> Vec<Wor
         .with(EnvFilter::new(level))
         .with(stdout_logging_layer)
         .with(JsonStorageLayer)
-        .with(file_logging_layer);
+        .with(file_logging_layer)
+        .with(jaeger_layer());
 
     tracing::subscriber::set_global_default(subscriber)
         .expect("error setting global tracing subscriber");


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

- enable file jaegertracing

![image](https://user-images.githubusercontent.com/36896360/130350439-0a052066-e194-45d7-bb63-3950f935171a.png)

```
$ > FUSE_JAEGER=on RUST_LOG=trace OTEL_BSP_SCHEDULE_DELAY=1 make run
$ > docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
```

## Changelog

- New Feature
- Improvement

## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

