### PR TITLE
[common/streams] remove unused declaration

### DIFF
--- a/common/streams/src/stream_take.rs
+++ b/common/streams/src/stream_take.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::option::Option::None;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Remove unused `use std::option::Option::None;` declaration

## Changelog

- Not for changelog (changelog entry is not required)

## Related Issues

No issue

## Test Plan

Unit Tests

Stateless Tests

