### PR TITLE
ISSUE-1632: fix range_remove index in log compaction

### DIFF
--- a/store/src/meta_service/raftmeta.rs
+++ b/store/src/meta_service/raftmeta.rs
@@ -454,18 +454,18 @@ impl RaftStorage<LogEntry, AppliedState> for MetaStore {
             .insert(&Entry::new_snapshot_pointer(&snapshot.meta))
             .await?;
 
-        let current_snapshot_last_log_index;
+        let last_snapshot_last_log_index;
 
         {
-            let current_snapshot = self.current_snapshot.read().await;
-            current_snapshot_last_log_index = match current_snapshot.as_ref() {
+            let last_snapshot = self.current_snapshot.read().await;
+            last_snapshot_last_log_index = match last_snapshot.as_ref() {
                 Some(snap) => snap.meta.last_log_id.index + 1,
                 None => 0,
             };
         }
 
         self.log
-            .range_remove(current_snapshot_last_log_index..last_applied_log.index)
+            .range_remove(last_snapshot_last_log_index..last_applied_log.index)
             .await?;
 
         tracing::debug!("log range_remove complete");


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

When do log compaction, the range should start from `last_snapshot_index + 1`.

## Changelog

- Bug Fix

## Related Issues

Fixes #1632 

## Test Plan

Unit Tests

Stateless Tests

