### PR TITLE
Initial work for saving table meta in obj storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
  "multiversion",
  "num-traits",
  "packed_simd_2",
- "parquet2 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parquet2",
  "regex",
  "serde",
  "serde_json",
@@ -673,7 +673,7 @@ version = "0.1.0"
 dependencies = [
  "arrow-flight",
  "arrow2",
- "parquet2 0.4.0 (git+https://github.com/datafuse-extras/parquet2?rev=83c3325)",
+ "parquet2",
 ]
 
 [[package]]
@@ -1415,6 +1415,7 @@ dependencies = [
  "common-building",
  "common-cache",
  "common-clickhouse-srv",
+ "common-dal",
  "common-datablocks",
  "common-datavalues",
  "common-exception",
@@ -1449,6 +1450,7 @@ dependencies = [
  "nom 7.0.0",
  "num",
  "num_cpus",
+ "parquet-format-async-temp 0.1.1",
  "paste",
  "pnet",
  "pretty_assertions",
@@ -3611,6 +3613,19 @@ dependencies = [
 
 [[package]]
 name = "parquet-format-async-temp"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde63e74461b2c6c31166c6bcd205096074c8972a9b46becfff0a4eb8c4fabd8"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "futures",
+ "integer-encoding 3.0.2",
+ "ordered-float 1.1.1",
+]
+
+[[package]]
+name = "parquet-format-async-temp"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03abc2f9c83fe9ceec83f47c76cc071bfd56caba33794340330f35623ab1f544"
@@ -3631,19 +3646,7 @@ dependencies = [
  "async-stream",
  "bitpacking",
  "futures",
- "parquet-format-async-temp",
- "streaming-iterator",
-]
-
-[[package]]
-name = "parquet2"
-version = "0.4.0"
-source = "git+https://github.com/datafuse-extras/parquet2?rev=83c3325#83c33258880a1ac7cfddf151a77c8e7ab744661f"
-dependencies = [
- "async-stream",
- "bitpacking",
- "futures",
- "parquet-format-async-temp",
+ "parquet-format-async-temp 0.2.0",
  "streaming-iterator",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,3 @@ debug = true
 [profile.dev]
 split-debuginfo = "unpacked"
 
-

--- a/common/arrow/Cargo.toml
+++ b/common/arrow/Cargo.toml
@@ -11,7 +11,8 @@ edition = "2021"
 [features]
 default = ["arrow-default", "parquet-default"]
 arrow-default = ["arrow/compute", "arrow/regex", "arrow/merge_sort", "arrow/io_csv", "arrow/io_parquet", "arrow/io_json"]
-parquet-default = ["parquet/stream"]
+#parquet-default = ["parquet/stream"]
+parquet-default = ["parquet2/stream"]
 simd = ["arrow/simd"]
 
 [dependencies] # In alphabetical order
@@ -20,7 +21,9 @@ simd = ["arrow/simd"]
 # Github dependencies
 arrow = { package = "arrow2", git="https://github.com/datafuse-extras/arrow2", default-features = false, rev = "4e4ea28" }
 arrow-flight = { git="https://github.com/datafuse-extras/arrow2", rev = "4e4ea28" }
-parquet = { package = "parquet2", git = "https://github.com/datafuse-extras/parquet2", default-features = false, rev = "83c3325" }
+#parquet = { package = "parquet2", git = "https://github.com/datafuse-extras/parquet2", default-features = false, rev = "83c3325" }
+#parquet = { package = "parquet2", git = "https://github.com/datafuse-extras/parquet2", default-features = false, rev = "1d310ee" }
+parquet2 = { version = "0.4", optional = false, default_features = false, features = ["stream"] }
 # Crates.io dependencies
 
 [dev-dependencies]

--- a/common/dal/src/blob_accessor.rs
+++ b/common/dal/src/blob_accessor.rs
@@ -13,32 +13,42 @@
 //  limitations under the License.
 //
 
+use std::io::Read;
+use std::io::Seek;
+
 use common_exception::Result;
 use futures::stream::Stream;
 use futures::AsyncRead;
 use futures::AsyncSeek;
+
 pub type Bytes = Vec<u8>;
 
-#[async_trait::async_trait]
-pub trait DataAccessor {
-    type InputStream: AsyncRead + AsyncSeek;
+pub trait AsyncSeekableReader: futures::AsyncRead + futures::AsyncSeek {}
 
-    async fn get_input_stream(
-        &self,
-        path: &str,
-        stream_len: Option<u64>,
-    ) -> Result<Self::InputStream>;
+impl<T> AsyncSeekableReader for T where T: AsyncRead + AsyncSeek {}
+
+pub type InputStream = Box<dyn AsyncSeekableReader + Send + Unpin>;
+
+pub trait SeekableReader: Read + Seek {}
+
+impl<T> SeekableReader for T where T: Read + Seek {}
+
+#[async_trait::async_trait]
+pub trait DataAccessor: Send + Sync {
+    fn get_reader(&self, path: &str, len: Option<u64>) -> Result<Box<dyn SeekableReader>>;
+
+    async fn get_input_stream(&self, path: &str, stream_len: Option<u64>) -> Result<InputStream>;
 
     async fn get(&self, path: &str) -> Result<Bytes>;
 
-    async fn put(&self, path: &str, content: Vec<u8>) -> common_exception::Result<()>;
+    async fn put(&self, path: &str, content: Vec<u8>) -> Result<()>;
 
-    async fn put_stream<S>(
+    async fn put_stream(
         &self,
         path: &str,
-        input_stream: S,
+        input_stream: Box<
+            dyn Stream<Item = std::result::Result<Bytes, std::io::Error>> + Send + Unpin + 'static,
+        >,
         stream_len: usize,
-    ) -> common_exception::Result<()>
-    where
-        S: Stream<Item = std::result::Result<Bytes, std::io::Error>> + Send + 'static;
+    ) -> Result<()>;
 }

--- a/common/dal/src/impls/builders.rs
+++ b/common/dal/src/impls/builders.rs
@@ -12,12 +12,3 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
-
-mod blob_accessor;
-mod impls;
-
-pub use blob_accessor::Bytes;
-pub use blob_accessor::DataAccessor;
-pub use impls::Local;
-pub use impls::StorageScheme;
-pub use impls::S3;

--- a/common/dal/src/impls/mod.rs
+++ b/common/dal/src/impls/mod.rs
@@ -15,8 +15,11 @@
 
 mod aws_s3;
 mod azure_blob;
+mod builders;
 mod fuse_dfs;
 mod local;
+mod schemes;
 
 pub use aws_s3::S3;
 pub use local::Local;
+pub use schemes::StorageScheme;

--- a/common/dal/src/impls/schemes.rs
+++ b/common/dal/src/impls/schemes.rs
@@ -13,11 +13,9 @@
 //  limitations under the License.
 //
 
-mod blob_accessor;
-mod impls;
-
-pub use blob_accessor::Bytes;
-pub use blob_accessor::DataAccessor;
-pub use impls::Local;
-pub use impls::StorageScheme;
-pub use impls::S3;
+#[derive(Clone, Debug)]
+pub enum StorageScheme {
+    LocalFs,
+    FuseDfs,
+    S3,
+}

--- a/common/datablocks/src/data_block.rs
+++ b/common/datablocks/src/data_block.rs
@@ -42,10 +42,7 @@ impl DataBlock {
     }
 
     pub fn create_by_array(schema: DataSchemaRef, arrays: Vec<Series>) -> Self {
-        let columns = arrays
-            .iter()
-            .map(|array| DataColumn::Array(array.clone()))
-            .collect();
+        let columns = arrays.into_iter().map(DataColumn::Array).collect();
         DataBlock { schema, columns }
     }
 

--- a/common/datavalues/src/data_schema.rs
+++ b/common/datavalues/src/data_schema.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use core::fmt;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use common_arrow::arrow::datatypes::Schema as ArrowSchema;
@@ -26,15 +27,26 @@ use crate::DataField;
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct DataSchema {
     pub(crate) fields: Vec<DataField>,
+    pub(crate) metadata: HashMap<String, String>,
 }
 
 impl DataSchema {
     pub fn empty() -> Self {
-        Self { fields: vec![] }
+        Self {
+            fields: vec![],
+            metadata: HashMap::new(),
+        }
     }
 
     pub fn new(fields: Vec<DataField>) -> Self {
-        Self { fields }
+        Self {
+            fields,
+            metadata: HashMap::new(),
+        }
+    }
+
+    pub fn new_from(fields: Vec<DataField>, metadata: HashMap<String, String>) -> Self {
+        Self { fields, metadata }
     }
 
     /// Returns an immutable reference of the vector of `Field` instances.
@@ -52,6 +64,12 @@ impl DataSchema {
     /// Returns an immutable reference of a specific `Field` instance selected by name.
     pub fn field_with_name(&self, name: &str) -> Result<&DataField> {
         Ok(&self.fields[self.index_of(name)?])
+    }
+
+    /// Returns an immutable reference to field `metadata`.
+    #[inline]
+    pub const fn meta(&self) -> &HashMap<String, String> {
+        &self.metadata
     }
 
     /// Find the index of the column with the given name.
@@ -98,7 +116,7 @@ impl DataSchema {
             .map(|f| f.to_arrow())
             .collect::<Vec<_>>();
 
-        ArrowSchema::new(fields)
+        ArrowSchema::new_from(fields, self.metadata.clone())
     }
 }
 

--- a/common/flights/src/impls/meta_api_impl.rs
+++ b/common/flights/src/impls/meta_api_impl.rs
@@ -13,12 +13,14 @@
 // limitations under the License.
 //
 
+use common_exception::ErrorCode;
 use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
 use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
+use common_store_api::CommitTableReply;
 pub use common_store_api::CreateDatabaseActionResult;
 pub use common_store_api::CreateTableActionResult;
 pub use common_store_api::DatabaseMetaReply;
@@ -99,6 +101,15 @@ impl MetaApi for StoreClient {
     ) -> common_exception::Result<DatabaseMetaReply> {
         self.do_action(GetDatabaseMetaAction { ver_lower_bound })
             .await
+    }
+
+    async fn commit_table(
+        &self,
+        _table_id: MetaId,
+        _prev_snapshot: String,
+        _new_snapshot: String,
+    ) -> common_exception::Result<CommitTableReply> {
+        Err(ErrorCode::UnImplement("commit_table not implemented"))
     }
 }
 

--- a/common/planners/src/plan_describe_table_test.rs
+++ b/common/planners/src/plan_describe_table_test.rs
@@ -38,8 +38,9 @@ fn test_describe_table_plan() -> Result<()> {
     DataSchema { fields: [\
         DataField { name: \"Field\", data_type: String, nullable: false }, \
         DataField { name: \"Type\", data_type: String, nullable: false }, \
-        DataField { name: \"Null\", data_type: String, nullable: false }\
-    ] }";
+        DataField { name: \"Null\", data_type: String, nullable: false }], \
+        metadata: {} \
+    }";
     let actual = format!("{:?}", describe.schema());
     assert_eq!(expect, actual);
 

--- a/common/planners/src/plan_insert_into.rs
+++ b/common/planners/src/plan_insert_into.rs
@@ -17,8 +17,8 @@ use std::sync::Arc;
 use common_datablocks::DataBlock;
 use common_datavalues::DataSchemaRef;
 use common_infallible::Mutex;
+use common_metatypes::MetaId;
 
-/// please do not keep this, this code is just for test purpose
 type BlockStream =
     std::pin::Pin<Box<dyn futures::stream::Stream<Item = DataBlock> + Sync + Send + 'static>>;
 
@@ -26,6 +26,7 @@ type BlockStream =
 pub struct InsertIntoPlan {
     pub db_name: String,
     pub tbl_name: String,
+    pub tbl_id: MetaId,
     pub schema: DataSchemaRef,
 
     #[serde(skip, default = "InsertIntoPlan::empty_stream")]

--- a/common/store-api/src/lib.rs
+++ b/common/store-api/src/lib.rs
@@ -21,6 +21,7 @@ pub use kv_api::GetKVActionResult;
 pub use kv_api::KVApi;
 pub use kv_api::PrefixListReply;
 pub use kv_api::UpsertKVActionResult;
+pub use meta_api::CommitTableReply;
 pub use meta_api::CreateDatabaseActionResult;
 pub use meta_api::CreateTableActionResult;
 pub use meta_api::DatabaseMetaReply;

--- a/common/store-api/src/meta_api.rs
+++ b/common/store-api/src/meta_api.rs
@@ -61,6 +61,16 @@ pub struct DatabaseMetaSnapshot {
 }
 pub type DatabaseMetaReply = Option<DatabaseMetaSnapshot>;
 
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub enum CommitTableReply {
+    // done
+    Success,
+    // recoverable, returns the current snapshot-id, which should be merged with
+    Conflict(String),
+    // fatal, not recoverable, returns the current snapshot-id
+    Failure(String),
+}
+
 #[async_trait::async_trait]
 pub trait MetaApi {
     async fn create_database(
@@ -102,4 +112,11 @@ pub trait MetaApi {
         &mut self,
         current_ver: Option<u64>,
     ) -> common_exception::Result<DatabaseMetaReply>;
+
+    async fn commit_table(
+        &self,
+        table_id: MetaId,
+        prev_snapshot: String,
+        new_snapshot: String,
+    ) -> common_exception::Result<CommitTableReply>;
 }

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -40,6 +40,7 @@ common-profling = { path = "../common/profiling" }
 common-store-api = { path = "../common/store-api" }
 common-io = { path = "../common/io" }
 common-metatypes = { path = "../common/metatypes" }
+common-dal= {path = "../common/dal"}
 common-clickhouse-srv = { path = "../common/clickhouse-srv" }
 
 # Github dependencies
@@ -87,6 +88,9 @@ hyper = "0.14.12"
 headers = "0.3.4"
 tokio-rustls = "0.22.0"
 axum-server = { version = "0.2", features = ["tls-rustls"] }
+
+[dependencies.parquet-format-async-temp]
+version = "0.1.0"
 
 [dev-dependencies]
 pretty_assertions = "0.7"

--- a/query/src/datasources/fuse_table/README.md
+++ b/query/src/datasources/fuse_table/README.md
@@ -1,0 +1,72 @@
+
+
+NOTE:
+
+This is an ongoing work.
+
+**Table Layout**
+
+A table comprised of a list of snapshots. MetaStore keeps a pointer to 
+the latest snapshot of a given table.
+
+- Snapshot
+
+  A consist view of given table, which comprises
+ 
+  - pointers to `Segment`s
+  - Table level aggregated statistics
+  - pointer to previous snapshot
+   
+- Segment
+ 
+  An intermediate level meta information, which comprises 
+ 
+  - pointers to `Block`s
+  - Segment level aggregated statistics
+   
+- Block
+ 
+  The basic unit of data for a table.
+
+**Ingestion Flow:**
+
+- Insert `Interpreter`
+
+  Accumulates/batch data into blocks, naturally ordered, not partitioning
+t this stage, we reply on background task to merge the data properly.
+  
+- `Table::append`
+  
+  For each block, save it in object store (as parquet for the time being).  
+    
+  A segment info is generated for those blocks, which tracks all the block
+  meta information. also, statistics of each block are aggregated and kept 
+  int the segment info.
+ 
+  Save Segment info in object store.
+ 
+  NOTE: 
+    - `append` may be executed parallel.
+    - operations should be logged/journaled in case of rollback/abort 
+     
+- "Driver"
+
+  Gather all the segments(info) , aggregates the statistics, merge segments
+  with previous snapshot, and commit.  
+
+  In case of conflicts, "Driver" need to re-try the transaction.(OCC, Table level, READ-COMMITTED)
+
+  For this iteration, the "Driver" is the `Table` itself.
+
+
+**Scan Flow:**
+
+
+- `Table::read_plan`
+
+   Prunes bocks by using the scan expressions / criteria, and statistics in Snapshot / Segment.
+
+- `Table::append`
+
+  Prunes columns by using the plan criteria 
+

--- a/query/src/datasources/fuse_table/io/block_appender.rs
+++ b/query/src/datasources/fuse_table/io/block_appender.rs
@@ -1,0 +1,216 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::sync::Arc;
+
+use common_arrow::arrow::datatypes::Schema as ArrowSchema;
+use common_arrow::arrow::io::parquet::read::read_metadata;
+use common_arrow::arrow::io::parquet::write::write_file;
+use common_arrow::arrow::io::parquet::write::WriteOptions;
+use common_arrow::arrow::io::parquet::write::*;
+use common_arrow::arrow::record_batch::RecordBatch;
+use common_arrow::parquet::statistics::serialize_statistics;
+use common_arrow::parquet::statistics::Statistics as ParquetStats;
+use common_datablocks::DataBlock;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_store_api::MetaApi;
+use futures::StreamExt;
+use uuid::Uuid;
+
+use crate::datasources::fuse_table::meta::table_snapshot::BlockLocation;
+use crate::datasources::fuse_table::meta::table_snapshot::BlockMeta;
+use crate::datasources::fuse_table::meta::table_snapshot::ColStats;
+use crate::datasources::fuse_table::meta::table_snapshot::SegmentInfo;
+use crate::datasources::fuse_table::meta::table_snapshot::Stats;
+use crate::datasources::fuse_table::table::FuseTable;
+use crate::datasources::fuse_table::util;
+use crate::sessions::DatafuseQueryContextRef;
+
+pub type BlockStream =
+    std::pin::Pin<Box<dyn futures::stream::Stream<Item = DataBlock> + Sync + Send + 'static>>;
+
+impl<T> FuseTable<T>
+where T: MetaApi + Send + Sync + 'static
+{
+    pub async fn append_blocks(
+        &self,
+        ctx: DatafuseQueryContextRef,
+        mut stream: BlockStream,
+    ) -> Result<SegmentInfo> {
+        let mut blocks = vec![];
+        let mut block_stats = vec![];
+
+        let mut summary_row_count = 0u64;
+        let mut summary_block_count = 0u64;
+        let mut summary_uncompressed_byte_size = 0u64;
+        let mut summary_compressed_byte_size = 0u64;
+
+        while let Some(block) = stream.next().await {
+            let schema = block.schema().to_arrow();
+
+            // 1. At present, for each block, we create a parquet
+            let buffer = write_in_memory(&schema, block)?;
+            let block_size = buffer.len() as u64;
+
+            // 2. extract statistics
+            // TODO : read it again? we need some love from parquet2
+            let mut cursor = Cursor::new(buffer);
+            let parquet_meta = read_metadata(&mut cursor)?;
+            let row_count = parquet_meta.num_rows as u64;
+
+            // We arrange exactly one row group, and one page insides the parquet file
+            let rg_meta = &parquet_meta.row_groups[0];
+
+            //let compressed_size = rg_meta.compressed_size() as u64;
+            //let total_byte_size = rg_meta.total_byte_size() as u64;
+
+            let mut col_dyn_stats = HashMap::new();
+            for (id, item) in rg_meta.columns().iter().enumerate() {
+                let col_id = id as u32; // fake id, TODO mapping to real column id
+                col_dyn_stats.insert(col_id, item.statistics().unwrap().unwrap().clone());
+            }
+
+            let part_uuid = Uuid::new_v4().to_simple().to_string() + ".parquet";
+            let location = format!("_t/{}", part_uuid);
+            // TODO, we need some love from parquet2 (accumulate size and stats while writing)
+            let meta_size = 0u64;
+
+            let col_stats = col_dyn_stats
+                .iter()
+                .map(|(id, stats)| {
+                    let s = serialize_statistics(stats.as_ref());
+                    (*id, ColStats {
+                        min: s.min_value,
+                        max: s.max_value,
+                        null_count: s.null_count.map(|v| v as u64),
+                    })
+                })
+                .collect::<HashMap<_, _>>();
+
+            let block_info = BlockMeta {
+                location: BlockLocation {
+                    location: location.clone(),
+                    meta_size,
+                },
+                row_count,
+                block_size,
+                col_stats,
+            };
+
+            blocks.push(block_info);
+
+            summary_block_count += 1;
+            summary_row_count += row_count;
+            summary_compressed_byte_size += block_size;
+            summary_uncompressed_byte_size += rg_meta.total_byte_size() as u64;
+            block_stats.push(col_dyn_stats);
+
+            // write to storage
+            self.data_accessor(&ctx)?
+                .put(&location, cursor.into_inner())
+                .await?;
+        }
+
+        let summary = reduce(block_stats);
+
+        let mut res = HashMap::new();
+        for (col, col_stats) in summary {
+            match col_stats {
+                Ok(Some(stats)) => {
+                    let s = serialize_statistics(stats.as_ref());
+                    let c = ColStats {
+                        min: s.min_value,
+                        max: s.max_value,
+                        null_count: s.null_count.map(|v| v as u64),
+                    };
+                    res.insert(col, c);
+                }
+                _ => todo!(),
+            }
+        }
+
+        let segment_info = SegmentInfo {
+            blocks,
+            summary: Stats {
+                row_count: summary_row_count,
+                block_count: summary_block_count,
+                uncompressed_byte_size: summary_uncompressed_byte_size,
+                compressed_byte_size: summary_compressed_byte_size,
+                col_stats: res,
+            },
+        };
+        Ok(segment_info)
+    }
+}
+
+pub(crate) fn write_in_memory(arrow_schema: &ArrowSchema, block: DataBlock) -> Result<Vec<u8>> {
+    // TODO pick proper compression / encoding algos
+    let options = WriteOptions {
+        write_statistics: true,
+        compression: Compression::Uncompressed,
+        version: Version::V2,
+    };
+    use std::iter::repeat;
+    let encodings: Vec<_> = repeat(Encoding::Plain).take(block.num_columns()).collect();
+
+    let memory_size = block.memory_size();
+    let batch = RecordBatch::try_from(block)?;
+    let iter = vec![Ok(batch)];
+    let row_groups = RowGroupIterator::try_new(iter.into_iter(), arrow_schema, options, encodings)?;
+    let writer = Vec::with_capacity(memory_size);
+    let mut cursor = Cursor::new(writer);
+    let parquet_schema = row_groups.parquet_schema().clone();
+    write_file(
+        &mut cursor,
+        row_groups,
+        arrow_schema,
+        parquet_schema,
+        options,
+        None,
+    )?;
+
+    Ok(cursor.into_inner())
+}
+
+fn reduce(
+    block_stats: Vec<HashMap<u32, Arc<dyn ParquetStats>>>,
+) -> HashMap<u32, Result<Option<Arc<dyn ParquetStats>>>> {
+    // accumulate stats by column
+    let col_stat_list = block_stats.iter().fold(HashMap::new(), |acc, item| {
+        item.iter().fold(
+            acc,
+            |mut acc: HashMap<u32, Vec<Arc<dyn ParquetStats>>>, (col_id, stats)| {
+                let entry = acc.entry(*col_id);
+                entry
+                    .and_modify(|v| v.push(stats.clone()))
+                    .or_insert_with(|| vec![stats.clone()]);
+                acc
+            },
+        )
+    });
+
+    // for each col, reduce the vector of statistics
+    col_stat_list
+        .iter()
+        .map(|(col_id, stat_list)| {
+            let reduced = util::stats_aggregation::reduce(stat_list.as_slice()).map_err(|e| {
+                ErrorCode::UnknownException(format!("TODO from parquet error, {}", e))
+            });
+            (*col_id, reduced)
+        })
+        .collect::<HashMap<u32, Result<Option<Arc<dyn ParquetStats>>>>>()
+}

--- a/query/src/datasources/fuse_table/io/block_reader.rs
+++ b/query/src/datasources/fuse_table/io/block_reader.rs
@@ -1,0 +1,123 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_arrow::arrow::datatypes::Schema as ArrowSchema;
+use common_arrow::arrow::io::parquet::read::decompress;
+use common_arrow::arrow::io::parquet::read::page_stream_to_array;
+use common_arrow::arrow::io::parquet::read::read_metadata_async;
+use common_arrow::parquet::read::get_page_stream;
+use common_cache::LruCache;
+use common_dal::DataAccessor;
+use common_datablocks::DataBlock;
+use common_datavalues::columns::DataColumn;
+use common_datavalues::prelude::IntoSeries;
+use common_datavalues::DataSchema;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_infallible::Mutex;
+use common_planners::Part;
+use common_runtime::tokio::sync::mpsc::Sender;
+use futures::StreamExt;
+
+use crate::datasources::fuse_table::util::location_gen::block_info_location;
+
+#[derive(PartialEq, Eq, Hash)]
+pub struct BlockMetaCacheKey {
+    block_id: String,
+}
+
+#[derive(PartialEq, Eq, Hash)]
+pub struct BlockColKey {
+    block_id: String,
+    col_id: u32,
+}
+
+pub type BlockColCache = Arc<Mutex<LruCache<BlockColKey, Vec<u8>>>>;
+pub type BlockMetaCache = Arc<Mutex<LruCache<BlockMetaCacheKey, Vec<u8>>>>;
+
+#[allow(dead_code)]
+pub struct BlockReader {
+    meta_cache: BlockMetaCache,
+    block_col_cache: BlockColCache,
+    data_accessor: Arc<dyn DataAccessor>,
+}
+
+#[allow(dead_code)]
+impl BlockReader {
+    pub async fn read_block(
+        &self,
+        _part: Part,
+        _data_accessor: Arc<dyn DataAccessor>,
+        _projection: Vec<usize>,
+        _sender: Sender<Result<DataBlock>>,
+        _arrow_schema: ArrowSchema,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(crate) async fn read_part(
+    part: Part,
+    data_accessor: Arc<dyn DataAccessor>,
+    projection: Vec<usize>,
+    sender: Sender<Result<DataBlock>>,
+    arrow_schema: &ArrowSchema,
+) -> Result<()> {
+    let loc = block_info_location(&part.name);
+    // TODO pass in parquet file len
+    let mut reader = data_accessor.get_input_stream(&loc, None).await?;
+    let metadata = read_metadata_async(&mut reader)
+        .await
+        .map_err(|e| ErrorCode::ParquetError(e.to_string()))?;
+
+    // only onw page in the the parquet
+    let row_group = 0;
+    let cols = projection
+        .iter()
+        .map(|idx| (metadata.row_groups[row_group].column(*idx), *idx));
+
+    let fields = arrow_schema.fields();
+    let mut arrays: Vec<Arc<dyn common_arrow::arrow::array::Array>> = vec![];
+    for (col_meta, idx) in cols {
+        // NOTE: here the page filter is !Send
+        let pages = get_page_stream(col_meta, &mut reader, vec![], Arc::new(|_, _| true))
+            .await
+            .map_err(|e| ErrorCode::ParquetError(e.to_string()))?;
+        let pages = pages.map(|compressed_page| decompress(compressed_page?, &mut vec![]));
+        // QUOTE(from arrow2): deserialize the pages. This is CPU bounded and SHOULD be done in a dedicated thread pool (e.g. Rayon)
+        let array = page_stream_to_array(
+            pages,
+            &metadata.row_groups[0].columns()[idx],
+            fields[idx].data_type.clone(),
+        )
+        .await?;
+        arrays.push(array.into());
+    }
+
+    let ser = arrays
+        .into_iter()
+        .map(|a| DataColumn::Array(a.into_series()))
+        .collect::<Vec<_>>();
+
+    let block = DataBlock::create(Arc::new(DataSchema::from(arrow_schema)), ser);
+    sender
+        .send(Ok(block))
+        .await
+        .map_err(|e| ErrorCode::BrokenChannel(e.to_string()))?;
+
+    Ok(())
+}

--- a/query/src/datasources/fuse_table/io/mod.rs
+++ b/query/src/datasources/fuse_table/io/mod.rs
@@ -11,7 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
-pub use arrow;
-pub use arrow_flight;
-pub use parquet2 as parquet;
+// consider remove these, read_util seems to be enough (type could be inferred)
+pub(crate) mod segment_reader;
+pub(crate) mod snapshot_reader;
+// end
+
+mod reader_util;
+
+pub(crate) mod block_appender;
+pub(crate) mod block_reader;

--- a/query/src/datasources/fuse_table/io/reader_util.rs
+++ b/query/src/datasources/fuse_table/io/reader_util.rs
@@ -1,0 +1,77 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+use std::sync::mpsc::channel;
+use std::sync::Arc;
+
+use common_dal::DataAccessor;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use futures::AsyncReadExt;
+use serde::de::DeserializeOwned;
+
+use crate::sessions::DatafuseQueryContextRef;
+
+pub fn do_read(
+    da: Arc<dyn DataAccessor>,
+    ctx: &DatafuseQueryContextRef,
+    loc: &str,
+) -> Result<Vec<u8>> {
+    let (tx, rx) = channel();
+    let location = loc.to_string();
+    ctx.execute_task(async move {
+        let input_stream = da.get_input_stream(&location, None);
+        match input_stream.await {
+            Ok(mut input) => {
+                let mut buffer = vec![];
+                // TODO send this error
+                input.read_to_end(&mut buffer).await?;
+                let _ = tx.send(Ok(buffer));
+            }
+            Err(e) => {
+                let _ = tx.send(Err(e));
+            }
+        }
+        Ok::<(), ErrorCode>(())
+    })?;
+
+    // TODO error code
+    rx.recv().map_err(ErrorCode::from_std_error)?
+}
+
+pub fn do_read_obj<T: DeserializeOwned>(
+    da: Arc<dyn DataAccessor>,
+    ctx: &DatafuseQueryContextRef,
+    loc: &str,
+) -> Result<T> {
+    let bytes = do_read(da, ctx, loc)?;
+    let r = serde_json::from_slice::<T>(&bytes)?;
+    Ok(r)
+}
+
+pub async fn do_read_async(da: Arc<dyn DataAccessor>, location: &str) -> Result<Vec<u8>> {
+    let mut input_stream = da.get_input_stream(location, None).await?;
+    let mut buffer = vec![];
+    input_stream.read_to_end(&mut buffer).await?;
+    Ok(buffer)
+}
+
+pub async fn do_read_obj_async<T: DeserializeOwned>(
+    da: Arc<dyn DataAccessor>,
+    loc: &str,
+) -> Result<T> {
+    let bytes = do_read_async(da, loc).await?;
+    let r = serde_json::from_slice::<T>(&bytes)?;
+    Ok(r)
+}

--- a/query/src/datasources/fuse_table/io/segment_reader.rs
+++ b/query/src/datasources/fuse_table/io/segment_reader.rs
@@ -1,0 +1,38 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_dal::DataAccessor;
+use common_exception::Result;
+
+use crate::datasources::fuse_table::io::reader_util::do_read_obj;
+use crate::datasources::fuse_table::io::reader_util::do_read_obj_async;
+use crate::datasources::fuse_table::meta::table_snapshot::SegmentInfo;
+use crate::sessions::DatafuseQueryContextRef;
+
+#[allow(dead_code)]
+pub fn read_segment(
+    da: Arc<dyn DataAccessor>,
+    ctx: &DatafuseQueryContextRef,
+    loc: &str,
+) -> Result<SegmentInfo> {
+    do_read_obj(da, ctx, loc)
+}
+
+#[allow(dead_code)]
+pub async fn read_segment_async(da: Arc<dyn DataAccessor>, loc: &str) -> Result<SegmentInfo> {
+    do_read_obj_async(da, loc).await
+}

--- a/query/src/datasources/fuse_table/io/snapshot_reader.rs
+++ b/query/src/datasources/fuse_table/io/snapshot_reader.rs
@@ -1,0 +1,40 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_dal::DataAccessor;
+use common_exception::Result;
+
+use crate::datasources::fuse_table::io::reader_util::do_read_obj;
+use crate::datasources::fuse_table::io::reader_util::do_read_obj_async;
+use crate::datasources::fuse_table::meta::table_snapshot::TableSnapshot;
+use crate::sessions::DatafuseQueryContextRef;
+
+pub fn read_table_snapshot(
+    da: Arc<dyn DataAccessor>,
+    ctx: &DatafuseQueryContextRef,
+    loc: &str,
+) -> Result<TableSnapshot> {
+    do_read_obj(da, ctx, loc)
+}
+
+#[allow(dead_code)]
+pub async fn read_table_snapshot_async(
+    da: Arc<dyn DataAccessor>,
+    loc: &str,
+) -> Result<TableSnapshot> {
+    do_read_obj_async(da, loc).await
+}

--- a/query/src/datasources/fuse_table/meta/meta_info_reader.rs
+++ b/query/src/datasources/fuse_table/meta/meta_info_reader.rs
@@ -1,0 +1,61 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::sync::Arc;
+
+use common_arrow::parquet::read::read_metadata;
+use common_dal::DataAccessor;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+use crate::datasources::fuse_table::io::segment_reader::read_segment;
+use crate::datasources::fuse_table::meta::table_snapshot::RawBlockStats;
+use crate::datasources::fuse_table::meta::table_snapshot::SegmentInfo;
+use crate::sessions::DatafuseQueryContextRef;
+
+// TODO cache
+pub struct MetaInfoReader {
+    da: Arc<dyn DataAccessor>,
+    ctx: DatafuseQueryContextRef,
+}
+
+impl MetaInfoReader {
+    pub fn new(da: Arc<dyn DataAccessor>, ctx: DatafuseQueryContextRef) -> Self {
+        MetaInfoReader { da, ctx }
+    }
+}
+
+impl MetaInfoReader {
+    #[allow(dead_code)]
+    // this method is called by Table::read_plan, which is sync
+    pub fn read_block_statistics(&self, location: &str) -> Result<RawBlockStats> {
+        let mut reader = self.da.get_reader(location, None)?;
+        let file_meta = read_metadata(&mut reader).map_err(ErrorCode::from_std_error)?; // TODO
+                                                                                        // one row group only
+        let cols = file_meta.row_groups[0].columns();
+        let mut res = std::collections::HashMap::new();
+        for (id, x) in cols.iter().enumerate() {
+            let s = x.statistics();
+            if let Some(Ok(stats)) = s {
+                res.insert(id as u32, stats);
+            }
+        }
+        Ok(res)
+    }
+    #[allow(dead_code)]
+    pub fn read_segment_info(&self, location: &str) -> Result<SegmentInfo> {
+        read_segment(self.da.clone(), &self.ctx, location)
+    }
+}

--- a/query/src/datasources/fuse_table/meta/mod.rs
+++ b/query/src/datasources/fuse_table/meta/mod.rs
@@ -13,11 +13,5 @@
 //  limitations under the License.
 //
 
-mod blob_accessor;
-mod impls;
-
-pub use blob_accessor::Bytes;
-pub use blob_accessor::DataAccessor;
-pub use impls::Local;
-pub use impls::StorageScheme;
-pub use impls::S3;
+pub mod meta_info_reader;
+pub mod table_snapshot;

--- a/query/src/datasources/fuse_table/meta/table_snapshot.rs
+++ b/query/src/datasources/fuse_table/meta/table_snapshot.rs
@@ -1,0 +1,90 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::collections::HashMap;
+
+use common_arrow::parquet::statistics::Statistics;
+use common_datavalues::DataSchema;
+use uuid::Uuid;
+
+pub type Bytes = Vec<u8>;
+pub type SnapshotId = Uuid;
+pub type ColumnId = u32;
+pub type Location = String;
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct TableSnapshot {
+    pub snapshot_id: SnapshotId,
+    pub prev_snapshot_id: Option<SnapshotId>,
+    /// For each snapshot, we keep a schema for it (in case of schema evolution)
+    pub schema: DataSchema,
+    /// Summary Statistics
+    pub summary: Stats,
+    /// Pointers to SegmentInfos
+    ///
+    /// We rely on background merge tasks to keep merging segments, so that
+    /// this the size of this vector could be kept reasonable
+    pub segments: Vec<Location>,
+}
+
+impl TableSnapshot {
+    pub fn new() -> Self {
+        todo!()
+    }
+}
+
+/// A segment comprised of one or more blocks
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct SegmentInfo {
+    pub blocks: Vec<BlockMeta>,
+    pub summary: Stats,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct Stats {
+    pub row_count: u64,
+    pub block_count: u64,
+    pub uncompressed_byte_size: u64,
+    pub compressed_byte_size: u64,
+    pub col_stats: HashMap<ColumnId, ColStats>,
+}
+
+/// Meta information of a block (currently, the parquet file)
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct BlockMeta {
+    /// Pointer of the data Block
+    pub row_count: u64,
+    pub block_size: u64,
+    pub col_stats: HashMap<ColumnId, ColStats>,
+    pub location: BlockLocation,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct BlockLocation {
+    pub location: Location,
+    // for parquet, this filed can be used to fetch the meta data without seeking around
+    pub meta_size: u64,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct ColStats {
+    pub min: Option<Bytes>,
+    pub max: Option<Bytes>,
+    pub null_count: Option<u64>,
+    // - bloom(RF?)
+}
+
+#[allow(dead_code)]
+pub type RawBlockStats = HashMap<u32, std::sync::Arc<dyn Statistics>>;

--- a/query/src/datasources/fuse_table/mod.rs
+++ b/query/src/datasources/fuse_table/mod.rs
@@ -13,11 +13,9 @@
 //  limitations under the License.
 //
 
-mod blob_accessor;
-mod impls;
+mod io;
+mod meta;
+mod table;
+mod util;
 
-pub use blob_accessor::Bytes;
-pub use blob_accessor::DataAccessor;
-pub use impls::Local;
-pub use impls::StorageScheme;
-pub use impls::S3;
+pub use table::FuseTable;

--- a/query/src/datasources/fuse_table/table.rs
+++ b/query/src/datasources/fuse_table/table.rs
@@ -1,0 +1,317 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::any::Any;
+use std::sync::Arc;
+
+use common_dal::DataAccessor;
+use common_datavalues::DataSchemaRef;
+use common_exception::ErrorCode;
+use common_exception::Result;
+use common_flights::StoreClient;
+use common_planners::InsertIntoPlan;
+use common_planners::Partitions;
+use common_planners::ReadDataSourcePlan;
+use common_planners::ScanPlan;
+use common_planners::Statistics;
+use common_planners::TableOptions;
+use common_planners::TruncateTablePlan;
+use common_store_api::MetaApi;
+use common_streams::ProgressStream;
+use common_streams::SendableDataBlockStream;
+use tokio_stream::wrappers::ReceiverStream;
+use uuid::Uuid;
+
+use crate::catalogs::Table;
+use crate::datasources::fuse_table::io::block_reader::read_part;
+use crate::datasources::fuse_table::io::snapshot_reader::read_table_snapshot;
+use crate::datasources::fuse_table::meta::meta_info_reader::MetaInfoReader;
+use crate::datasources::fuse_table::meta::table_snapshot::BlockLocation;
+use crate::datasources::fuse_table::meta::table_snapshot::SegmentInfo;
+use crate::datasources::fuse_table::meta::table_snapshot::TableSnapshot;
+use crate::datasources::fuse_table::util::index_helpers;
+use crate::datasources::fuse_table::util::location_gen::segment_info_location;
+use crate::datasources::fuse_table::util::location_gen::snapshot_location;
+use crate::datasources::fuse_table::util::projection_helper::project_col_idx;
+use crate::datasources::fuse_table::util::storage_scheme_helper::parse_storage_scheme;
+use crate::datasources::fuse_table::util::storage_scheme_helper::TableStorageScheme;
+use crate::sessions::DatafuseQueryContextRef;
+
+pub struct FuseTable<T = StoreClient> {
+    pub db: String,
+    pub name: String,
+    pub schema: DataSchemaRef,
+    // Storage scheme is fixed during the whole life of the table
+    // Local | FuseDFS | S3 | ... etc.
+    pub storage_scheme: TableStorageScheme,
+    pub meta_client: T,
+    pub local: bool,
+}
+
+impl<T> FuseTable<T> {
+    pub(crate) async fn save_segment(
+        &self,
+        location: &str,
+        data_accessor: &Arc<dyn DataAccessor>,
+        segment_info: SegmentInfo,
+    ) -> Result<()> {
+        let bytes = serde_json::to_vec(&segment_info)?;
+        data_accessor.put(location, bytes).await
+    }
+    pub(crate) async fn save_snapshot(
+        &self,
+        location: &str,
+        data_accessor: &Arc<dyn DataAccessor>,
+        snapshot: TableSnapshot,
+    ) -> Result<()> {
+        let bytes = serde_json::to_vec(&snapshot)?;
+        data_accessor.put(location, bytes).await
+    }
+    pub(crate) fn merge_seg(&self, new_seg: String, mut prev: TableSnapshot) -> TableSnapshot {
+        prev.segments.push(new_seg);
+        let new_id = Uuid::new_v4();
+        prev.snapshot_id = new_id;
+        prev
+    }
+}
+
+impl<T> FuseTable<T>
+where T: MetaApi + Send + Sync + 'static
+{
+    pub fn try_create(
+        db: String,
+        name: String,
+        schema: DataSchemaRef,
+        options: TableOptions,
+        meta_client: T,
+    ) -> Result<Box<dyn Table>> {
+        let storage_scheme = parse_storage_scheme(options.get("STORAGE_SCHEME"))?;
+        let res = FuseTable {
+            db,
+            name,
+            schema,
+            storage_scheme,
+            meta_client,
+            local: true,
+        };
+
+        Ok(Box::new(res))
+    }
+}
+
+#[async_trait::async_trait]
+impl<T> Table for FuseTable<T>
+where T: MetaApi + Send + Sync + 'static
+{
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn engine(&self) -> &str {
+        "fuse"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> Result<DataSchemaRef> {
+        Ok(self.schema.clone())
+    }
+
+    fn is_local(&self) -> bool {
+        self.local
+    }
+
+    fn read_plan(
+        &self,
+        ctx: DatafuseQueryContextRef,
+        scan: &ScanPlan,
+        _partitions: usize,
+    ) -> Result<ReadDataSourcePlan> {
+        // primary work to do: partition pruning/elimination
+        let tbl_snapshot = self.table_snapshot(&ctx)?;
+        if let Some(snapshot) = tbl_snapshot {
+            let da = self.data_accessor(&ctx)?;
+            let meta_reader = MetaInfoReader::new(da, ctx.clone());
+            let block_locations =
+                index_helpers::range_filter(&snapshot, &scan.push_downs, meta_reader)?;
+            let (statistics, parts) = self.to_partitions(&block_locations);
+            let plan = ReadDataSourcePlan {
+                db: scan.schema_name.clone(),
+                table: self.name().to_string(),
+                table_id: scan.table_id,
+                table_version: scan.table_version,
+                schema: self.schema()?,
+                parts,
+                statistics,
+                description: "".to_string(),
+                scan_plan: Arc::new(scan.clone()),
+                remote: true,
+            };
+            Ok(plan)
+        } else {
+            self.empty_read_source_plan(scan)
+        }
+    }
+
+    async fn read(
+        &self,
+        ctx: DatafuseQueryContextRef,
+        source_plan: &ReadDataSourcePlan,
+    ) -> Result<SendableDataBlockStream> {
+        let projection = project_col_idx(
+            &source_plan.scan_plan.table_schema,
+            &source_plan.scan_plan.projected_schema,
+        )?;
+
+        let (tx, rx) = common_runtime::tokio::sync::mpsc::channel(1024);
+
+        let bite_size = 1; // TODO config
+        let mut iter = {
+            let ctx = ctx.clone();
+            std::iter::from_fn(move || match ctx.clone().try_get_partitions(bite_size) {
+                Err(_) => None,
+                Ok(parts) if parts.is_empty() => None,
+                Ok(parts) => Some(parts),
+            })
+            .flatten()
+        };
+        let da = self.data_accessor(&ctx)?;
+        let arrow_schema = source_plan.scan_plan.table_schema.to_arrow();
+        let _h = common_runtime::tokio::task::spawn_local(async move {
+            // TODO error handling is buggy
+            for part in &mut iter {
+                read_part(
+                    part,
+                    da.clone(),
+                    projection.clone(),
+                    tx.clone(),
+                    &arrow_schema,
+                )
+                .await?;
+            }
+            Ok::<(), ErrorCode>(())
+        });
+
+        let progress_callback = ctx.progress_callback()?;
+        let receiver = ReceiverStream::new(rx);
+        let stream = ProgressStream::try_create(Box::pin(receiver), progress_callback)?;
+        Ok(Box::pin(stream))
+    }
+
+    async fn append_data(
+        &self,
+        ctx: DatafuseQueryContextRef,
+        insert_plan: InsertIntoPlan,
+    ) -> Result<()> {
+        // 1. take out input stream from plan
+        //    Assumes that, insert_interpreter has already split data into blocks properly
+        let block_stream = {
+            match insert_plan.input_stream.lock().take() {
+                Some(s) => s,
+                None => return Err(ErrorCode::EmptyData("input stream consumed")),
+            }
+        };
+
+        let data_accessor = self.data_accessor(&ctx)?;
+
+        // 2. Append blocks to storage
+        let segment_info = self.append_blocks(ctx.clone(), block_stream).await?;
+        let seg_loc = {
+            let uuid = Uuid::new_v4().to_simple().to_string();
+            segment_info_location(&uuid)
+        };
+        self.save_segment(&seg_loc, &data_accessor, segment_info)
+            .await?;
+
+        // 3. new snapshot
+        let tbl_snapshot = self
+            .table_snapshot(&ctx)?
+            .unwrap_or_else(TableSnapshot::new);
+        let snapshot_id = tbl_snapshot.snapshot_id;
+        let new_snapshot: TableSnapshot = self.merge_seg(seg_loc, tbl_snapshot);
+        let new_snapshot_id = new_snapshot.snapshot_id;
+
+        let snapshot_loc = {
+            let uuid = Uuid::new_v4().to_simple().to_string();
+            snapshot_location(&uuid)
+        };
+
+        self.save_snapshot(&snapshot_loc, &data_accessor, new_snapshot)
+            .await?;
+
+        // 4. commit
+        let table_id = insert_plan.tbl_id;
+        // TODO simple retry strategy
+        self.meta_client
+            .commit_table(
+                table_id,
+                snapshot_id.to_simple().to_string(),
+                new_snapshot_id.to_simple().to_string(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn truncate(
+        &self,
+        _ctx: DatafuseQueryContextRef,
+        _truncate_plan: TruncateTablePlan,
+    ) -> Result<()> {
+        todo!()
+    }
+}
+
+impl<T> FuseTable<T>
+where T: MetaApi + Sync + Send + 'static
+{
+    fn table_snapshot(&self, ctx: &DatafuseQueryContextRef) -> Result<Option<TableSnapshot>> {
+        let schema = self.schema()?;
+        if let Some(loc) = schema.meta().get("META_SNAPSHOT_LOCATION") {
+            let r = read_table_snapshot(self.data_accessor(ctx)?, ctx, loc)?;
+            Ok(Some(r))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(crate) fn empty_read_source_plan(&self, scan: &ScanPlan) -> Result<ReadDataSourcePlan> {
+        Ok(ReadDataSourcePlan {
+            db: scan.schema_name.clone(),
+            table: self.name().to_string(),
+            table_id: scan.table_id,
+            table_version: scan.table_version,
+            schema: self.schema()?,
+            parts: vec![],
+            statistics: Statistics::default(),
+            description: "".to_string(),
+            scan_plan: Arc::new(scan.clone()),
+            remote: true,
+        })
+    }
+
+    pub(crate) fn to_partitions(&self, _blocs: &[BlockLocation]) -> (Statistics, Partitions) {
+        todo!()
+    }
+
+    pub(crate) fn data_accessor(
+        &self,
+        ctx: &DatafuseQueryContextRef,
+    ) -> Result<Arc<dyn DataAccessor>> {
+        let scheme = &self.storage_scheme;
+        ctx.get_data_accessor(scheme)
+    }
+}

--- a/query/src/datasources/fuse_table/util/index_helpers.rs
+++ b/query/src/datasources/fuse_table/util/index_helpers.rs
@@ -1,0 +1,72 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use common_exception::Result;
+use common_planners::Extras;
+
+use crate::datasources::fuse_table::meta::meta_info_reader::MetaInfoReader;
+use crate::datasources::fuse_table::meta::table_snapshot::BlockLocation;
+use crate::datasources::fuse_table::meta::table_snapshot::TableSnapshot;
+
+// Imaginary api , tobe polished (heavily)
+
+struct TableSparseIndex {}
+struct CacheMgr;
+
+// non-distributed indexing
+impl TableSparseIndex {
+    pub fn load(
+        _table_snapshot: &TableSnapshot,
+        _meta_reader: &MetaInfoReader,
+        _cache_mgr: &CacheMgr,
+    ) -> Result<Self> {
+        // load index, which may be cached (or partially cached)
+        todo!()
+    }
+
+    // Returns an iterator or stream would be better
+    // let's begin with
+    pub fn apply(&self, _expression: &Extras) -> Result<Vec<BlockLocation>> {
+        // prunes blocks
+        todo!()
+    }
+}
+
+pub fn range_filter(
+    table_snapshot: &TableSnapshot,
+    push_down: &Extras,
+    // MetaInfoReader takes care of caching itself
+    meta_reader: MetaInfoReader,
+) -> Result<Vec<BlockLocation>> {
+    let cache_mgr = CacheMgr; // TODO passed in from context
+    let range_index = TableSparseIndex::load(table_snapshot, &meta_reader, &cache_mgr)?;
+    range_index.apply(push_down)
+
+    /*
+    for seg_loc in &table_snapshot.segments {
+        // TODO filter by seg.summary
+        let seg = meta_reader.read_segment_info(seg_loc)?;
+        let _seg_summary = &seg.summary;
+        for x in seg.blocks {
+            // filter by block_meta's ColStats if necessary
+            let _col_stats = &x.col_stats;
+            // keep the block we are fond of
+            res.push(x);
+        }
+    }
+
+    Ok(res)
+    */
+}

--- a/query/src/datasources/fuse_table/util/location_gen.rs
+++ b/query/src/datasources/fuse_table/util/location_gen.rs
@@ -13,11 +13,14 @@
 //  limitations under the License.
 //
 
-mod blob_accessor;
-mod impls;
+pub fn block_info_location(name: &str) -> String {
+    format!("_b/{}", name)
+}
 
-pub use blob_accessor::Bytes;
-pub use blob_accessor::DataAccessor;
-pub use impls::Local;
-pub use impls::StorageScheme;
-pub use impls::S3;
+pub fn segment_info_location(name: &str) -> String {
+    format!("_sg/{}", name)
+}
+
+pub fn snapshot_location(name: &str) -> String {
+    format!("_ss/{}", name)
+}

--- a/query/src/datasources/fuse_table/util/mod.rs
+++ b/query/src/datasources/fuse_table/util/mod.rs
@@ -13,11 +13,12 @@
 //  limitations under the License.
 //
 
-mod blob_accessor;
-mod impls;
+pub mod index_helpers;
+pub mod location_gen;
+pub mod projection_helper;
 
-pub use blob_accessor::Bytes;
-pub use blob_accessor::DataAccessor;
-pub use impls::Local;
-pub use impls::StorageScheme;
-pub use impls::S3;
+// copied from parquet2,
+pub mod stats_aggregation;
+pub mod storage_scheme_helper;
+
+pub use projection_helper::project_col_idx;

--- a/query/src/datasources/fuse_table/util/projection_helper.rs
+++ b/query/src/datasources/fuse_table/util/projection_helper.rs
@@ -1,0 +1,49 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use std::collections::HashMap;
+
+use common_datavalues::DataSchemaRef;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+/// Note: assuming table attribute will NOT be renamed.
+/// which is not realistic, we should have column_id for each relation attribute.  
+#[allow(dead_code)]
+pub fn project_col_idx(schema: &DataSchemaRef, projection: &DataSchemaRef) -> Result<Vec<usize>> {
+    let col_map = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .fold(HashMap::new(), |mut v, (i, item)| {
+            v.insert(item.name().to_string(), i);
+            v
+        });
+
+    let mut proj_idx = vec![];
+
+    for col in projection.fields() {
+        let name = col.name();
+        if let Some(idx) = col_map.get(col.name()) {
+            proj_idx.push(*idx)
+        } else {
+            return Err(ErrorCode::IllegalSchema(format!(
+                "column [{}] specified in projection, but does not exist in schema",
+                name
+            )));
+        }
+    }
+    Ok(proj_idx)
+}

--- a/query/src/datasources/fuse_table/util/stats_aggregation.rs
+++ b/query/src/datasources/fuse_table/util/stats_aggregation.rs
@@ -1,0 +1,179 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+// NOTE: COPIED from parquet2
+
+use std::sync::Arc;
+
+use common_arrow::parquet::error::ParquetError;
+use common_arrow::parquet::error::Result;
+use common_arrow::parquet::schema::types::PhysicalType;
+use common_arrow::parquet::statistics::*;
+use common_arrow::parquet::types::NativeType;
+
+pub fn reduce(stats: &[Arc<dyn Statistics>]) -> Result<Option<Arc<dyn Statistics>>> {
+    if stats.is_empty() {
+        return Ok(None);
+    }
+    let same_type = stats
+        .iter()
+        .skip(1)
+        .all(|x| x.physical_type() == stats[0].physical_type());
+    if !same_type {
+        return Err(ParquetError::OutOfSpec(
+            "The statistics do not have the same data_type".to_string(),
+        ));
+    };
+    Ok(match stats[0].physical_type() {
+        PhysicalType::Boolean => {
+            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
+            Some(Arc::new(reduce_boolean(stats)))
+        }
+        PhysicalType::Int32 => {
+            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
+            Some(Arc::new(reduce_primitive::<i32, _>(stats)))
+        }
+        PhysicalType::Int64 => {
+            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
+            Some(Arc::new(reduce_primitive::<i64, _>(stats)))
+        }
+        PhysicalType::Float => {
+            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
+            Some(Arc::new(reduce_primitive::<f32, _>(stats)))
+        }
+        PhysicalType::Double => {
+            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
+            Some(Arc::new(reduce_primitive::<f64, _>(stats)))
+        }
+        PhysicalType::ByteArray => {
+            let stats = stats.iter().map(|x| x.as_any().downcast_ref().unwrap());
+            Some(Arc::new(reduce_binary(stats)))
+        }
+        _ => todo!(),
+    })
+}
+
+#[allow(dead_code)]
+fn reduce_binary<'a, I: Iterator<Item = &'a BinaryStatistics>>(mut stats: I) -> BinaryStatistics {
+    let initial = stats.next().unwrap().clone();
+    stats.fold(initial, |mut acc, new| {
+        acc.min_value = match (acc.min_value, &new.min_value) {
+            (None, None) => None,
+            (Some(x), None) => Some(x),
+            (None, Some(x)) => Some(x.clone()),
+            (Some(x), Some(y)) => Some(ord_binary(x, y.clone(), false)),
+        };
+        acc.max_value = match (acc.max_value, &new.max_value) {
+            (None, None) => None,
+            (Some(x), None) => Some(x),
+            (None, Some(x)) => Some(x.clone()),
+            (Some(x), Some(y)) => Some(ord_binary(x, y.clone(), true)),
+        };
+        acc.null_count = match (acc.null_count, &new.null_count) {
+            (None, None) => None,
+            (Some(x), None) => Some(x),
+            (None, Some(x)) => Some(*x),
+            (Some(x), Some(y)) => Some(x + *y),
+        };
+        acc.distinct_count = None;
+        acc
+    })
+}
+
+#[allow(dead_code)]
+fn ord_binary(a: Vec<u8>, b: Vec<u8>, max: bool) -> Vec<u8> {
+    for (v1, v2) in a.iter().zip(b.iter()) {
+        match v1.cmp(v2) {
+            std::cmp::Ordering::Greater => {
+                if max {
+                    return a;
+                } else {
+                    return b;
+                }
+            }
+            std::cmp::Ordering::Less => {
+                if max {
+                    return b;
+                } else {
+                    return a;
+                }
+            }
+            _ => {}
+        }
+    }
+    a
+}
+
+#[allow(dead_code)]
+fn reduce_boolean<'a, I: Iterator<Item = &'a BooleanStatistics>>(
+    mut stats: I,
+) -> BooleanStatistics {
+    let initial = stats.next().unwrap().clone();
+    stats.fold(initial, |mut acc, new| {
+        acc.min_value = match (acc.min_value, &new.min_value) {
+            (None, None) => None,
+            (Some(x), None) => Some(x),
+            (None, Some(x)) => Some(*x),
+            (Some(x), Some(y)) => Some(if x & !(*y) { *y } else { x }),
+        };
+        acc.max_value = match (acc.max_value, &new.max_value) {
+            (None, None) => None,
+            (Some(x), None) => Some(x),
+            (None, Some(x)) => Some(*x),
+            (Some(x), Some(y)) => Some(if x & !(*y) { x } else { *y }),
+        };
+        acc.null_count = match (acc.null_count, &new.null_count) {
+            (None, None) => None,
+            (Some(x), None) => Some(x),
+            (None, Some(x)) => Some(*x),
+            (Some(x), Some(y)) => Some(x + *y),
+        };
+        acc.distinct_count = None;
+        acc
+    })
+}
+
+#[allow(dead_code)]
+fn reduce_primitive<
+    'a,
+    T: NativeType + std::cmp::PartialOrd,
+    I: Iterator<Item = &'a PrimitiveStatistics<T>>,
+>(
+    mut stats: I,
+) -> PrimitiveStatistics<T> {
+    let initial = stats.next().unwrap().clone();
+    stats.fold(initial, |mut acc, new| {
+        acc.min_value = match (acc.min_value, &new.min_value) {
+            (None, None) => None,
+            (Some(x), None) => Some(x),
+            (None, Some(x)) => Some(*x),
+            (Some(x), Some(y)) => Some(if x > *y { *y } else { x }),
+        };
+        acc.max_value = match (acc.max_value, &new.max_value) {
+            (None, None) => None,
+            (Some(x), None) => Some(x),
+            (None, Some(x)) => Some(*x),
+            (Some(x), Some(y)) => Some(if x < *y { x } else { *y }),
+        };
+        acc.null_count = match (acc.null_count, &new.null_count) {
+            (None, None) => None,
+            (Some(x), None) => Some(x),
+            (None, Some(x)) => Some(*x),
+            (Some(x), Some(y)) => Some(x + *y),
+        };
+        acc.distinct_count = None;
+        acc
+    })
+}

--- a/query/src/datasources/fuse_table/util/storage_scheme_helper.rs
+++ b/query/src/datasources/fuse_table/util/storage_scheme_helper.rs
@@ -1,0 +1,36 @@
+//  Copyright 2021 Datafuse Labs.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+use common_dal::StorageScheme;
+use common_exception::ErrorCode;
+use common_exception::Result;
+
+pub type TableStorageScheme = StorageScheme;
+
+pub fn parse_storage_scheme(value: Option<&String>) -> Result<StorageScheme> {
+    if let Some(v) = value {
+        let v = v.to_uppercase();
+        match v.as_str() {
+            "LOCAL_FS" | "LOCAL" => Ok(TableStorageScheme::LocalFs),
+            "FuseDfs" => Ok(TableStorageScheme::FuseDfs),
+            "S3" => Ok(TableStorageScheme::S3),
+            _ => Err(ErrorCode::IllegalSchema(format!("unknown scheme {}", v))),
+        }
+    } else {
+        Err(ErrorCode::IllegalSchema(
+            "invalid table option for Fuse Table, no Storage Scheme provided",
+        ))
+    }
+}

--- a/query/src/datasources/local/local_meta_backend.rs
+++ b/query/src/datasources/local/local_meta_backend.rs
@@ -17,6 +17,13 @@ use std::sync::Arc;
 
 use common_exception::ErrorCode;
 use common_exception::Result;
+use common_flights::meta_api_impl::CreateDatabaseActionResult;
+use common_flights::meta_api_impl::CreateTableActionResult;
+use common_flights::meta_api_impl::DatabaseMetaReply;
+use common_flights::meta_api_impl::DropDatabaseActionResult;
+use common_flights::meta_api_impl::DropTableActionResult;
+use common_flights::meta_api_impl::GetDatabaseActionResult;
+use common_flights::meta_api_impl::GetTableActionResult;
 use common_infallible::RwLock;
 use common_metatypes::MetaId;
 use common_metatypes::MetaVersion;
@@ -24,11 +31,14 @@ use common_planners::CreateDatabasePlan;
 use common_planners::CreateTablePlan;
 use common_planners::DropDatabasePlan;
 use common_planners::DropTablePlan;
+use common_store_api::CommitTableReply;
+use common_store_api::MetaApi;
 
 use crate::catalogs::impls::LOCAL_TBL_ID_BEGIN;
 use crate::catalogs::Database;
 use crate::catalogs::InMemoryMetas;
 use crate::catalogs::TableMeta;
+use crate::datasources::fuse_table::FuseTable;
 use crate::datasources::local::CsvTable;
 use crate::datasources::local::LocalDatabase;
 use crate::datasources::local::MemoryTable;
@@ -146,6 +156,9 @@ impl MetaBackend for LocalMetaBackend {
             "CSV" => CsvTable::try_create(plan.db, plan.table, plan.schema, plan.options)?,
             "NULL" => NullTable::try_create(plan.db, plan.table, plan.schema, plan.options)?,
             "MEMORY" => MemoryTable::try_create(plan.db, plan.table, plan.schema, plan.options)?,
+            "FUSE_LOCAL" => {
+                FuseTable::try_create(plan.db, plan.table, plan.schema, plan.options, self.clone())?
+            }
             _ => {
                 return Result::Err(ErrorCode::UnImplement(format!(
                     "Local database does not support '{:?}' table engine, table engine must be one of Parquet, JSONEachRow, Null, Memory or CSV",
@@ -290,5 +303,56 @@ impl MetaBackend for LocalMetaBackend {
         }
         self.databases.write().remove(db_name);
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl MetaApi for LocalMetaBackend {
+    async fn create_database(
+        &mut self,
+        _plan: CreateDatabasePlan,
+    ) -> Result<CreateDatabaseActionResult> {
+        todo!()
+    }
+
+    async fn get_database(&mut self, _db: &str) -> Result<GetDatabaseActionResult> {
+        todo!()
+    }
+
+    async fn drop_database(&mut self, _plan: DropDatabasePlan) -> Result<DropDatabaseActionResult> {
+        todo!()
+    }
+
+    async fn create_table(&mut self, _plan: CreateTablePlan) -> Result<CreateTableActionResult> {
+        todo!()
+    }
+
+    async fn drop_table(&mut self, _plan: DropTablePlan) -> Result<DropTableActionResult> {
+        todo!()
+    }
+
+    async fn get_table(&mut self, _db: String, _table: String) -> Result<GetTableActionResult> {
+        todo!()
+    }
+
+    async fn get_table_ext(
+        &mut self,
+        _table_id: MetaId,
+        _db_ver: Option<MetaVersion>,
+    ) -> Result<GetTableActionResult> {
+        todo!()
+    }
+
+    async fn get_database_meta(&mut self, _current_ver: Option<u64>) -> Result<DatabaseMetaReply> {
+        todo!()
+    }
+
+    async fn commit_table(
+        &self,
+        _table_id: MetaId,
+        _prev_snapshot: String,
+        _new_snapshot: String,
+    ) -> Result<CommitTableReply> {
+        todo!()
     }
 }

--- a/query/src/datasources/local/memory_table_test.rs
+++ b/query/src/datasources/local/memory_table_test.rs
@@ -55,6 +55,7 @@ async fn test_memorytable() -> Result<()> {
         let insert_plan = InsertIntoPlan {
             db_name: "default".to_string(),
             tbl_name: "a".to_string(),
+            tbl_id: 0,
             schema: schema,
             input_stream: Arc::new(Mutex::new(Some(Box::pin(input_stream)))),
         };

--- a/query/src/datasources/local/null_table_test.rs
+++ b/query/src/datasources/local/null_table_test.rs
@@ -50,6 +50,7 @@ async fn test_null_table() -> Result<()> {
         let insert_plan = InsertIntoPlan {
             db_name: "default".to_string(),
             tbl_name: "a".to_string(),
+            tbl_id: 0,
             schema: schema.clone(),
             input_stream: Arc::new(Mutex::new(Some(Box::pin(input_stream)))),
         };

--- a/query/src/datasources/mod.rs
+++ b/query/src/datasources/mod.rs
@@ -21,6 +21,7 @@ mod common;
 mod meta_backend;
 
 pub(crate) mod example;
+mod fuse_table;
 pub(crate) mod local;
 pub(crate) mod remote;
 pub(crate) mod system;

--- a/query/src/sessions/context.rs
+++ b/query/src/sessions/context.rs
@@ -18,6 +18,10 @@ use std::sync::atomic::Ordering;
 use std::sync::atomic::Ordering::Acquire;
 use std::sync::Arc;
 
+use common_dal::DataAccessor;
+use common_dal::Local;
+use common_dal::StorageScheme;
+use common_dal::S3;
 use common_exception::ErrorCode;
 use common_exception::Result;
 use common_infallible::RwLock;
@@ -223,6 +227,17 @@ impl DatafuseQueryContext {
 
     pub fn get_sessions_manager(self: &Arc<Self>) -> SessionManagerRef {
         self.shared.session.get_sessions_manager()
+    }
+
+    pub fn get_data_accessor(
+        &self,
+        storage_scheme: &StorageScheme,
+    ) -> Result<Arc<dyn DataAccessor>> {
+        match storage_scheme {
+            StorageScheme::S3 => Ok(Arc::new(S3::fake_new())),
+            StorageScheme::LocalFs => Ok(Arc::new(Local::new("/tmp"))),
+            _ => todo!(),
+        }
     }
 }
 

--- a/query/src/sql/plan_parser.rs
+++ b/query/src/sql/plan_parser.rs
@@ -435,6 +435,7 @@ impl PlanParser {
         let table = self.ctx.get_catalog().get_table(&db_name, &tbl_name)?;
 
         let mut schema = table.raw().schema()?;
+        let tbl_id = table.meta_id();
 
         if !columns.is_empty() {
             let fields = columns
@@ -470,6 +471,7 @@ impl PlanParser {
         let plan_node = InsertIntoPlan {
             db_name,
             tbl_name,
+            tbl_id,
             schema,
             input_stream: Arc::new(Mutex::new(Some(Box::pin(input_stream)))),
         };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Initial work for:

- Save table partition/statistics  data into object storage
- First step of integrating DAL/Cache layers


The remaining jobs will be split in other PRs

## Changelog


- Improvement


## Related Issues

Fixes #issue

## Test Plan

Unit Tests

Stateless Tests

