### PR TITLE
Regulate the arguments type of if function

### DIFF
--- a/common/datavalues/src/columns/conditional.rs
+++ b/common/datavalues/src/columns/conditional.rs
@@ -20,7 +20,6 @@ use crate::prelude::*;
 impl DataColumn {
     pub fn if_then_else(&self, lhs: &DataColumn, rhs: &DataColumn) -> Result<DataColumn> {
         let cond = self.to_minimal_array()?;
-        let cond = cond.cast_with_type(&DataType::Boolean)?;
 
         let dtype = aggregate_types(&[lhs.data_type(), rhs.data_type()])?;
         let mut left = lhs.to_minimal_array()?;

--- a/common/datavalues/src/series/arithmetic.rs
+++ b/common/datavalues/src/series/arithmetic.rs
@@ -219,7 +219,7 @@ fn coerce_lhs_rhs(
 }
 
 fn coerce_lhs_rhs_no_op(lhs: &Series, rhs: &Series) -> Result<(Series, Series)> {
-    let dtype = numerical_coercion(&lhs.data_type(), &rhs.data_type())?;
+    let dtype = numerical_coercion(&lhs.data_type(), &rhs.data_type(), true)?;
 
     let mut left = lhs.clone();
     if lhs.data_type() != dtype {

--- a/common/datavalues/src/series/comparison.rs
+++ b/common/datavalues/src/series/comparison.rs
@@ -75,7 +75,7 @@ fn coerce_cmp_lhs_rhs(lhs: &Series, rhs: &Series) -> Result<(Series, Series)> {
         return Ok((lhs.into_series(), rhs.into_series()));
     }
 
-    let dtype = numerical_coercion(&lhs.data_type(), &rhs.data_type())?;
+    let dtype = numerical_coercion(&lhs.data_type(), &rhs.data_type(), true)?;
 
     let mut left = lhs.clone();
     if lhs.data_type() != dtype {

--- a/common/datavalues/src/series/date_wrap.rs
+++ b/common/datavalues/src/series/date_wrap.rs
@@ -154,18 +154,24 @@ macro_rules! impl_dyn_arrays {
             }
 
             fn if_then_else(&self, rhs: &Series, predicate: &Series) -> Result<Series> {
-                if self.data_type() == rhs.data_type() {
-                    Ok(self
-                        .0
-                        .if_then_else(rhs.as_ref().as_ref(), predicate.bool()?)?
-                        .into_series())
-                } else {
-                    Err(ErrorCode::BadArguments(format!(
+                if predicate.data_type() != DataType::Boolean {
+                    return Err(ErrorCode::BadDataValueType(
+                        "If function requires the first argument type must be Boolean",
+                    ));
+                }
+
+                if self.data_type() != rhs.data_type() {
+                    return Err(ErrorCode::BadArguments(format!(
                         "If then else requires the arguments to have the same datatypes ({} != {})",
                         self.data_type(),
                         rhs.data_type()
-                    )))
+                    )));
                 }
+
+                Ok(self
+                    .0
+                    .if_then_else(rhs.as_ref().as_ref(), predicate.bool()?)?
+                    .into_series())
             }
 
             fn try_get(&self, index: usize) -> Result<DataValue> {

--- a/common/datavalues/src/series/wrap.rs
+++ b/common/datavalues/src/series/wrap.rs
@@ -109,18 +109,24 @@ macro_rules! impl_dyn_array {
             }
 
             fn if_then_else(&self, rhs: &Series, predicate: &Series) -> Result<Series> {
-                if self.data_type() == rhs.data_type() {
-                    Ok(self
-                        .0
-                        .if_then_else(rhs.as_ref().as_ref(), predicate.bool()?)?
-                        .into_series())
-                } else {
-                    Err(ErrorCode::BadArguments(format!(
+                if predicate.data_type() != DataType::Boolean {
+                    return Err(ErrorCode::BadDataValueType(
+                        "If function requires the first argument type must be Boolean",
+                    ));
+                }
+
+                if self.data_type() != rhs.data_type() {
+                    return Err(ErrorCode::BadArguments(format!(
                         "If then else requires the arguments to have the same datatypes ({} != {})",
                         self.data_type(),
                         rhs.data_type()
-                    )))
+                    )));
                 }
+
+                Ok(self
+                    .0
+                    .if_then_else(rhs.as_ref().as_ref(), predicate.bool()?)?
+                    .into_series())
             }
 
             fn try_get(&self, index: usize) -> Result<DataValue> {

--- a/common/datavalues/src/types/data_type_coercion.rs
+++ b/common/datavalues/src/types/data_type_coercion.rs
@@ -121,11 +121,14 @@ pub fn string_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<DataT
 /// Coercion rule for numerical types: The type that both lhs and rhs
 /// can be casted to for numerical calculation, while maintaining
 /// maximum precision
-pub fn numerical_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<DataType> {
+pub fn numerical_coercion(
+    lhs_type: &DataType,
+    rhs_type: &DataType,
+    allow_overflow: bool,
+) -> Result<DataType> {
     let has_float = is_floating(lhs_type) || is_floating(rhs_type);
     let has_integer = is_integer(lhs_type) || is_integer(rhs_type);
     let has_signed = is_signed_numeric(lhs_type) || is_signed_numeric(rhs_type);
-    let has_unsigned = !is_signed_numeric(lhs_type) || !is_signed_numeric(rhs_type);
 
     let size_of_lhs = numeric_byte_size(lhs_type)?;
     let size_of_rhs = numeric_byte_size(rhs_type)?;
@@ -183,19 +186,26 @@ pub fn numerical_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<Da
     );
 
     let should_double = (has_float && has_integer && max_size_of_integer >= max_size_of_float)
-        || (has_signed
-            && has_unsigned
-            && max_size_of_unsigned_integer >= max_size_of_signed_integer);
+        || (has_signed && max_size_of_unsigned_integer >= max_size_of_signed_integer);
 
-    construct_numeric_type(
-        has_signed,
-        has_float,
-        if should_double {
-            cmp::max(size_of_rhs, size_of_lhs) * 2
+    let mut max_size = if should_double {
+        cmp::max(size_of_rhs, size_of_lhs) * 2
+    } else {
+        cmp::max(size_of_rhs, size_of_lhs)
+    };
+
+    if max_size > 8 {
+        if allow_overflow {
+            max_size = 8
         } else {
-            cmp::max(size_of_rhs, size_of_lhs)
-        },
-    )
+            return Result::Err(ErrorCode::BadDataValueType(format!(
+                "Can't construct type from {} and {}",
+                lhs_type, rhs_type
+            )));
+        }
+    }
+
+    construct_numeric_type(has_signed, has_float, max_size)
 }
 
 #[inline]
@@ -267,7 +277,7 @@ pub fn equal_coercion(lhs_type: &DataType, rhs_type: &DataType) -> Result<DataTy
         return Ok(lhs_type.clone());
     }
 
-    numerical_coercion(lhs_type, rhs_type)
+    numerical_coercion(lhs_type, rhs_type, true)
 }
 
 // aggregate_types aggregates data types for a multi-argument function.
@@ -334,7 +344,7 @@ pub fn merge_types(lhs_type: &DataType, rhs_type: &DataType) -> Result<DataType>
                 return Ok(lhs_type.clone());
             }
             if is_numeric(lhs_type) && is_numeric(rhs_type) {
-                numerical_coercion(lhs_type, rhs_type)
+                numerical_coercion(lhs_type, rhs_type, false)
             } else {
                 Result::Err(ErrorCode::BadDataValueType(format!(
                     "Can't merge types from {} and {}",

--- a/common/functions/src/scalars/conditionals/if_test.rs
+++ b/common/functions/src/scalars/conditionals/if_test.rs
@@ -34,7 +34,7 @@ fn test_if_function() -> Result<()> {
     }
 
     let schema = DataSchemaRefExt::create(vec![
-        DataField::new("a", DataType::Int64, false),
+        DataField::new("a", DataType::Int32, false),
         DataField::new("b", DataType::Int64, false),
     ]);
 
@@ -50,7 +50,7 @@ fn test_if_function() -> Result<()> {
         ],
         columns: vec![
             Series::new(vec![true, false, false, true]).into(),
-            Series::new(vec![1i64, 2, 3, 4]).into(),
+            Series::new(vec![1i32, 2, 3, 4]).into(),
             DataColumn::Constant(DataValue::Float64(Some(2.5)), 4),
         ],
         expect: Series::new(vec![1f64, 2.5, 2.5, 4f64]),

--- a/tests/suites/0_stateless/02_0010_function_if.result
+++ b/tests/suites/0_stateless/02_0010_function_if.result
@@ -4,9 +4,6 @@ true
 1
 1
 2
-0
-0.5
-2
 2
 1
 2
@@ -16,6 +13,5 @@ Z+
 true
 NULL
 NULL
-0
-1
-2
+Int64
+Float64

--- a/tests/suites/0_stateless/02_0010_function_if.sql
+++ b/tests/suites/0_stateless/02_0010_function_if.sql
@@ -1,7 +1,7 @@
 select if(number>1, true, false) from numbers(3) order by number;
 select if(number>1, number, 1) from numbers(3) order by number;
-select if(number>1, number, number/2) from numbers(3) order by number;
 select if(number<1, 2, number) from numbers(3) order by number;
-select if(number, 'Z+', 'zero') from numbers(3) order by number;
+select if(number>0, 'Z+', 'zero') from numbers(3) order by number;
 select if(number<1, true, null) from numbers(3) order by number;
-select if(1, number, number/2) from numbers(3) order by number;
+select toTypeName(if(number % 3 = 0, toUInt32(1), toInt64(3))) from numbers(10) limit 1;
+select toTypeName(if(number % 3 = 0, toUInt32(1), toFloat32(3))) from numbers(10) limit 1;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Summary about this PR

```
mysql> select toTypeName(if(number % 3 = 0, toUInt32(1), toInt32(3))) from numbers(10) limit 1;
+-------------------------------------------------------------+
| toTypeName(if(((number % 3) = 0), toUInt32(1), toInt32(3))) |
+-------------------------------------------------------------+
| Int64                                                       |
+-------------------------------------------------------------+
1 row in set (0.01 sec)

mysql> select if(number, toUInt32(1), toInt32(3)) from numbers(10) limit 1;
ERROR 1105 (HY000): Code: 10, displayText = If function requires the first argument must be Boolean.

mysql> select toTypeName( if( number % 3 = 0 , toUInt64(1) , toInt64(3) ) ) from numbers(10) limit 3;
ERROR 1105 (HY000): Code: 10, displayText = Can't construct type from UInt64 and Int64.

mysql> select if(number % 3 = 0, toInt64(1), toFloat64(3)) from numbers(10) limit 3;
ERROR 1105 (HY000): Code: 10, displayText = Can't construct type from Int64 and Float64.
```

## Changelog

- Improvement

## Related Issues

Fixes #1588 

## Test Plan

Stateless Tests

