### PR TITLE
[store] feature: add flight action API update_kv_meta() that only update the value meta, e.g. the expire time, leaving the value as is.

### DIFF
--- a/common/flights/src/impls/kv_api_impl.rs
+++ b/common/flights/src/impls/kv_api_impl.rs
@@ -46,6 +46,20 @@ impl KVApi for StoreClient {
         .await
     }
 
+    async fn update_kv_meta(
+        &mut self,
+        key: &str,
+        seq: MatchSeq,
+        value_meta: Option<KVMeta>,
+    ) -> Result<UpsertKVActionResult> {
+        self.do_action(KVMetaAction {
+            key: key.to_string(),
+            seq,
+            value_meta,
+        })
+        .await
+    }
+
     #[tracing::instrument(level = "debug", skip(self))]
     async fn get_kv(&mut self, key: &str) -> Result<GetKVActionResult> {
         self.do_action(GetKVAction {
@@ -128,4 +142,17 @@ action_declare!(
     UpsertKVAction,
     UpsertKVActionResult,
     StoreDoAction::UpsertKV
+);
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct KVMetaAction {
+    pub key: String,
+    pub seq: MatchSeq,
+    pub value_meta: Option<KVMeta>,
+}
+
+action_declare!(
+    KVMetaAction,
+    UpsertKVActionResult,
+    StoreDoAction::UpdateKVMeta
 );

--- a/common/flights/src/store_do_action.rs
+++ b/common/flights/src/store_do_action.rs
@@ -21,6 +21,7 @@ use prost::Message;
 use tonic::Request;
 
 use crate::impls::kv_api_impl::GetKVAction;
+use crate::impls::kv_api_impl::KVMetaAction;
 use crate::impls::kv_api_impl::MGetKVAction;
 use crate::impls::kv_api_impl::PrefixListReq;
 use crate::impls::kv_api_impl::UpsertKVAction;
@@ -72,6 +73,7 @@ pub enum StoreDoAction {
 
     // general purpose kv
     UpsertKV(UpsertKVAction),
+    UpdateKVMeta(KVMetaAction),
     GetKV(GetKVAction),
     MGetKV(MGetKVAction),
     PrefixListKV(PrefixListReq),

--- a/common/management/src/namespace/namespace_mgr_test.rs
+++ b/common/management/src/namespace/namespace_mgr_test.rs
@@ -46,11 +46,18 @@ mock! {
             value_meta: Option<KVMeta>
         ) -> Result<UpsertKVActionResult>;
 
-    async fn get_kv(&mut self, key: &str) -> Result<GetKVActionResult>;
+        async fn update_kv_meta(
+            &mut self,
+            key: &str,
+            seq: MatchSeq,
+            value_meta: Option<KVMeta>
+        ) -> Result<UpsertKVActionResult>;
 
-    async fn mget_kv(&mut self,key: &[String],) -> Result<MGetKVActionResult>;
+        async fn get_kv(&mut self, key: &str) -> Result<GetKVActionResult>;
 
-    async fn prefix_list_kv(&mut self, prefix: &str) -> Result<PrefixListReply>;
+        async fn mget_kv(&mut self,key: &[String],) -> Result<MGetKVActionResult>;
+
+        async fn prefix_list_kv(&mut self, prefix: &str) -> Result<PrefixListReply>;
     }
 }
 

--- a/common/management/src/user/user_mgr_test.rs
+++ b/common/management/src/user/user_mgr_test.rs
@@ -47,15 +47,22 @@ mock! {
             value_meta: Option<KVMeta>
         ) -> common_exception::Result<UpsertKVActionResult>;
 
-    async fn get_kv(&mut self, key: &str) -> common_exception::Result<GetKVActionResult>;
+        async fn update_kv_meta(
+            &mut self,
+            key: &str,
+            seq: MatchSeq,
+            value_meta: Option<KVMeta>
+        ) -> common_exception::Result<UpsertKVActionResult>;
 
-    async fn mget_kv(
-        &mut self,
-        key: &[String],
-    ) -> common_exception::Result<MGetKVActionResult>;
+        async fn get_kv(&mut self, key: &str) -> common_exception::Result<GetKVActionResult>;
 
-    async fn prefix_list_kv(&mut self, prefix: &str) -> common_exception::Result<PrefixListReply>;
-    }
+        async fn mget_kv(
+            &mut self,
+            key: &[String],
+        ) -> common_exception::Result<MGetKVActionResult>;
+
+        async fn prefix_list_kv(&mut self, prefix: &str) -> common_exception::Result<PrefixListReply>;
+        }
 }
 #[test]
 fn test_user_info_converter() {

--- a/common/metatypes/src/lib.rs
+++ b/common/metatypes/src/lib.rs
@@ -18,6 +18,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
+use std::fmt::Debug;
 use std::fmt::Formatter;
 
 pub use errors::ConflictSeq;
@@ -105,3 +106,22 @@ impl fmt::Display for Table {
 
 pub type MetaVersion = u64;
 pub type MetaId = u64;
+
+/// An operation that updates a field, delete it, or leave it as is.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum Operation<T> {
+    Update(T),
+    Delete,
+    AsIs,
+}
+
+impl<T> From<Option<T>> for Operation<T>
+where for<'x> T: Serialize + Deserialize<'x> + Debug + Clone
+{
+    fn from(v: Option<T>) -> Self {
+        match v {
+            None => Operation::Delete,
+            Some(x) => Operation::Update(x),
+        }
+    }
+}

--- a/common/store-api/src/kv_api.rs
+++ b/common/store-api/src/kv_api.rs
@@ -49,6 +49,13 @@ pub trait KVApi {
         value_meta: Option<KVMeta>,
     ) -> common_exception::Result<UpsertKVActionResult>;
 
+    async fn update_kv_meta(
+        &mut self,
+        key: &str,
+        seq: MatchSeq,
+        value_meta: Option<KVMeta>,
+    ) -> common_exception::Result<UpsertKVActionResult>;
+
     async fn get_kv(&mut self, key: &str) -> common_exception::Result<GetKVActionResult>;
 
     // mockall complains about AsRef... so we use String here

--- a/store/src/executor/action_handler.rs
+++ b/store/src/executor/action_handler.rs
@@ -112,6 +112,7 @@ impl ActionHandler {
 
             // general-purpose kv
             StoreDoAction::UpsertKV(a) => s.serialize(self.handle(a).await?),
+            StoreDoAction::UpdateKVMeta(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::GetKV(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::MGetKV(a) => s.serialize(self.handle(a).await?),
             StoreDoAction::PrefixListKV(a) => s.serialize(self.handle(a).await?),

--- a/store/src/meta_service/cmd.rs
+++ b/store/src/meta_service/cmd.rs
@@ -18,6 +18,7 @@ use async_raft::NodeId;
 use common_metatypes::Database;
 use common_metatypes::KVMeta;
 use common_metatypes::MatchSeq;
+use common_metatypes::Operation;
 use common_metatypes::Table;
 use serde::Deserialize;
 use serde::Serialize;
@@ -86,11 +87,12 @@ pub enum Cmd {
         seq: MatchSeq,
 
         /// The value to set. A `None` indicates to delete it.
-        value: Option<Vec<u8>>,
+        value: Operation<Vec<u8>>,
 
         /// Meta data of a value.
         value_meta: Option<KVMeta>,
     },
+
     /// Truncate Table
     TruncateTable { db_name: String, table_name: String },
 }

--- a/store/src/meta_service/raftmeta_test.rs
+++ b/store/src/meta_service/raftmeta_test.rs
@@ -424,7 +424,7 @@ async fn test_meta_node_snapshot_replication() -> anyhow::Result<()> {
             cmd: Cmd::UpsertKV {
                 key: key.clone(),
                 seq: MatchSeq::Any,
-                value: Some(b"v".to_vec()),
+                value: Some(b"v".to_vec()).into(),
                 value_meta: None,
             },
         })

--- a/store/src/meta_service/testing.rs
+++ b/store/src/meta_service/testing.rs
@@ -19,6 +19,7 @@ use async_raft::raft::EntryPayload;
 use async_raft::raft::MembershipConfig;
 use async_raft::LogId;
 use common_metatypes::MatchSeq;
+use common_metatypes::Operation;
 use maplit::btreeset;
 use sled::IVec;
 
@@ -46,7 +47,7 @@ pub fn snapshot_logs() -> (Vec<Entry<LogEntry>>, Vec<String>) {
                     cmd: Cmd::UpsertKV {
                         key: "a".to_string(),
                         seq: MatchSeq::Any,
-                        value: Some(b"A".to_vec()),
+                        value: Operation::Update(b"A".to_vec()),
                         value_meta: None,
                     },
                 },


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [store] feature: add flight action API update_kv_meta() that only update the value meta, e.g. the expire time, leaving the value as is.

## Changelog

- New Feature





## Related Issues

- #271
- #1080

fix: #1402
fix: #1426 