### PR TITLE
Add label for METRIC_INTERPRETER_USEDTIME

### DIFF
--- a/query/src/servers/clickhouse/interactive_worker_base.rs
+++ b/query/src/servers/clickhouse/interactive_worker_base.rs
@@ -65,11 +65,13 @@ impl InteractiveWorkerBase {
             _ => {
                 let start = Instant::now();
                 let interpreter = InterpreterFactory::get(ctx.clone(), plan)?;
+                let name = interpreter.name().to_string();
                 let async_data_stream = interpreter.execute();
                 let mut data_stream = async_data_stream.await?;
                 histogram!(
                     super::clickhouse_metrics::METRIC_INTERPRETER_USEDTIME,
-                    start.elapsed()
+                    start.elapsed(),
+                    "interpreter" => name
                 );
                 let mut interval_stream = IntervalStream::new(interval(Duration::from_millis(30)));
                 let cancel = Arc::new(AtomicBool::new(false));
@@ -115,6 +117,7 @@ impl InteractiveWorkerBase {
         };
         insert.set_input_stream(Box::pin(stream));
         let interpreter = InterpreterFactory::get(ctx.clone(), PlanNode::InsertInto(insert))?;
+        let name = interpreter.name().to_string();
 
         let (mut tx, rx) = mpsc::channel(20);
         tx.send(BlockItem::InsertSample(sample_block)).await.ok();
@@ -128,7 +131,8 @@ impl InteractiveWorkerBase {
         })?;
         histogram!(
             super::clickhouse_metrics::METRIC_INTERPRETER_USEDTIME,
-            start.elapsed()
+            start.elapsed(),
+            "interpreter" => name
         );
         Ok(rx)
     }

--- a/query/src/servers/mysql/mysql_interactive_worker.rs
+++ b/query/src/servers/mysql/mysql_interactive_worker.rs
@@ -178,10 +178,12 @@ impl<W: std::io::Write> InteractiveWorkerBase<W> {
         let fetch_query_blocks = || -> Result<Vec<DataBlock>> {
             let start = Instant::now();
             let interpreter = InterpreterFactory::get(context.clone(), plan?)?;
+            let name = interpreter.name().to_string();
             let data_stream = runtime.block_on(interpreter.execute())?;
             histogram!(
                 super::mysql_metrics::METRIC_INTERPRETER_USEDTIME,
-                start.elapsed()
+                start.elapsed(),
+                "interpreter" => name
             );
             runtime.block_on(data_stream.collect::<Result<Vec<DataBlock>>>())
         };


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://datafuse.rs/policies/cla/

## Summary

Add  interpreter name label for the METRIC_INTERPRETER_USEDTIME.

## Changelog

- Improvement

## Test Plan

Unit Tests

Stateless Tests


## The metric result
```
# TYPE interpreter_usedtime summary
interpreter_usedtime{interpreter="CreateDatabaseInterpreter",quantile="0"} 0.08251562
interpreter_usedtime{interpreter="CreateDatabaseInterpreter",quantile="0.5"} 0.08251562
interpreter_usedtime{interpreter="CreateDatabaseInterpreter",quantile="0.9"} 0.08251562
interpreter_usedtime{interpreter="CreateDatabaseInterpreter",quantile="0.95"} 0.08251562
interpreter_usedtime{interpreter="CreateDatabaseInterpreter",quantile="0.99"} 0.08251562
interpreter_usedtime{interpreter="CreateDatabaseInterpreter",quantile="0.999"} 0.08251562
interpreter_usedtime{interpreter="CreateDatabaseInterpreter",quantile="1"} 0.08251562
interpreter_usedtime_sum{interpreter="CreateDatabaseInterpreter"} 0.08251562
interpreter_usedtime_count{interpreter="CreateDatabaseInterpreter"} 1
interpreter_usedtime{interpreter="CreateTableInterpreter",quantile="0"} 0.000020549
interpreter_usedtime{interpreter="CreateTableInterpreter",quantile="0.5"} 0.000020549
interpreter_usedtime{interpreter="CreateTableInterpreter",quantile="0.9"} 0.000020549
interpreter_usedtime{interpreter="CreateTableInterpreter",quantile="0.95"} 0.000020549
interpreter_usedtime{interpreter="CreateTableInterpreter",quantile="0.99"} 0.000020549
interpreter_usedtime{interpreter="CreateTableInterpreter",quantile="0.999"} 0.000020549
interpreter_usedtime{interpreter="CreateTableInterpreter",quantile="1"} 0.000020549
interpreter_usedtime_sum{interpreter="CreateTableInterpreter"} 0.000020549
interpreter_usedtime_count{interpreter="CreateTableInterpreter"} 1
interpreter_usedtime{interpreter="InsertIntoInterpreter",quantile="0"} 0.000009003
interpreter_usedtime{interpreter="InsertIntoInterpreter",quantile="0.5"} 0.000009003
interpreter_usedtime{interpreter="InsertIntoInterpreter",quantile="0.9"} 0.000009003
interpreter_usedtime{interpreter="InsertIntoInterpreter",quantile="0.95"} 0.000009003
interpreter_usedtime{interpreter="InsertIntoInterpreter",quantile="0.99"} 0.000009003
interpreter_usedtime{interpreter="InsertIntoInterpreter",quantile="0.999"} 0.000009003
interpreter_usedtime{interpreter="InsertIntoInterpreter",quantile="1"} 0.000009003474102464532
interpreter_usedtime_sum{interpreter="InsertIntoInterpreter"} 0.000028074000000000003
interpreter_usedtime_count{interpreter="InsertIntoInterpreter"} 2
interpreter_usedtime{interpreter="SelectInterpreter",quantile="0"} 0.000089442
interpreter_usedtime{interpreter="SelectInterpreter",quantile="0.5"} 0.00009092277519002169
interpreter_usedtime{interpreter="SelectInterpreter",quantile="0.9"} 0.00010076695981458807
interpreter_usedtime{interpreter="SelectInterpreter",quantile="0.95"} 0.00010076695981458807
interpreter_usedtime{interpreter="SelectInterpreter",quantile="0.99"} 0.00010076695981458807
interpreter_usedtime{interpreter="SelectInterpreter",quantile="0.999"} 0.00010076695981458807
interpreter_usedtime{interpreter="SelectInterpreter",quantile="1"} 0.001602644780741884
interpreter_usedtime_sum{interpreter="SelectInterpreter"} 0.004042909000000001
interpreter_usedtime_count{interpreter="SelectInterpreter"} 5
```

