### PR TITLE
Move the local/system register out catalog

### DIFF
--- a/query/benches/suites/mod.rs
+++ b/query/benches/suites/mod.rs
@@ -19,6 +19,7 @@ use criterion::Criterion;
 use datafuse_query::interpreters::SelectInterpreter;
 use datafuse_query::sessions::SessionManager;
 use datafuse_query::sql::PlanParser;
+use datafuse_query::tests::try_create_session_mgr;
 use futures::StreamExt;
 
 pub mod bench_aggregate_query_sql;
@@ -27,7 +28,7 @@ pub mod bench_limit_query_sql;
 pub mod bench_sort_query_sql;
 
 pub async fn select_executor(sql: &str) -> Result<()> {
-    let session_manager = SessionManager::try_create(1)?;
+    let session_manager = try_create_session_mgr(Some(1))?;
     let executor_session = session_manager.create_session("Benches")?;
     let ctx = executor_session.create_context();
 

--- a/query/src/api/rpc/flight_dispatcher_test.rs
+++ b/query/src/api/rpc/flight_dispatcher_test.rs
@@ -25,7 +25,7 @@ use crate::api::rpc::DatafuseQueryFlightDispatcher;
 use crate::api::FlightAction;
 use crate::api::ShuffleAction;
 use crate::tests::parse_query;
-use crate::tests::try_create_sessions;
+use crate::tests::try_create_session_mgr;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_get_stream_with_non_exists_stream() -> Result<()> {
@@ -53,7 +53,7 @@ async fn test_run_shuffle_action_with_no_scatters() -> Result<()> {
     if let (Some(query_id), Some(stage_id), Some(stream_id)) = generate_uuids(3) {
         let flight_dispatcher = DatafuseQueryFlightDispatcher::create();
 
-        let sessions = try_create_sessions()?;
+        let sessions = try_create_session_mgr(None)?;
         let rpc_session = sessions.create_rpc_session(query_id.clone(), false)?;
 
         flight_dispatcher.shuffle_action(
@@ -95,7 +95,7 @@ async fn test_run_shuffle_action_with_scatter() -> Result<()> {
     if let (Some(query_id), Some(stage_id), None) = generate_uuids(2) {
         let flight_dispatcher = DatafuseQueryFlightDispatcher::create();
 
-        let sessions = try_create_sessions()?;
+        let sessions = try_create_session_mgr(None)?;
         let rpc_session = sessions.create_rpc_session(query_id.clone(), false)?;
 
         flight_dispatcher.shuffle_action(

--- a/query/src/api/rpc/flight_service_test.rs
+++ b/query/src/api/rpc/flight_service_test.rs
@@ -33,11 +33,11 @@ use crate::api::rpc::DatafuseQueryFlightService;
 use crate::api::FlightTicket;
 use crate::api::ShuffleAction;
 use crate::tests::parse_query;
-use crate::tests::try_create_sessions;
+use crate::tests::try_create_session_mgr;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_do_flight_action_with_shared_session() -> Result<()> {
-    let sessions = try_create_sessions()?;
+    let sessions = try_create_session_mgr(None)?;
     let dispatcher = Arc::new(DatafuseQueryFlightDispatcher::create());
     let service = DatafuseQueryFlightService::create(dispatcher, sessions);
 
@@ -60,7 +60,7 @@ async fn test_do_flight_action_with_shared_session() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_do_flight_action_with_different_session() -> Result<()> {
-    let sessions = try_create_sessions()?;
+    let sessions = try_create_session_mgr(None)?;
     let dispatcher = Arc::new(DatafuseQueryFlightDispatcher::create());
     let service = DatafuseQueryFlightService::create(dispatcher, sessions);
 
@@ -83,7 +83,7 @@ async fn test_do_flight_action_with_different_session() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_do_flight_action_with_abort_session() -> Result<()> {
-    let sessions = try_create_sessions()?;
+    let sessions = try_create_session_mgr(None)?;
     let dispatcher = Arc::new(DatafuseQueryFlightDispatcher::create());
     let service = DatafuseQueryFlightService::create(dispatcher.clone(), sessions);
 
@@ -115,7 +115,7 @@ async fn test_do_flight_action_with_abort_session() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_do_flight_action_with_abort_and_new_session() -> Result<()> {
-    let sessions = try_create_sessions()?;
+    let sessions = try_create_session_mgr(None)?;
     let dispatcher = Arc::new(DatafuseQueryFlightDispatcher::create());
     let service = DatafuseQueryFlightService::create(dispatcher.clone(), sessions);
 

--- a/query/src/datasources/local/default_database.rs
+++ b/query/src/datasources/local/default_database.rs
@@ -1,0 +1,82 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_exception::Result;
+use common_metatypes::MetaId;
+use common_metatypes::MetaVersion;
+use common_planners::CreateTablePlan;
+use common_planners::DropTablePlan;
+
+use crate::catalogs::Database;
+use crate::catalogs::TableFunctionMeta;
+use crate::catalogs::TableMeta;
+use crate::datasources::local::LocalDatabase;
+
+// Default database.
+pub struct DefaultDatabase {
+    local: LocalDatabase,
+}
+
+impl DefaultDatabase {
+    pub fn create() -> Self {
+        DefaultDatabase {
+            local: LocalDatabase::create(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Database for DefaultDatabase {
+    fn name(&self) -> &str {
+        "default"
+    }
+
+    fn engine(&self) -> &str {
+        "local"
+    }
+
+    fn is_local(&self) -> bool {
+        true
+    }
+
+    fn get_table(&self, table_name: &str) -> Result<Arc<TableMeta>> {
+        self.local.get_table(table_name)
+    }
+
+    fn get_table_by_id(
+        &self,
+        table_id: MetaId,
+        table_version: Option<MetaVersion>,
+    ) -> Result<Arc<TableMeta>> {
+        self.local.get_table_by_id(table_id, table_version)
+    }
+
+    fn get_tables(&self) -> Result<Vec<Arc<TableMeta>>> {
+        self.local.get_tables()
+    }
+
+    fn get_table_functions(&self) -> Result<Vec<Arc<TableFunctionMeta>>> {
+        self.local.get_table_functions()
+    }
+
+    async fn create_table(&self, plan: CreateTablePlan) -> Result<()> {
+        self.local.create_table(plan).await
+    }
+
+    async fn drop_table(&self, plan: DropTablePlan) -> Result<()> {
+        self.local.drop_table(plan).await
+    }
+}

--- a/query/src/datasources/local/local_database.rs
+++ b/query/src/datasources/local/local_database.rs
@@ -47,6 +47,7 @@ impl LocalDatabase {
             tbl_id_seq: AtomicU64::new(LOCAL_TBL_ID_BEGIN),
         }
     }
+
     fn next_db_id(&self) -> u64 {
         // `fetch_add` wraps around on overflow, but as LOCAL_TBL_ID_BEGIN
         // is defined as (1 << 62) + 10000, there are about 13 quintillion ids are reserved

--- a/query/src/datasources/local/local_factory.rs
+++ b/query/src/datasources/local/local_factory.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use common_exception::Result;
 
 use crate::catalogs::Database;
+use crate::datasources::local::DefaultDatabase;
 use crate::datasources::local::LocalDatabase;
 
 pub struct LocalFactory;
@@ -26,8 +27,12 @@ impl LocalFactory {
         Self
     }
 
+    /// Local databases: Local database + Default database.
     pub fn load_databases(&self) -> Result<Vec<Arc<dyn Database>>> {
-        let databases: Vec<Arc<dyn Database>> = vec![Arc::new(LocalDatabase::create())];
+        let databases: Vec<Arc<dyn Database>> = vec![
+            Arc::new(LocalDatabase::create()),
+            Arc::new(DefaultDatabase::create()),
+        ];
         Ok(databases)
     }
 }

--- a/query/src/datasources/local/mod.rs
+++ b/query/src/datasources/local/mod.rs
@@ -23,6 +23,7 @@ mod parquet_table_test;
 
 mod csv_table;
 mod csv_table_stream;
+mod default_database;
 mod local_database;
 mod local_factory;
 mod memory_table;
@@ -32,6 +33,7 @@ mod parquet_table;
 
 pub use csv_table::CsvTable;
 pub use csv_table_stream::CsvTableStream;
+pub use default_database::DefaultDatabase;
 pub use local_database::LocalDatabase;
 pub use local_factory::LocalFactory;
 pub use memory_table::MemoryTable;

--- a/query/src/datasources/tests.rs
+++ b/query/src/datasources/tests.rs
@@ -18,15 +18,15 @@ use common_runtime::tokio;
 use pretty_assertions::assert_eq;
 
 use crate::catalogs::Catalog;
-use crate::catalogs::DatabaseCatalog;
+use crate::tests::try_create_catalog;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_datasource() -> Result<()> {
-    let datasource = DatabaseCatalog::try_create()?;
+    let catalog = try_create_catalog()?;
 
     // Table check.
-    datasource.get_table("system", "numbers_mt")?;
-    if let Err(e) = datasource.get_table("system", "numbersxx") {
+    catalog.get_table("system", "numbers_mt")?;
+    if let Err(e) = catalog.get_table("system", "numbersxx") {
         let expect = "Code: 25, displayText = Unknown table: \'numbersxx\'.";
         let actual = format!("{}", e);
         assert_eq!(expect, actual);
@@ -35,7 +35,7 @@ async fn test_datasource() -> Result<()> {
     // Database tests.
     {
         // Create database.
-        datasource
+        catalog
             .create_database(CreateDatabasePlan {
                 if_not_exists: false,
                 db: "test_db".to_string(),
@@ -45,11 +45,11 @@ async fn test_datasource() -> Result<()> {
             .await?;
 
         // Check
-        let result = datasource.get_database("test_db");
+        let result = catalog.get_database("test_db");
         assert_eq!(true, result.is_ok());
 
         // Drop database.
-        datasource
+        catalog
             .drop_database(DropDatabasePlan {
                 if_exists: false,
                 db: "test_db".to_string(),
@@ -57,7 +57,7 @@ async fn test_datasource() -> Result<()> {
             .await?;
 
         // Check.
-        let result = datasource.get_database("test_db");
+        let result = catalog.get_database("test_db");
         assert_eq!(true, result.is_err());
     }
 

--- a/query/src/servers/clickhouse/clickhouse_handler_test.rs
+++ b/query/src/servers/clickhouse/clickhouse_handler_test.rs
@@ -24,11 +24,11 @@ use common_exception::Result;
 use common_runtime::tokio;
 
 use crate::servers::ClickHouseHandler;
-use crate::sessions::SessionManager;
+use crate::tests::try_create_session_mgr;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_clickhouse_handler_query() -> Result<()> {
-    let sessions = SessionManager::try_create(1)?;
+    let sessions = try_create_session_mgr(Some(1))?;
     let mut handler = ClickHouseHandler::create(sessions);
 
     let listening = "0.0.0.0:0".parse::<SocketAddr>()?;
@@ -45,7 +45,7 @@ async fn test_clickhouse_handler_query() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_clickhouse_insert_data() -> Result<()> {
-    let sessions = SessionManager::try_create(1)?;
+    let sessions = try_create_session_mgr(Some(1))?;
     let mut handler = ClickHouseHandler::create(sessions);
 
     let listening = "0.0.0.0:0".parse::<SocketAddr>()?;
@@ -68,7 +68,7 @@ async fn test_clickhouse_insert_data() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_reject_clickhouse_connection() -> Result<()> {
-    let sessions = SessionManager::try_create(1)?;
+    let sessions = try_create_session_mgr(Some(1))?;
     let mut handler = ClickHouseHandler::create(sessions);
 
     let listening = "0.0.0.0:0".parse::<SocketAddr>()?;
@@ -97,7 +97,7 @@ async fn test_reject_clickhouse_connection() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_abort_clickhouse_server() -> Result<()> {
-    let sessions = SessionManager::try_create(3)?;
+    let sessions = try_create_session_mgr(Some(3))?;
     let mut handler = ClickHouseHandler::create(sessions);
 
     let listening = "0.0.0.0:0".parse::<SocketAddr>()?;

--- a/query/src/servers/mysql/mysql_handler_test.rs
+++ b/query/src/servers/mysql/mysql_handler_test.rs
@@ -29,11 +29,11 @@ use mysql::FromRowError;
 use mysql::Row;
 
 use crate::servers::MySQLHandler;
-use crate::sessions::SessionManager;
+use crate::tests::try_create_session_mgr;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_use_database_with_on_query() -> Result<()> {
-    let mut handler = MySQLHandler::create(SessionManager::try_create(1)?);
+    let mut handler = MySQLHandler::create(try_create_session_mgr(Some(1))?);
 
     let listening = "0.0.0.0:0".parse::<SocketAddr>()?;
     let runnable_server = handler.start(listening).await?;
@@ -49,7 +49,7 @@ async fn test_use_database_with_on_query() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_rejected_session_with_sequence() -> Result<()> {
-    let mut handler = MySQLHandler::create(SessionManager::try_create(1)?);
+    let mut handler = MySQLHandler::create(try_create_session_mgr(Some(1))?);
 
     let listening = "0.0.0.0:0".parse::<SocketAddr>()?;
     let listening = handler.start(listening).await?;
@@ -107,7 +107,7 @@ async fn test_rejected_session_with_parallel() -> Result<()> {
         })
     }
 
-    let mut handler = MySQLHandler::create(SessionManager::try_create(1)?);
+    let mut handler = MySQLHandler::create(try_create_session_mgr(Some(1))?);
 
     let listening = "0.0.0.0:0".parse::<SocketAddr>()?;
     let listening = handler.start(listening).await?;

--- a/query/src/tests/catalog.rs
+++ b/query/src/tests/catalog.rs
@@ -1,0 +1,40 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use common_exception::Result;
+
+use crate::catalogs::DatabaseCatalog;
+use crate::catalogs::RemoteMetaStoreClient;
+use crate::configs::Config;
+use crate::datasources::local::LocalFactory;
+use crate::datasources::remote::RemoteFactory;
+use crate::datasources::system::SystemFactory;
+
+pub fn try_create_catalog() -> Result<DatabaseCatalog> {
+    let conf = Config::default();
+    let remote_factory = RemoteFactory::new(&conf);
+    let store_client_provider = remote_factory.store_client_provider();
+    let cli = Arc::new(RemoteMetaStoreClient::create(Arc::new(
+        store_client_provider,
+    )));
+    let catalog = DatabaseCatalog::try_create_with_config(conf, cli)?;
+    let system = SystemFactory::create().load_databases()?;
+    catalog.register_databases(system)?;
+    let local = LocalFactory::create().load_databases()?;
+    catalog.register_databases(local)?;
+
+    Ok(catalog)
+}

--- a/query/src/tests/context.rs
+++ b/query/src/tests/context.rs
@@ -28,6 +28,7 @@ pub fn try_create_context() -> Result<DatafuseQueryContextRef> {
     let config = Config::default();
     try_create_context_with_conf(config)
 }
+
 pub fn try_create_context_with_conf(mut config: Config) -> Result<DatafuseQueryContextRef> {
     let cluster = Cluster::empty();
 

--- a/query/src/tests/mod.rs
+++ b/query/src/tests/mod.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod catalog;
 mod context;
 mod number;
 mod parquet;
@@ -19,6 +20,7 @@ mod parse_query;
 mod sessions;
 pub(crate) mod tls_constants;
 
+pub use catalog::try_create_catalog;
 pub use context::try_create_cluster_context;
 pub use context::try_create_context;
 pub use context::try_create_context_with_conf;
@@ -26,4 +28,4 @@ pub use context::ClusterNode;
 pub use number::NumberTestData;
 pub use parquet::ParquetTestData;
 pub use parse_query::parse_query;
-pub use sessions::try_create_sessions;
+pub use sessions::try_create_session_mgr;

--- a/query/src/tests/number.rs
+++ b/query/src/tests/number.rs
@@ -24,9 +24,9 @@ use common_planners::ReadDataSourcePlan;
 use common_planners::ScanPlan;
 
 use crate::catalogs::Catalog;
-use crate::catalogs::DatabaseCatalog;
 use crate::pipelines::transforms::SourceTransform;
 use crate::sessions::DatafuseQueryContextRef;
+use crate::tests::try_create_catalog;
 
 pub struct NumberTestData {
     ctx: DatafuseQueryContextRef,
@@ -44,16 +44,16 @@ impl NumberTestData {
     }
 
     pub fn number_schema_for_test(&self) -> Result<DataSchemaRef> {
-        let datasource = DatabaseCatalog::try_create()?;
-        datasource
+        let catalog = try_create_catalog()?;
+        catalog
             .get_table(self.db, self.table)?
             .datasource()
             .schema()
     }
 
     pub fn number_read_source_plan_for_test(&self, numbers: i64) -> Result<ReadDataSourcePlan> {
-        let datasource = DatabaseCatalog::try_create()?;
-        let table_meta = datasource.get_table(self.db, self.table)?;
+        let catalog = try_create_catalog()?;
+        let table_meta = catalog.get_table(self.db, self.table)?;
         let table = table_meta.datasource();
         table.read_plan(
             self.ctx.clone(),

--- a/query/src/tests/sessions.rs
+++ b/query/src/tests/sessions.rs
@@ -21,15 +21,17 @@ use crate::configs::Config;
 use crate::sessions::SessionManager;
 use crate::sessions::SessionManagerRef;
 
-pub fn try_create_sessions() -> Result<SessionManagerRef> {
-    let mut config = Config::default();
-    let cluster = Cluster::empty();
-
+pub fn try_create_session_mgr(max_active_sessions: Option<u64>) -> Result<SessionManagerRef> {
+    let mut conf = Config::default();
     // Setup log dir to the tests directory.
-    config.log.log_dir = env::current_dir()?
+    conf.log.log_dir = env::current_dir()?
         .join("../tests/data/logs")
         .display()
         .to_string();
+    // Set max active session number if have.
+    if let Some(max) = max_active_sessions {
+        conf.query.max_active_sessions = max;
+    }
 
-    SessionManager::from_conf(config, cluster)
+    SessionManager::from_conf(conf, Cluster::empty())
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

This PR including:
* Move out datasource database register from catalog, to the place who needs register them, like `SessionManager::from_conf` in sessions/sessions.rs.
* Move some functions to tests mod which only test needs, such as: `DatabaseCatalog::try_create` and `SessionManager::try_create`


## Changelog

- Improvement


## Related Issues

Fixes N/A

## Test Plan

Unit Tests

Stateless Tests

