### PR TITLE
Delete Intermediate files generated by `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ profile:
 
 clean:
 	cargo clean
+	rm -f ./nohup.out ./tests/suites/0_stateless/*.stdout-e
+	rm -rf ./_local_fs/ ./_meta/ ./_logs/ ./common/stoppable/_logs/ ./query/_logs/ ./store/_logs/
 
 docker_release:
 	docker buildx build . -f ./docker/release/Dockerfile  --platform ${PLATFORM} --allow network.host --builder host -t ${HUB}/datafuse:${TAG} --build-arg version=$VERSION --push


### PR DESCRIPTION
Signed-off-by: jyz0309 <45495947@qq.com>

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Delete Intermediate files generated by `make test`, which are not deleted by `make clean`

## Changelog

- Improvement

## Related Issues

Fixes #1668 

## Test Plan

Unit Tests

Stateless Tests

