### PR TITLE
support get_db_engines and engine_desc

### DIFF
--- a/query/src/catalogs/catalog.rs
+++ b/query/src/catalogs/catalog.rs
@@ -58,4 +58,7 @@ pub trait Catalog {
     // Operation with database.
     fn create_database(&self, plan: CreateDatabasePlan) -> Result<()>;
     fn drop_database(&self, plan: DropDatabasePlan) -> Result<()>;
+
+    // Get all db engines.
+    fn get_db_engines(&self) -> Result<Vec<Arc<dyn DatabaseEngine>>>;
 }

--- a/query/src/catalogs/database_engine.rs
+++ b/query/src/catalogs/database_engine.rs
@@ -34,4 +34,7 @@ pub trait DatabaseEngine: Send + Sync {
 
     fn create_database(&self, plan: CreateDatabasePlan) -> Result<()>;
     fn drop_database(&self, plan: DropDatabasePlan) -> Result<()>;
+
+    // A description for this engine.
+    fn engine_desc(&self) -> &str;
 }

--- a/query/src/catalogs/impls/database_catalog.rs
+++ b/query/src/catalogs/impls/database_catalog.rs
@@ -186,4 +186,10 @@ impl Catalog for DatabaseCatalog {
             )))
         }
     }
+
+    fn get_db_engines(&self) -> Result<Vec<Arc<dyn DatabaseEngine>>> {
+        let db_engines: Vec<Arc<dyn DatabaseEngine>> =
+            self.database_engines.read().values().cloned().collect();
+        Ok(db_engines)
+    }
 }

--- a/query/src/datasources/example/example_databases.rs
+++ b/query/src/datasources/example/example_databases.rs
@@ -60,4 +60,8 @@ impl DatabaseEngine for ExampleDatabases {
     fn drop_database(&self, plan: DropDatabasePlan) -> Result<()> {
         self.meta_backend.drop_database(plan)
     }
+
+    fn engine_desc(&self) -> &str {
+        "The example engine is used by example databases and tables."
+    }
 }

--- a/query/src/datasources/local/local_databases.rs
+++ b/query/src/datasources/local/local_databases.rs
@@ -64,4 +64,8 @@ impl DatabaseEngine for LocalDatabases {
     fn drop_database(&self, plan: DropDatabasePlan) -> Result<()> {
         self.meta_backend.drop_database(plan)
     }
+
+    fn engine_desc(&self) -> &str {
+        "The local engine stores data in DatafuseQuery local memory or disk, which can be one of Memory, Parquet, CSV, Null, it is used mainly for testing."
+    }
 }

--- a/query/src/datasources/remote/remote_databases.rs
+++ b/query/src/datasources/remote/remote_databases.rs
@@ -70,4 +70,8 @@ impl DatabaseEngine for RemoteDatabases {
     fn drop_database(&self, plan: DropDatabasePlan) -> Result<()> {
         self.meta_backend.drop_database(plan)
     }
+
+    fn engine_desc(&self) -> &str {
+        "The remote engine stores data in remote DatafuseStore cluster."
+    }
 }

--- a/query/src/datasources/system/system_databases.rs
+++ b/query/src/datasources/system/system_databases.rs
@@ -59,4 +59,8 @@ impl DatabaseEngine for SystemDatabases {
     fn drop_database(&self, _plan: DropDatabasePlan) -> Result<()> {
         Err(ErrorCode::UnImplement("Cannot drop system database"))
     }
+
+    fn engine_desc(&self) -> &str {
+        "The system engine is used by tables in the system database, which store Datafuse information."
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Support function `get_db_engines` and `engine_desc`

## Changelog

- Improvement

## Related Issues

Fixes #1722

## Test Plan

