### PR TITLE
[common/management] feature: add LocalKVStore: a KVApi impl backed with a sled tree, for testing purpose mainly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,10 +882,14 @@ dependencies = [
  "common-metatypes",
  "common-runtime",
  "common-store-api",
+ "common-tracing",
+ "datafuse-store",
+ "lazy_static",
  "mockall",
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]

--- a/common/management/Cargo.toml
+++ b/common/management/Cargo.toml
@@ -14,8 +14,13 @@ edition = "2021"
 common-exception= {path = "../exception"}
 common-metatypes= {path = "../metatypes"}
 common-store-api= {path = "../store-api"}
+common-tracing= {path = "../tracing"}
+
+datafuse-store = {path= "../../store"}
 
 async-trait = "0.1"
+tempfile = "3.2.0"
+lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9.6"

--- a/common/management/src/namespace/local_kv_store.rs
+++ b/common/management/src/namespace/local_kv_store.rs
@@ -1,0 +1,163 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+
+use async_trait::async_trait;
+use common_exception::Result;
+use common_metatypes::KVMeta;
+use common_metatypes::MatchSeq;
+use common_metatypes::Operation;
+use common_store_api::kv_api::MGetKVActionResult;
+use common_store_api::GetKVActionResult;
+use common_store_api::KVApi;
+use common_store_api::PrefixListReply;
+use common_store_api::UpsertKVActionResult;
+use common_tracing::tracing;
+use datafuse_store::configs;
+use datafuse_store::meta_service::AppliedState;
+use datafuse_store::meta_service::Cmd;
+use datafuse_store::meta_service::LogEntry;
+use datafuse_store::meta_service::StateMachine;
+
+/// Local storage that provides the API defined by `KVApi`.
+/// It is just a wrapped `StateMachine`, which is the same one used by raft driven meta-store service.
+/// For a local store, there is no distributed WAL involved,
+/// thus it just bypasses the raft log and operate directly on the `StateMachine`.
+///
+/// Since `StateMachine` is backed with sled::Tree, this impl has the same limitation as meta-store:
+/// - A sled::Db has to be a singleton, according to sled doc.
+/// - Every unit test has to generate a unique sled::Tree name to create a `LocalKVStore`.
+pub struct LocalKVStore {
+    inner: StateMachine,
+}
+
+impl LocalKVStore {
+    /// Creates a KVApi impl backed with a `StateMachine`.
+    ///
+    /// A LocalKVStore is identified by the `name`.
+    /// Caveat: Two instances with the same `name` reference to the same underlying sled::Tree.
+    ///
+    /// One of the following has to be called to initialize a process-wise sled::Db,
+    /// before using `LocalKVStore`:
+    /// - `datafuse_store::meta_service::raft_db::init_sled_db`
+    /// - `datafuse_store::meta_service::raft_db::init_temp_sled_db`
+    #[allow(dead_code)]
+    pub async fn new(name: &str) -> common_exception::Result<LocalKVStore> {
+        let mut config = configs::Config::empty();
+
+        config.sled_tree_prefix = format!("{}-local-kv-store", name);
+
+        if cfg!(target_os = "macos") {
+            tracing::warn!("Disabled fsync for meta data tests. fsync on mac is quite slow");
+            config.meta_no_sync = true;
+        }
+
+        Ok(LocalKVStore {
+            // StateMachine does not need to be replaced, thus we always use id=0
+            inner: StateMachine::open(&config, 0).await?,
+        })
+    }
+
+    /// Creates a KVApi impl with a random and unique name.
+    /// For use in testing, one should:
+    /// - call `datafuse_store::meta_service::raft_db::init_temp_sled_db()` to
+    ///   initialize sled::Db so that persistent data is cleaned up when process exits.
+    /// - create a unique LocalKVStore with this function.
+    ///
+    #[allow(dead_code)]
+    pub async fn new_temp() -> common_exception::Result<LocalKVStore> {
+        // generate a unique id as part of the name of sled::Tree
+
+        static GLOBAL_SEQ: AtomicUsize = AtomicUsize::new(0);
+        let x = GLOBAL_SEQ.fetch_add(1, Ordering::SeqCst);
+        let id = 29000_u64 + (x as u64);
+
+        let name = format!("temp-{}", id);
+
+        Self::new(&name).await
+    }
+}
+
+#[async_trait]
+impl KVApi for LocalKVStore {
+    async fn upsert_kv(
+        &mut self,
+        key: &str,
+        seq: MatchSeq,
+        value: Option<Vec<u8>>,
+        value_meta: Option<KVMeta>,
+    ) -> Result<UpsertKVActionResult> {
+        let cmd = Cmd::UpsertKV {
+            key: key.to_string(),
+            seq,
+            value: value.into(),
+            value_meta,
+        };
+
+        let res = self
+            .inner
+            .apply_non_dup(&LogEntry { txid: None, cmd })
+            .await?;
+
+        match res {
+            AppliedState::KV { prev, result } => Ok(UpsertKVActionResult { prev, result }),
+            _ => {
+                panic!("expect AppliedState::KV");
+            }
+        }
+    }
+
+    async fn update_kv_meta(
+        &mut self,
+        key: &str,
+        seq: MatchSeq,
+        value_meta: Option<KVMeta>,
+    ) -> Result<UpsertKVActionResult> {
+        let cmd = Cmd::UpsertKV {
+            key: key.to_string(),
+            seq,
+            value: Operation::AsIs,
+            value_meta,
+        };
+
+        let res = self
+            .inner
+            .apply_non_dup(&LogEntry { txid: None, cmd })
+            .await?;
+
+        match res {
+            AppliedState::KV { prev, result } => Ok(UpsertKVActionResult { prev, result }),
+            _ => {
+                panic!("expect AppliedState::KV");
+            }
+        }
+    }
+
+    async fn get_kv(&mut self, key: &str) -> Result<GetKVActionResult> {
+        let res = self.inner.get_kv(key)?;
+        Ok(GetKVActionResult { result: res })
+    }
+
+    async fn mget_kv(&mut self, key: &[String]) -> Result<MGetKVActionResult> {
+        let res = self.inner.mget_kv(key)?;
+        Ok(MGetKVActionResult { result: res })
+    }
+
+    async fn prefix_list_kv(&mut self, prefix: &str) -> Result<PrefixListReply> {
+        let res = self.inner.prefix_list_kv(prefix)?;
+        Ok(res)
+    }
+}

