### PR TITLE
Improvement:  Date/DateTime toYYYYMM function

### DIFF
--- a/common/functions/src/scalars/dates/date.rs
+++ b/common/functions/src/scalars/dates/date.rs
@@ -15,7 +15,7 @@
 use common_exception::Result;
 
 use super::now::NowFunction;
-use super::ToYYYYFunction;
+use super::ToYYYYMMFunction;
 use super::TodayFunction;
 use super::TomorrowFunction;
 use super::YesterdayFunction;
@@ -31,7 +31,7 @@ impl DateFunction {
         map.insert("yesterday".into(), YesterdayFunction::try_create);
         map.insert("tomorrow".into(), TomorrowFunction::try_create);
         map.insert("now".into(), NowFunction::try_create);
-        map.insert("toYYYYMM".into(), ToYYYYFunction::try_create);
+        map.insert("toYYYYMM".into(), ToYYYYMMFunction::try_create);
 
         Ok(())
     }

--- a/common/functions/src/scalars/dates/date_function_test.rs
+++ b/common/functions/src/scalars/dates/date_function_test.rs
@@ -22,7 +22,7 @@ use crate::scalars::ToYYYYMMFunction;
 #[test]
 fn test_toyyyymm_date16_function() -> Result<()> {
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date16, false)]);
-    let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![0u32])]);
+    let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![0u16])]);
 
     {
         let col = ToYYYYMMFunction::try_create("a")?;
@@ -43,7 +43,7 @@ fn test_toyyyymm_date16_function() -> Result<()> {
 
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date16, false)]);
     let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![
-        0u32, 1u32, 2u32, 3u32,
+        0u16, 0u16, 0u16, 0u16,
     ])]);
 
     {
@@ -92,7 +92,7 @@ fn test_toyyyymm_date32_function() -> Result<()> {
         assert_eq!(actual, &expected);
     }
 
-    let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date16, false)]);
+    let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date32, false)]);
     let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![
         0u32, 1u32, 2u32, 3u32,
     ])]);
@@ -143,7 +143,7 @@ fn test_toyyyymm_date_time_function() -> Result<()> {
         assert_eq!(actual, &expected);
     }
 
-    let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date16, false)]);
+    let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::DateTime32, false)]);
     let block = DataBlock::create_by_array(schema.clone(), vec![Series::new(vec![
         0u32, 1u32, 2u32, 3u32,
     ])]);
@@ -166,6 +166,80 @@ fn test_toyyyymm_date_time_function() -> Result<()> {
             .as_slice()
             .to_vec();
         assert_eq!(vec![197001u32, 197001u32, 197001u32, 197001u32], actual_ref);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_toyyyymm_constant_function() -> Result<()> {
+    // date16
+    let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date16, false)]);
+    let block = DataBlock::create(schema.clone(), vec![DataColumn::Constant(
+        DataValue::UInt16(Some(0u16)),
+        1,
+    )]);
+    {
+        let col = ToYYYYMMFunction::try_create("a")?;
+        let columns = vec![DataColumnWithField::new(
+            block.try_column_by_name("a")?.clone(),
+            schema.field_with_name("a")?.clone(),
+        )];
+        let result = col.eval(&columns, block.num_rows())?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.data_type(), DataType::UInt32);
+
+        let actual_ref = result.get_array_ref().unwrap();
+        let actual = actual_ref.as_any().downcast_ref::<UInt32Array>().unwrap();
+        let expected = UInt32Array::from_slice([197001; 1]);
+
+        assert_eq!(actual, &expected);
+    }
+
+    // date32
+    let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date32, false)]);
+    let block = DataBlock::create(schema.clone(), vec![DataColumn::Constant(
+        DataValue::UInt32(Some(0u32)),
+        1,
+    )]);
+    {
+        let col = ToYYYYMMFunction::try_create("a")?;
+        let columns = vec![DataColumnWithField::new(
+            block.try_column_by_name("a")?.clone(),
+            schema.field_with_name("a")?.clone(),
+        )];
+        let result = col.eval(&columns, block.num_rows())?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.data_type(), DataType::UInt32);
+
+        let actual_ref = result.get_array_ref().unwrap();
+        let actual = actual_ref.as_any().downcast_ref::<UInt32Array>().unwrap();
+        let expected = UInt32Array::from_slice([197001; 1]);
+
+        assert_eq!(actual, &expected);
+    }
+
+    // datetime
+    let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::DateTime32, false)]);
+    let block = DataBlock::create(schema.clone(), vec![DataColumn::Constant(
+        DataValue::UInt32(Some(0u32)),
+        1,
+    )]);
+    {
+        let col = ToYYYYMMFunction::try_create("a")?;
+        let columns = vec![DataColumnWithField::new(
+            block.try_column_by_name("a")?.clone(),
+            schema.field_with_name("a")?.clone(),
+        )];
+        let result = col.eval(&columns, block.num_rows())?;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.data_type(), DataType::UInt32);
+
+        let actual_ref = result.get_array_ref().unwrap();
+        let actual = actual_ref.as_any().downcast_ref::<UInt32Array>().unwrap();
+        let expected = UInt32Array::from_slice([197001; 1]);
+
+        assert_eq!(actual, &expected);
     }
 
     Ok(())

