### PR TITLE
Support date/datetime arithmetic operations

### DIFF
--- a/common/datavalues/src/types/data_type_coercion.rs
+++ b/common/datavalues/src/types/data_type_coercion.rs
@@ -20,7 +20,6 @@ use common_exception::Result;
 use crate::prelude::DataType;
 use crate::DataField;
 use crate::DataValueArithmeticOperator;
-use crate::PhysicalDataType;
 
 /// Determine if a DataType is signed numeric or not
 pub fn is_signed_numeric(dt: &DataType) -> bool {

--- a/common/datavalues/src/types/data_type_coercion.rs
+++ b/common/datavalues/src/types/data_type_coercion.rs
@@ -20,6 +20,7 @@ use common_exception::Result;
 use crate::prelude::DataType;
 use crate::DataField;
 use crate::DataValueArithmeticOperator;
+use crate::PhysicalDataType;
 
 /// Determine if a DataType is signed numeric or not
 pub fn is_signed_numeric(dt: &DataType) -> bool {
@@ -278,7 +279,7 @@ pub fn datetime_arithmetic_coercion(
 
     let mut a = lhs_type.clone();
     let mut b = rhs_type.clone();
-    if !is_numeric(lhs_type) {
+    if !is_date_or_date_time(&a) {
         a = rhs_type.clone();
         b = lhs_type.clone();
     }
@@ -290,16 +291,8 @@ pub fn datetime_arithmetic_coercion(
             if is_numeric(&b) {
                 Ok(a)
             } else {
-                if a != b {
-                    return e;
-                }
-
-                match a {
-                    DataType::Date16 => Ok(DataType::UInt16),
-                    DataType::Date32 => Ok(DataType::UInt32),
-                    DataType::DateTime32 => Ok(DataType::UInt32),
-                    _ => e,
-                }
+                // Date minus Date or DateTime minus DateTime
+                Ok(DataType::Int32)
             }
         }
         _ => e,

--- a/common/functions/src/scalars/arithmetics/arithmetic.rs
+++ b/common/functions/src/scalars/arithmetics/arithmetic.rs
@@ -63,12 +63,10 @@ impl Function for ArithmeticFunction {
         if args.len() == 1 {
             return Ok(args[0].clone());
         }
-
-        // TODO support: date <op> number
-        // if is_date_or_date_time(&args[0]) || is_date_or_date_time(&args[1]) {
-        //     return common_datavalues::datetime_arithmetic_coercion(&self.op, &args[0], &args[1]);
-        // }
-        common_datavalues::numerical_arithmetic_coercion(&self.op, &args[0], &args[1])
+        if is_date_or_date_time(&args[0]) || is_date_or_date_time(&args[1]) {
+            return datetime_arithmetic_coercion(&self.op, &args[0], &args[1]);
+        }
+        numerical_arithmetic_coercion(&self.op, &args[0], &args[1])
     }
 
     fn nullable(&self, _input_schema: &DataSchema) -> Result<bool> {
@@ -76,11 +74,23 @@ impl Function for ArithmeticFunction {
     }
 
     fn eval(&self, columns: &DataColumnsWithField, _input_rows: usize) -> Result<DataColumn> {
-        match columns.len() {
+        let result = match columns.len() {
             1 => std::ops::Neg::neg(columns[0].column()),
             _ => columns[0]
                 .column()
                 .arithmetic(self.op.clone(), columns[1].column()),
+        }?;
+
+        let has_date_or_date_time = columns.iter().any(|c| is_date_or_date_time(c.data_type()));
+        if has_date_or_date_time {
+            let args = columns
+                .iter()
+                .map(|f| f.data_type().clone())
+                .collect::<Vec<_>>();
+            let data_type = self.return_type(&args)?;
+            result.cast_with_type(&data_type)
+        } else {
+            Ok(result)
         }
     }
 

--- a/tests/suites/0_stateless/02_0012_function_datetimes.result
+++ b/tests/suites/0_stateless/02_0012_function_datetimes.result
@@ -2,3 +2,10 @@ true
 true
 2021-08-30 10:47:42	true
 2021-08-30	true
+true
+true
+true
+true
+true
+true
+true

--- a/tests/suites/0_stateless/02_0012_function_datetimes.sql
+++ b/tests/suites/0_stateless/02_0012_function_datetimes.sql
@@ -2,3 +2,12 @@ SELECT today() >= 18869;
 SELECT now() >= 1630295616;
 select  toDateTime(1630320462), toUInt32(toDateTime(1630320462))  = 1630320462;
 select  toDate(18869), toUInt32(toDate(18869))  = 18869;
+
+select toTypeName(today() + 3) = 'Date16';
+select toTypeName(today() - 3) = 'Date16';
+select toTypeName(now() - 3) = 'DateTime32';
+select today() + 1 - today() = 1;
+
+select toTypeName(today() - today()) = 'Int32';
+select toTypeName(now() - now()) = 'Int32';
+select sum(today() + number - today()) = 45 from numbers(10);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Support date/datetime arithmetic operations

```
mysql> select now() + 1;
+---------------------+
| (now() + 1)         |
+---------------------+
| 2021-08-31 01:55:50 |
+---------------------+
1 row in set (0.02 sec)

mysql>  select today()  + number from numbers(10) order by number;
+--------------------+
| (today() + number) |
+--------------------+
| 2021-08-31         |
| 2021-09-01         |
| 2021-09-02         |
| 2021-09-03         |
| 2021-09-04         |
| 2021-09-05         |
| 2021-09-06         |
| 2021-09-07         |
| 2021-09-08         |
| 2021-09-09         |
+--------------------+
10 rows in set (0.07 sec)
```

## Changelog


- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

