### PR TITLE
[store] refactor: add snapshot-pointer for leader to indicate replication to switch to snapshot replication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 [[package]]
 name = "async-raft"
 version = "0.6.1"
-source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.13#2eccb9e1f82f1bf71f6a2cf9ef6da7bf6232fa84"
+source = "git+https://github.com/datafuse-extras/async-raft?tag=v0.6.2-alpha.14#8cd24ba0f0212e94e61f21a7be0ce0806fcc66d5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -37,7 +37,7 @@ common-tracing = {path = "../common/tracing"}
 
 # Crates.io dependencies
 anyhow = "1.0.43"
-async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.13" }
+async-raft = { git = "https://github.com/datafuse-extras/async-raft", tag = "v0.6.2-alpha.14" }
 async-trait = "0.1"
 byteorder = "1.1.0"
 env_logger = "0.9"

--- a/store/src/configs/config.rs
+++ b/store/src/configs/config.rs
@@ -128,6 +128,14 @@ pub struct Config {
 
     #[structopt(
         long,
+        env = "STORE_INSTALL_SNAPSHOT_TIMEOUT",
+        default_value = "4000",
+        help = concat!("The max time in milli seconds that a leader wait for install-snapshot ack from a follower or non-voter.")
+    )]
+    pub install_snapshot_timeout: u64,
+
+    #[structopt(
+        long,
         env = "STORE_BOOT",
         help = "Whether to boot up a new cluster. If already booted, it is ignored"
     )]

--- a/store/src/meta_service/raftmeta.rs
+++ b/store/src/meta_service/raftmeta.rs
@@ -600,7 +600,7 @@ impl MetaStore {
 
 pub struct MetaNodeBuilder {
     node_id: Option<NodeId>,
-    config: Option<Config>,
+    raft_config: Option<Config>,
     sto: Option<Arc<MetaStore>>,
     monitor_metrics: bool,
     addr: Option<String>,
@@ -613,7 +613,7 @@ impl MetaNodeBuilder {
             .ok_or_else(|| ErrorCode::InvalidConfig("node_id is not set"))?;
 
         let config = self
-            .config
+            .raft_config
             .take()
             .ok_or_else(|| ErrorCode::InvalidConfig("config is not set"))?;
 
@@ -679,7 +679,7 @@ impl MetaNode {
 
         MetaNodeBuilder {
             node_id: None,
-            config: Some(raft_config),
+            raft_config: Some(raft_config),
             sto: None,
             monitor_metrics: true,
             addr: None,
@@ -696,6 +696,7 @@ impl MetaNode {
             // Choose a rational value for election timeout.
             .election_timeout_min(hb * 8)
             .election_timeout_max(hb * 12)
+            .install_snapshot_timeout(config.install_snapshot_timeout)
             .snapshot_policy(SnapshotPolicy::LogsSinceLast(
                 config.snapshot_logs_since_last,
             ))

--- a/store/src/meta_service/raftmeta_test.rs
+++ b/store/src/meta_service/raftmeta_test.rs
@@ -398,6 +398,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
 
     let mut tc = new_test_context();
     tc.config.snapshot_logs_since_last = snap_logs;
+    tc.config.install_snapshot_timeout = 10_1000; // milli seconds. In a CI multi-threads test delays async task badly.
     let addr = tc.config.meta_api_addr();
 
     let mn = MetaNode::boot(0, &tc.config).await?;
@@ -887,7 +888,7 @@ where T: Fn(&RaftMetrics) -> bool + Send {
 
 /// Make a default timeout for wait() for test.
 fn timeout() -> Option<Duration> {
-    Some(Duration::from_millis(4000))
+    Some(Duration::from_millis(5000))
 }
 
 fn test_context_nodes(tcs: &Vec<StoreTestContext>) -> Vec<Arc<MetaNode>> {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] refactor: extend install-snapshot timeout for tests. Sometimes an RPS is delayed by several seconds in CI VM

##### [store] refactor: upgrade to async-raft v0.6.2-alpha.14
- fix: RaftCore.entries_cache is inconsistent with storage. removed it.

    - When leader changes, `entries_cache` is cleared.
      Thus there may be cached entries wont be applied to state machine.

    - When applying finished, the applied entries are not removed from the
      cache.
      Thus there could be entries being applied more than once.

- fix: snapshot replication does not need to send a last 0 size chunk

##### [store] refactor: add snapshot-pointer for leader to indicate replication to switch to snapshot replication

## Changelog




- Improvement


## Related Issues

- #271
- #1080
- fix: https://github.com/datafuselabs/datafuse/issues/1564#issuecomment-903370204