--- a/common/functions/src/scalars/dates/date_function_test.rs
+++ b/common/functions/src/scalars/dates/date_function_test.rs
@@ -177,7 +177,7 @@ fn test_toyyyymm_constant_function() -> Result<()> {
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date16, false)]);
     let block = DataBlock::create(schema.clone(), vec![DataColumn::Constant(
         DataValue::UInt16(Some(0u16)),
-        1,
+        5,
     )]);
     {
         let col = ToYYYYMMFunction::try_create("a")?;
@@ -186,12 +186,12 @@ fn test_toyyyymm_constant_function() -> Result<()> {
             schema.field_with_name("a")?.clone(),
         )];
         let result = col.eval(&columns, block.num_rows())?;
-        assert_eq!(result.len(), 1);
+        assert_eq!(result.len(), 5);
         assert_eq!(result.data_type(), DataType::UInt32);
 
         let actual_ref = result.get_array_ref().unwrap();
         let actual = actual_ref.as_any().downcast_ref::<UInt32Array>().unwrap();
-        let expected = UInt32Array::from_slice([197001; 1]);
+        let expected = UInt32Array::from_slice([197001; 5]);
 
         assert_eq!(actual, &expected);
     }
@@ -200,7 +200,7 @@ fn test_toyyyymm_constant_function() -> Result<()> {
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::Date32, false)]);
     let block = DataBlock::create(schema.clone(), vec![DataColumn::Constant(
         DataValue::UInt32(Some(0u32)),
-        1,
+        10,
     )]);
     {
         let col = ToYYYYMMFunction::try_create("a")?;
@@ -209,12 +209,12 @@ fn test_toyyyymm_constant_function() -> Result<()> {
             schema.field_with_name("a")?.clone(),
         )];
         let result = col.eval(&columns, block.num_rows())?;
-        assert_eq!(result.len(), 1);
+        assert_eq!(result.len(), 10);
         assert_eq!(result.data_type(), DataType::UInt32);
 
         let actual_ref = result.get_array_ref().unwrap();
         let actual = actual_ref.as_any().downcast_ref::<UInt32Array>().unwrap();
-        let expected = UInt32Array::from_slice([197001; 1]);
+        let expected = UInt32Array::from_slice([197001; 10]);
 
         assert_eq!(actual, &expected);
     }
@@ -223,7 +223,7 @@ fn test_toyyyymm_constant_function() -> Result<()> {
     let schema = DataSchemaRefExt::create(vec![DataField::new("a", DataType::DateTime32, false)]);
     let block = DataBlock::create(schema.clone(), vec![DataColumn::Constant(
         DataValue::UInt32(Some(0u32)),
-        1,
+        15,
     )]);
     {
         let col = ToYYYYMMFunction::try_create("a")?;
@@ -232,12 +232,12 @@ fn test_toyyyymm_constant_function() -> Result<()> {
             schema.field_with_name("a")?.clone(),
         )];
         let result = col.eval(&columns, block.num_rows())?;
-        assert_eq!(result.len(), 1);
+        assert_eq!(result.len(), 15);
         assert_eq!(result.data_type(), DataType::UInt32);
 
         let actual_ref = result.get_array_ref().unwrap();
         let actual = actual_ref.as_any().downcast_ref::<UInt32Array>().unwrap();
-        let expected = UInt32Array::from_slice([197001; 1]);
+        let expected = UInt32Array::from_slice([197001; 15]);
 
         assert_eq!(actual, &expected);
     }

--- a/common/functions/src/scalars/dates/mod.rs
+++ b/common/functions/src/scalars/dates/mod.rs
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 mod date;
+#[cfg(test)]
+mod date_function_test;
 mod now;
 mod number_function;
 mod simple_date;
 
 pub use date::DateFunction;
-pub use number_function::ToYYYYFunction;
+pub use number_function::ToYYYYMMFunction;
 pub use simple_date::TodayFunction;
 pub use simple_date::TomorrowFunction;
 pub use simple_date::YesterdayFunction;

--- a/common/functions/src/scalars/dates/number_function.rs
+++ b/common/functions/src/scalars/dates/number_function.rs
@@ -15,7 +15,6 @@
 use std::fmt;
 use std::marker::PhantomData;
 
-use common_datavalues::arrays::DFUInt32Array;
 use common_datavalues::chrono::DateTime;
 use common_datavalues::chrono::Datelike;
 use common_datavalues::chrono::TimeZone;
