### PR TITLE
CI: ignore the datafuse cli code coverage

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -18,3 +18,4 @@ ignore:
   - "*/tracing/*"
   - "*/api/http/debug/*"
   - "*/datasources/example/*"
+  - "*/cli/*"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

ignore the datafuse cli code coverage

## Changelog

- Build/Testing/CI


## Related Issues

Fixes N/A

## Test Plan

Unit Tests

Stateless Tests

