### PR TITLE
[improve] use eamil to uniq authors

### DIFF
--- a/common/building/src/lib.rs
+++ b/common/building/src/lib.rs
@@ -45,7 +45,9 @@ pub fn add_env_vergen() {
 
 pub fn add_env_commit_authors() {
     let r = run_script::run_script!(
-        r#"git shortlog HEAD --summary | perl -lnE 's/^\s+\d+\s+(.+)/  "$1",/; next unless $1; say $_' | sort | xargs"#
+        // use eamil to uniq authors
+        r#"git shortlog HEAD -sne | awk '{$1=""; sub(" ", "    \""); print }' | awk -F'<' '!x[$1]++' | \
+        awk -F'<' '!x[$2]++' | awk -F'<' '{gsub(/ +$/, "\",", $1); print $1}' | sort | xargs"#
     );
     let authors = match r {
         Ok((_, output, _)) => output,


### PR DESCRIPTION
Signed-off-by: Chojan Shang <psiace@outlook.com>

I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

use eamil to uniq authors

## Changelog

- Improvement

## Related Issues

see https://github.com/datafuselabs/datafuse/issues/949#issuecomment-872700656 , email is relatively private, so ...

## Test Plan

Unit Tests

Stateless Tests