@@ -77,12 +76,12 @@ where T: NumberResultFunction + Clone + Sync + Send + 'static
 
     fn eval(&self, columns: &DataColumnsWithField, input_rows: usize) -> Result<DataColumn> {
         let data_type = columns[0].data_type();
-        let number_array: DFUInt32Array = match data_type {
+        let number_array: DataColumn = match data_type {
             DataType::Date16 => {
                 if let DataColumn::Constant(v, _) = columns[0].column() {
                     let date_time = Utc.timestamp(v.as_u64().unwrap() as i64 * 24 * 3600, 0_u32);
-                    let number_result = Some(T::execute(date_time));
-                    Ok(DFUInt32Array::from_iter(vec![number_result; input_rows]))
+                    let constant_result = Some(T::execute(date_time));
+                    Ok(DataColumn::Constant(DataValue::UInt32(constant_result), input_rows))
                 }else {
                     let result = columns[0].column()
                         .to_array()?
@@ -92,14 +91,14 @@ where T: NumberResultFunction + Clone + Sync + Send + 'static
                             T::execute(date_time)
                         }
                     );
-                    Ok(result)
+                    Ok(result.into())
                 }
             },
             DataType::Date32 => {
                 if let DataColumn::Constant(v, _) = columns[0].column() {
                     let date_time = Utc.timestamp(v.as_u64().unwrap() as i64 * 24 * 3600, 0_u32);
-                    let number_result = Some(T::execute(date_time));
-                    Ok(DFUInt32Array::from_iter(vec![number_result; input_rows]))
+                    let constant_result = Some(T::execute(date_time));
+                    Ok(DataColumn::Constant(DataValue::UInt32(constant_result), input_rows))
                 }else {
                     let result = columns[0].column()
                         .to_array()?
@@ -109,14 +108,14 @@ where T: NumberResultFunction + Clone + Sync + Send + 'static
                             T::execute(date_time)
                         }
                     );
-                    Ok(result)
+                    Ok(result.into())
                 }
             },
             DataType::DateTime32 => {
                 if let DataColumn::Constant(v, _) = columns[0].column() {
                     let date_time = Utc.timestamp(v.as_u64().unwrap() as i64, 0_u32);
-                    let number_result = Some(T::execute(date_time));
-                    Ok(DFUInt32Array::from_iter(vec![number_result; input_rows]))
+                    let constant_result = Some(T::execute(date_time));
+                    Ok(DataColumn::Constant(DataValue::UInt32(constant_result), input_rows))
                 }else {
                     let result = columns[0].column()
                         .to_array()?
@@ -126,14 +125,14 @@ where T: NumberResultFunction + Clone + Sync + Send + 'static
                             T::execute(date_time)
                         }
                     );
-                    Ok(result)
+                    Ok(result.into())
                 }
             },
             other => Result::Err(ErrorCode::IllegalDataType(format!(
                "Illegal type {:?} of argument of function toYYYYMM.Should be a date16/data32 or a dateTime32",
                 other))),
         }?;
-        Ok(number_array.into())
+        Ok(number_array)
     }
 }
 

--- a/common/functions/src/scalars/dates/number_function.rs
+++ b/common/functions/src/scalars/dates/number_function.rs
@@ -85,7 +85,11 @@ where T: NumberResultFunction + Clone + Sync + Send + 'static
         let data_type = columns[0].data_type();
         let number_vec: Vec<Option<u32>> = match data_type {
             DataType::Date16 => {
-                let number_vec_result = columns[0].column().to_array()?.u16()?.iter().map(|value|{
+                let number_vec_result = columns[0].column()
+                .to_array()?
+                .u16()?
+                .iter()
+                .map(|value|{
                     match value {
                         Some(v) => {
                             let date_time = Utc.timestamp(*v as i64 * 24 * 3600, 0_u32);
@@ -97,7 +101,11 @@ where T: NumberResultFunction + Clone + Sync + Send + 'static
                 Ok(number_vec_result)
             },
             DataType::Date32 => {
-                let number_vec_result = columns[0].column().to_array()?.u32()?.iter().map(|value|{
+                let number_vec_result = columns[0].column()
+                .to_array()?
+                .u32()?
+                .iter()
+                .map(|value|{
                     match value {
                         Some(v) => {
                             let date_time = Utc.timestamp(*v as i64 * 24 * 3600, 0_u32);
@@ -109,7 +117,11 @@ where T: NumberResultFunction + Clone + Sync + Send + 'static
                 Ok(number_vec_result)
             },
             DataType::DateTime32 => {
-                let number_vec_result = columns[0].column().to_array()?.u32()?.iter().map(|value|{
+                let number_vec_result = columns[0].column()
+                .to_array()?
+                .u32()?
+                .iter()
+                .map(|value|{
                     match value {
                         Some(v) => {
                             let date_time = Utc.timestamp(*v as i64, 0_u32);
@@ -134,4 +146,4 @@ impl<T> fmt::Display for NumberFunction<T> {
     }
 }
 
-pub type ToYYYYFunction = NumberFunction<ToYYYYMM>;
+pub type ToYYYYMMFunction = NumberFunction<ToYYYYMM>;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Summary about this PR
1. fix toYYYYMM function unit tests.
2. using apply_cast_numeric instead iter.
3. constant path improvement.

## Changelog

- Improvement

## Related Issues

Fixes #853 

## Test Plan

Unit Tests

Stateless Tests

