### PR TITLE
Fix deploy bug about http service port

### DIFF
--- a/store/src/configs/config.rs
+++ b/store/src/configs/config.rs
@@ -54,7 +54,7 @@ pub struct Config {
     )]
     pub metric_api_address: String,
 
-    #[structopt(long, env = "HTTP_API_ADDRESS", default_value = "127.0.0.1:8181")]
+    #[structopt(long, env = "HTTP_API_ADDRESS", default_value = "127.0.0.1:8081")]
     pub http_api_address: String,
 
     #[structopt(long, env = "TLS_SERVER_CERT", default_value = "")]

--- a/website/datafuse/docs/api/config.md
+++ b/website/datafuse/docs/api/config.md
@@ -8,7 +8,7 @@ Get the config of the Datafuse query server.
 ## Examples
 
 ```
-curl http://127.0.0.1:8080/v1/configs
+curl http://127.0.0.1:8081/v1/configs
 
 Config { log_level: "INFO", log_dir: "./_logs", num_cpus: 16, mysql_handler_host: "127.0.0.1", mysql_handler_port: 3307, max_active_sessions: 256, clickhouse_handler_host: "127.0.0.1", clickhouse_handler_port: 9000, flight_api_address: "127.0.0.1:9090", http_api_address: "127.0.0.1:8080", metric_api_address: "127.0.0.1:7070", store_api_address: "127.0.0.1:9191", store_api_username: ******, store_api_password: ******, config_file: "" }
 ```


### PR DESCRIPTION
Signed-off-by: jyz0309 <a1kaid@foxmail.com>

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

For now, the http service default port is different from the make run default port(`datafuse-query-node-1.toml`).

## Changelog

- Bug Fix
- Documentation

## Test Plan

Unit Tests

Stateless Tests

