### PR TITLE
Remove unused deps checked by cargo-udeps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,6 @@ dependencies = [
  "common-arrow",
  "common-datavalues",
  "common-exception",
- "common-infallible",
  "common-io",
  "pretty_assertions",
 ]
@@ -731,12 +730,10 @@ dependencies = [
  "lexical-core",
  "num",
  "ordered-float 2.7.0",
- "paste",
  "pretty_assertions",
  "serde",
  "serde_json",
  "strength_reduce",
- "unsafe_unwrap",
 ]
 
 [[package]]
@@ -949,7 +946,6 @@ dependencies = [
 name = "common-tracing"
 version = "0.1.0"
 dependencies = [
- "common-runtime",
  "lazy_static",
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -1343,7 +1339,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "structopt",
  "sysinfo 0.20.0",
  "tar",
  "tempfile",
@@ -1370,7 +1365,6 @@ dependencies = [
  "common-functions",
  "common-infallible",
  "common-io",
- "common-management",
  "common-metatypes",
  "common-planners",
  "common-profling",
@@ -1450,7 +1444,6 @@ dependencies = [
  "metrics-exporter-prometheus",
  "num",
  "num_cpus",
- "paste",
  "pretty_assertions",
  "prost 0.7.0",
  "rand 0.8.4",
@@ -5729,12 +5722,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "unsafe_unwrap"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1230ec65f13e0f9b28d789da20d2d419511893ea9dac2c1f4ef67b8b14e5da80"
 
 [[package]]
 name = "untrusted"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -31,7 +31,6 @@ rustyline = "9.0.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9.5"
-structopt = "0.3"
 sysinfo = "0.20.0"
 tar = "0.4.37"
 thiserror = "1.0.20"

--- a/common/datablocks/Cargo.toml
+++ b/common/datablocks/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2021"
 common-arrow = {path = "../arrow"}
 common-datavalues = {path = "../datavalues"}
 common-exception = {path = "../exception"}
-common-infallible = {path = "../infallible"}
 common-io = {path = "../io"}
 
 

--- a/common/datavalues/Cargo.toml
+++ b/common/datavalues/Cargo.toml
@@ -17,9 +17,7 @@ common-io = {path = "../io"}
 # Github dependencies
 
 # Crates.io dependencies
-paste = "^1.0"
 num = "^0.4"
-unsafe_unwrap = "^0.1.0"
 ordered-float = "2.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/common/functions/Cargo.toml
+++ b/common/functions/Cargo.toml
@@ -19,7 +19,6 @@ common-io = {path = "../io"}
 # Github dependencies
 
 # Crates.io dependencies
-bumpalo = "3.7.0"
 dyn-clone = "1.0.4"
 indexmap = "1.7.0"
 lazy_static = "1.4.0"
@@ -30,8 +29,7 @@ unicase = "2.6.0"
 num = "^0.4"
 ordered-float = "2.7"
 
-
-
 [dev-dependencies]
+bumpalo = "3.7.0"
 common-datablocks = {path = "../datablocks"}
 pretty_assertions = "0.7"

--- a/common/progress/Cargo.toml
+++ b/common/progress/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2021"
 
 [dependencies] # In alphabetical order
 # Workspace dependencies
-common-exception = { path = "../exception" }
 
 # Github dependencies
 
 # Crates.io dependencies
 
 [dev-dependencies]
+common-exception = { path = "../exception" }
 pretty_assertions = "0.7"

--- a/common/tracing/Cargo.toml
+++ b/common/tracing/Cargo.toml
@@ -9,8 +9,6 @@ publish = false
 edition = "2021"
 
 [dependencies] # In alphabetical order
-common-runtime = {path = "../runtime"}
-
 lazy_static = "1.4.0"
 opentelemetry = { version = "0.16", default-features = false, features = ["trace", "rt-tokio"] }
 opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio"] }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -37,7 +37,6 @@ common-streams = { path = "../common/streams" }
 common-tracing = { path = "../common/tracing" }
 common-profling = { path = "../common/profiling" }
 common-store-api = { path = "../common/store-api" }
-common-management = { path = "../common/management" }
 common-io = { path = "../common/io" }
 common-metatypes = { path = "../common/metatypes" }
 

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -32,7 +32,6 @@ common-profling = { path = "../common/profiling" }
 common-runtime = {path = "../common/runtime"}
 common-tracing = {path = "../common/tracing"}
 
-
 # Github dependencies
 
 # Crates.io dependencies
@@ -50,7 +49,6 @@ metrics = "0.17.0"
 metrics-exporter-prometheus = "0.6.0"
 num = "0.4"
 num_cpus = "1.0"
-paste = "^1.0"
 prost = "0.7"
 rand = "0.8.4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Checked by cargo-udeps:
```
unused dependencies:
`common-datablocks v0.1.0 (/home/bohu/github/datafuselabs/datafuse/common/datablocks)`
└─── dependencies
     └─── "common-infallible"
`common-datavalues v0.1.0 (/home/bohu/github/datafuselabs/datafuse/common/datavalues)`
└─── dependencies
     ├─── "paste"
     └─── "unsafe_unwrap"
`common-functions v0.1.0 (/home/bohu/github/datafuselabs/datafuse/common/functions)`
└─── dependencies
     └─── "bumpalo"
`common-progress v0.1.0 (/home/bohu/github/datafuselabs/datafuse/common/progress)`
└─── dependencies
     └─── "common-exception"
`common-tracing v0.1.0 (/home/bohu/github/datafuselabs/datafuse/common/tracing)`
└─── dependencies
     └─── "common-runtime"
`datafuse-cli v0.1.0 (/home/bohu/github/datafuselabs/datafuse/cli)`
└─── dependencies
     └─── "structopt"
`datafuse-query v0.1.0 (/home/bohu/github/datafuselabs/datafuse/query)`
└─── dependencies
     └─── "common-management"
`datafuse-store v0.1.0 (/home/bohu/github/datafuselabs/datafuse/store)`
└─── dependencies
     ├─── "maplit"
     └─── "paste"
Note: These dependencies might be used by other targets.
      To find dependencies that are not used by any target, enable `--all-targets`.
Note: They might be false-positive.
      For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
      To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.
```

## Changelog

- Improvement


## Related Issues

N/A

## Test Plan

Unit Tests

Stateless Tests