--- a/common/management/src/namespace/local_kv_store_test.rs
+++ b/common/management/src/namespace/local_kv_store_test.rs
@@ -1,0 +1,234 @@
+// Copyright 2020 Datafuse Labs.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use common_exception::Result;
+use common_metatypes::KVMeta;
+use common_metatypes::KVValue;
+use common_metatypes::MatchSeq;
+use common_runtime::tokio;
+use common_store_api::kv_api::MGetKVActionResult;
+use common_store_api::GetKVActionResult;
+use common_store_api::KVApi;
+use common_store_api::UpsertKVActionResult;
+use common_tracing::tracing;
+use datafuse_store::meta_service::raft_db::init_temp_sled_db;
+
+use crate::namespace::namespace_mgr::NamespaceMgr;
+use crate::namespace::LocalKVStore;
+use crate::namespace::NamespaceApi;
+use crate::namespace::NodeInfo;
+
+#[tokio::test]
+async fn test_mgr_backed_with_local_kv_store() -> Result<()> {
+    init_testing_sled_db();
+
+    let tenant_id = "tenant1";
+    let namespace_id = "cluster1";
+    let node_id = "node1";
+    let node = NodeInfo {
+        id: node_id.to_string(),
+        cpu_nums: 0,
+        version: 0,
+        ip: "".to_string(),
+        port: 0,
+    };
+
+    let api = LocalKVStore::new_temp().await?;
+
+    let mut mgr = NamespaceMgr::new(api);
+    let res = mgr
+        .add_node(
+            tenant_id.to_string(),
+            namespace_id.to_string(),
+            node.clone(),
+        )
+        .await?;
+
+    assert_eq!(1, res, "the seq of the first added node");
+
+    let got = mgr
+        .get_nodes(tenant_id.to_string(), namespace_id.to_string(), None)
+        .await?;
+
+    assert_eq!(vec![(1, node.clone())], got, "fetch added nodes");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_local_kv_store() -> Result<()> {
+    init_testing_sled_db();
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+
+    let mut api = LocalKVStore::new_temp().await?;
+
+    tracing::info!("--- upsert");
+
+    let res = api
+        .upsert_kv(
+            "upsert-key",
+            MatchSeq::Any,
+            Some(b"upsert-value".to_vec()),
+            None,
+        )
+        .await?;
+
+    assert_eq!(
+        UpsertKVActionResult {
+            prev: None,
+            result: Some((1, KVValue {
+                meta: None,
+                value: b"upsert-value".to_vec(),
+            }))
+        },
+        res
+    );
+
+    tracing::info!("--- update meta with mismatching seq");
+
+    let res = api
+        .update_kv_meta(
+            "upsert-key",
+            MatchSeq::Exact(10),
+            Some(KVMeta {
+                expire_at: Some(now + 20),
+            }),
+        )
+        .await?;
+
+    assert_eq!(
+        UpsertKVActionResult {
+            prev: Some((1, KVValue {
+                meta: None,
+                value: b"upsert-value".to_vec(),
+            })),
+            result: Some((1, KVValue {
+                meta: None,
+                value: b"upsert-value".to_vec(),
+            }))
+        },
+        res,
+        "unchanged with mismatching seq"
+    );
+
+    tracing::info!("--- update meta with matching seq");
+
+    let res = api
+        .update_kv_meta(
+            "upsert-key",
+            MatchSeq::Exact(1),
+            Some(KVMeta {
+                expire_at: Some(now + 20),
+            }),
+        )
+        .await?;
+
+    assert_eq!(
+        UpsertKVActionResult {
+            prev: Some((1, KVValue {
+                meta: None,
+                value: b"upsert-value".to_vec(),
+            })),
+            result: Some((2, KVValue {
+                meta: Some(KVMeta {
+                    expire_at: Some(now + 20)
+                }),
+                value: b"upsert-value".to_vec(),
+            })),
+        },
+        res
+    );
+
+    tracing::info!("--- get_kv");
+
+    let res = api.get_kv("upsert-key").await?;
+    assert_eq!(
+        GetKVActionResult {
+            result: Some((2, KVValue {
+                meta: Some(KVMeta {
+                    expire_at: Some(now + 20)
+                }),
+                value: b"upsert-value".to_vec(),
+            })),
+        },
+        res
+    );
+
+    tracing::info!("--- mget_kv");
+
+    let _res = api
+        .upsert_kv(
+            "upsert-key-2",
+            MatchSeq::Any,
+            Some(b"upsert-value-2".to_vec()),
+            None,
+        )
+        .await?;
+
+    let res = api
+        .mget_kv(&[
+            "upsert-key".to_string(),
+            "upsert-key-2".to_string(),
+            "nonexistent".to_string(),
+        ])
+        .await?;
+
+    assert_eq!(
+        MGetKVActionResult {
+            result: vec![
+                Some((2, KVValue {
+                    meta: Some(KVMeta {
+                        expire_at: Some(now + 20)
+                    }),
+                    value: b"upsert-value".to_vec(),
+                })),
+                Some((3, KVValue {
+                    meta: None,
+                    value: b"upsert-value-2".to_vec(),
+                })),
+                None
+            ]
+        },
+        res
+    );
+
+    tracing::info!("--- prefix_list_kv");
+
+    let res = api.prefix_list_kv("upsert-key-").await?;
+    assert_eq!(
+        vec![(
+            "upsert-key-2".to_string(),
+            (3, KVValue {
+                meta: None,
+                value: b"upsert-value-2".to_vec(),
+            })
+        )],
+        res
+    );
+
+    Ok(())
+}
+
+fn init_testing_sled_db() {
+    let t = tempfile::tempdir().expect("create temp dir to sled db");
+    init_temp_sled_db(t);
+}

--- a/common/management/src/namespace/mod.rs
+++ b/common/management/src/namespace/mod.rs
@@ -14,10 +14,14 @@
 //
 
 #[cfg(test)]
+mod local_kv_store_test;
+#[cfg(test)]
 mod namespace_mgr_test;
 
+mod local_kv_store;
 mod namespace_api;
 mod namespace_mgr;
 
+pub use local_kv_store::LocalKVStore;
 pub use namespace_api::NamespaceApi;
 pub use namespace_api::NodeInfo;

--- a/store/src/meta_service/raft_db.rs
+++ b/store/src/meta_service/raft_db.rs
@@ -64,6 +64,8 @@ pub fn init_sled_db(path: String) {
 
 pub fn get_sled_db() -> sled::Db {
     let x = GLOBAL_SLED.as_ref().lock().unwrap();
-    let y = x.as_ref().unwrap();
+    let y = x.as_ref().expect(
+        "init_sled_db() or init_temp_sled_db() has to be called before using get_sled_db()",
+    );
     y.db.clone()
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

##### [common/management] feature: add LocalKVStore: a KVApi impl backed with local store, for testing purpose mainly

For use in unitest:
1. initialize sled::Db in a temp dir.
1. create a LocalKVStore with unique name for every test case:

```rust
fn test_xxx() {
    let t = tempfile::tempdir().expect("create temp dir to sled db");
    init_temp_sled_db(t);

    let kv1 = LocalKVStore::new_temp();
    let kv2 = LocalKVStore::new_temp();
}
```

For use in production:
```rust
init_sled_db("sled-db-dir");

let kv1 = LocalKVStore::new("name-of-the-underlying-sled-tree");
let kv2 = LocalKVStore::new("another-name-of-the-underlying-sled-tree");
```

Caveat: Two LocalKVStore instances with the same `name` reference to the same underlying sled::Tree.


## Changelog

- New Feature





## Related Issues

fix: #1737 