### PR TITLE
[CLI/Bug Fix] fix unit test arg parse

### DIFF
--- a/cli/src/cmds/status_test.rs
+++ b/cli/src/cmds/status_test.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::RefCell;
+
 use tempfile::tempdir;
 
 use crate::cmds::Config;
@@ -20,8 +22,13 @@ use crate::error::Result;
 
 #[test]
 fn test_status() -> Result<()> {
-    let mut conf = Config::create();
-
+    let mut conf = Config {
+        group: "foo".to_string(),
+        datafuse_dir: "/tmp/.datafuse".to_string(),
+        download_url: "".to_string(),
+        tag_url: "".to_string(),
+        clap: RefCell::new(Default::default()),
+    };
     let t = tempdir()?;
     conf.datafuse_dir = t.path().to_str().unwrap().to_string();
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary
Avoid to parse arguments during unit tests.
Previously
```bash
cargo test -p datafuse-cli -- --skip foo
```
cannot work, now it should work normally

## Changelog

- Bug Fix

## Related Issues

fixes https://github.com/datafuselabs/datafuse/issues/1574

## Test Plan

Unit Tests

Stateless Tests

