### PR TITLE
CLI: ignore the datafuse cli codecov, it mainly use integration test

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -17,3 +17,4 @@ ignore:
   - "*/profiling/*"
   - "*/tracing/*"
   - "*/api/http/debug/*"
+  - "*/cli/*"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

ignore the datafuse cli codecov

## Changelog


- Build/Testing/CI


## Related Issues

Fixes N/A

## Test Plan

Unit Tests

Stateless Tests

